### PR TITLE
Fix MSVC compilation issues

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 
-add_compile_options(-Wall -W -Wextra)
-add_compile_options(-Wno-ignored-attributes)
+if(NOT MSVC)
+    add_compile_options(-Wall -W -Wextra)
+    add_compile_options(-Wno-ignored-attributes)
+endif()
 
 add_library(OpenCL SHARED
   api.cpp

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -377,7 +377,7 @@ cl_build_status cvk_program::compile_source()
 {
     // Create temporary folder
     std::string tmp_template{"clvk-XXXXXX"};
-    const char* tmp = mkdtemp(&tmp_template.front());
+    const char* tmp = cvk_mkdtemp(tmp_template);
     if (tmp == nullptr) {
         return CL_BUILD_ERROR;
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -12,11 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "utils.hpp"
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 
-#include "utils.hpp"
+#ifdef WIN32
+#include <Windows.h>
+#include <io.h>
+#endif
+
+char* cvk_mkdtemp(std::string& tmpl)
+{
+#ifdef WIN32
+    if (_mktemp_s(&tmpl.front(), tmpl.size() + 1) != 0) {
+        return nullptr;
+    }
+
+    if (!CreateDirectory(tmpl.c_str(), nullptr)) {
+        return nullptr;
+    }
+
+    return &tmpl.front();
+#else
+    return mkdtemp(&tmpl.front());
+#endif
+}
 
 const char* vulkan_error_string(VkResult result) {
     switch(result) {


### PR DESCRIPTION
* Skip GCC specific attributes/flags
* Include necessary header files
* Add windows specific mkdtemp function

Note that clspv needs some compile fixes before this can work