### PR TITLE
Add ${Vulkan_INCLUDE_DIRS} to include directories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ find_package(Threads)
 target_link_libraries(OpenCL ${CMAKE_THREAD_LIBS_INIT})
 
 find_package(Vulkan)
+target_include_directories(OpenCL SYSTEM PRIVATE "${Vulkan_INCLUDE_DIRS}")
 target_link_libraries(OpenCL ${Vulkan_LIBRARIES})
 
 add_dependencies(OpenCL clspv)


### PR DESCRIPTION
This is necessary when the Vulkan headers are not in the system header
search path.