### PR TITLE
Update clspv

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following applications work at least partially:
 * [clinfo](https://github.com/Oblomov/clinfo)
 * [OpenCL conformance tests](https://github.com/KhronosGroup/OpenCL-CTS)
 * [SHOC](https://github.com/vetter/shoc)
+* [OCLToys](https://github.com/ignatenkobrain/ocltoys.git)
 * Let others know whether your favourite application works or not, send a PR :)
 
 TODO move to a separate doc file and list the status for all applications that

--- a/tests/conformance/results-kpet.json
+++ b/tests/conformance/results-kpet.json
@@ -73,8 +73,8 @@
   },
   "Geometric Functions": {
     "duration": "00:00:02.478193",
-    "passed": 3,
-    "retcode": 5,
+    "passed": 6,
+    "retcode": 2,
     "total": 8
   },
   "Half Ops": {


### PR DESCRIPTION
Fixes #14.

The fractal explorer from OCLToys now just works.

Signed-off-by: Kévin Petit <kpet@free.fr>