### PR TITLE
Don't restrict the device choice to GPUs in simple_test

### DIFF
--- a/tests/simple/simple.cpp
+++ b/tests/simple/simple.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[])
 
     printf("Platform: %s\n", platform_name);
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, nullptr);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, nullptr);
     CHECK_CL_ERRCODE(err);
 
     char device_name[128];


### PR DESCRIPTION
This enables the test to run on Talvos.

Signed-off-by: Kévin Petit <kpet@free.fr>