### PR TITLE
Move unistd.h include to utils.cpp

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -19,10 +19,6 @@
 #include <utility>
 #include <vector>
 
-#ifdef __APPLE__
-#include <unistd.h>
-#endif
-
 #include <vulkan/vulkan.h>
 
 #include "spirv/1.0/spirv.hpp"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -17,6 +17,10 @@
 #include <cstdio>
 #include <cstdlib>
 
+#ifdef __APPLE__
+#include <unistd.h>
+#endif
+
 #ifdef WIN32
 #include <Windows.h>
 #include <io.h>


### PR DESCRIPTION
Fixes use of mkdtemp() on macOS.