### PR TITLE
Return CL_DEVICE_NOT_FOUND from clGetDeviceIDs

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -167,6 +167,10 @@ clGetDeviceIDs(
         *num_devices = num;
     }
 
+    if (num == 0) {
+        return CL_DEVICE_NOT_FOUND;
+    }
+
     return CL_SUCCESS;
 }
 


### PR DESCRIPTION
Without this, `simple_test` crashes when no GPU devices are found.