### PR TITLE
Use clspv api through Cmake option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ Passing `-DBUILD_CONFORMANCE_TESTS=ON` will instruct CMake to build the
 [OpenCL conformance tests](https://github.com/KhronosGroup/OpenCL-CTS).
 This is _not expected to work out-of-the box_ at the moment.
 
+### Clspv compilation
+
+You can select the compilation style that clvk will use with Clspv via
+the `CLVK_CLSPV_ONLINE_COMPILER` option. By default, Clspv is run in a
+separate process.
+
+* `-DCLVK_CLSPV_ONLINE_COMPILER=1` will cause clvk to compile kernels
+in the same process via the Clspv C++ API.
+
 # Using
 
 To use clvk to run an OpenCL application, you just need to make sure

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,10 @@ if(NOT MSVC)
     add_compile_options(-Wno-ignored-attributes)
 endif()
 
+if (DEFINED CLVK_CLSPV_ONLINE_COMPILER)
+  add_compile_options(-DCLSPV_ONLINE_COMPILER)
+endif()
+
 add_library(OpenCL SHARED
   api.cpp
   device.cpp
@@ -42,8 +46,10 @@ target_link_libraries(OpenCL ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(OpenCL SYSTEM BEFORE PRIVATE "${Vulkan_INCLUDE_DIRS}")
 target_link_libraries(OpenCL ${Vulkan_LIBRARIES})
 
-#add_dependencies(OpenCL clspv)
 target_link_libraries(OpenCL clspv_core SPIRV-Tools-opt SPIRV-Tools-link)
+if (NOT DEFINED CLVK_CLSPV_ONLINE_COMPILER)
+  add_dependencies(OpenCL clspv)
+endif()
 
 target_compile_definitions(OpenCL PRIVATE
     DEFAULT_CLSPV_BINARY_PATH="$<TARGET_FILE:clspv>")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,8 +42,8 @@ target_link_libraries(OpenCL ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(OpenCL SYSTEM BEFORE PRIVATE "${Vulkan_INCLUDE_DIRS}")
 target_link_libraries(OpenCL ${Vulkan_LIBRARIES})
 
-add_dependencies(OpenCL clspv)
-target_link_libraries(OpenCL SPIRV-Tools-opt SPIRV-Tools-link)
+#add_dependencies(OpenCL clspv)
+target_link_libraries(OpenCL clspv_core SPIRV-Tools-opt SPIRV-Tools-link)
 
 target_compile_definitions(OpenCL PRIVATE
     DEFAULT_CLSPV_BINARY_PATH="$<TARGET_FILE:clspv>")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,8 @@ if(NOT MSVC)
     add_compile_options(-Wno-ignored-attributes)
 endif()
 
-if (DEFINED CLVK_CLSPV_ONLINE_COMPILER)
+option(CLVK_CLSPV_ONLINE_COMPILER "Use the Clspv C++ API for compilation of kernels")
+if (CLVK_CLSPV_ONLINE_COMPILER)
   add_compile_options(-DCLSPV_ONLINE_COMPILER)
 endif()
 
@@ -46,8 +47,10 @@ target_link_libraries(OpenCL ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(OpenCL SYSTEM BEFORE PRIVATE "${Vulkan_INCLUDE_DIRS}")
 target_link_libraries(OpenCL ${Vulkan_LIBRARIES})
 
-target_link_libraries(OpenCL clspv_core SPIRV-Tools-opt SPIRV-Tools-link)
-if (NOT DEFINED CLVK_CLSPV_ONLINE_COMPILER)
+target_link_libraries(OpenCL SPIRV-Tools-opt SPIRV-Tools-link)
+if (CLVK_CLSPV_ONLINE_COMPILER)
+  target_link_libraries(OpenCL clspv_core)
+else()
   add_dependencies(OpenCL clspv)
 endif()
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -419,11 +419,9 @@ cl_build_status cvk_program::compile_source()
         options += " -cluster-pod-kernel-args ";
         options += " -cl-single-precision-constant ";
         options += " -pod-ubo ";
-        options += " -o ";
-        options += spirv_file;
 
         cvk_info("About to compile \"%s\"", options.c_str());
-        auto error = clspv::CompileFromSourceString(m_source, options);
+        auto error = clspv::CompileFromSourceString(m_source, "", options, m_binary.raw_binary());
         std::cerr << "Return code " << error << std::endl;
         if (error != 0) {
             cvk_error_fn("failed to compile the program");
@@ -480,15 +478,16 @@ cl_build_status cvk_program::compile_source()
             cvk_error_fn("failed to compile the program");
             return CL_BUILD_ERROR;
         }
-    }
 
-    // Load SPIR-V program
-    const char *filename = spirv_file.c_str();
-    if (!m_binary.load_spir(filename)) {
-        cvk_error("Could not load SPIR-V binary from \"%s\"", filename);
-        return CL_BUILD_ERROR;
-    } else {
-        cvk_info("Loaded SPIR-V binary from \"%s\", size = %zu words", filename, m_binary.code().size());
+        // Load SPIR-V program
+        const char *filename = spirv_file.c_str();
+        if (!m_binary.load_spir(filename)) {
+            cvk_error("Could not load SPIR-V binary from \"%s\"", filename);
+            return CL_BUILD_ERROR;
+        } else {
+          cvk_info("Loaded SPIR-V binary from \"%s\", size = %zu words",
+                   filename, m_binary.code().size());
+        }
     }
 
     // Load descriptor map

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -469,7 +469,7 @@ cl_build_status cvk_program::compile_source()
     if (loc != std::string::npos) {
         processed_options.replace(loc, search.length(), replace);
     }
- 
+
     // Save headers
     if (m_operation == build_operation::compile) {
         for (cl_uint i = 0; i < m_num_input_programs; i++) {
@@ -496,13 +496,13 @@ cl_build_status cvk_program::compile_source()
 
     cvk_info("About to compile \"%s\"", options.c_str());
     std::vector<clspv::version0::DescriptorMapEntry> entries;
-    auto error = clspv::CompileFromSourceString(
+    auto result = clspv::CompileFromSourceString(
         m_source, "", options, m_binary.raw_binary(), &entries);
-    if (error != 0) {
-        cvk_error_fn("failed to compile the program");
+    if (result.result_code != 0) {
+        cvk_error_fn("failed to compile the program: %s", result.message.c_str());
         return CL_BUILD_ERROR;
     }
-    cvk_info("Return code was: %d", error);
+    cvk_info("Return code was: %d", result.result_code);
 
     // Load descriptor map
     if (!m_binary.load_descriptor_map(entries)) {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -22,7 +22,9 @@
 
 #include <vulkan/vulkan.h>
 
+#ifdef CLSPV_ONLINE_COMPILER
 #include "clspv/Compiler.h"
+#endif
 #include "spirv/1.0/spirv.hpp"
 #include "spirv-tools/linker.hpp"
 #include "spirv-tools/optimizer.hpp"
@@ -360,6 +362,7 @@ bool spir_binary::load_descriptor_map(const char *fname)
     return load_descriptor_map(ifile);
 }
 
+#ifdef CLSPV_ONLINE_COMPILER
 bool spir_binary::load_descriptor_map(const std::vector<clspv::version0::DescriptorMapEntry> &entries)
 {
   m_dmaps.clear();
@@ -418,6 +421,7 @@ bool spir_binary::load_descriptor_map(const std::vector<clspv::version0::Descrip
 
   return true;
 }
+#endif
 
 void spir_binary::insert_descriptor_map(const spir_binary &other)
 {
@@ -513,11 +517,11 @@ cl_build_status cvk_program::compile_source()
     std::vector<clspv::version0::DescriptorMapEntry> entries;
     auto result = clspv::CompileFromSourceString(
         m_source, "", options, m_binary.raw_binary(), &entries);
+    cvk_info("Return code was: %d", result);
     if (result != 0) {
         cvk_error_fn("failed to compile the program");
         return CL_BUILD_ERROR;
     }
-    cvk_info("Return code was: %d", result);
 
     // Load descriptor map
     if (!m_binary.load_descriptor_map(entries)) {

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -21,6 +21,7 @@
 
 #include <vulkan/vulkan.h>
 
+#include "clspv/DescriptorMap.h"
 #include "spirv-tools/libspirv.h"
 #include "spirv/1.0/spirv.hpp"
 
@@ -71,6 +72,7 @@ public:
     CHECK_RETURN bool load_spir(std::istream &istream, uint32_t size);
     CHECK_RETURN bool load_descriptor_map(const char *fname);
     CHECK_RETURN bool load_descriptor_map(std::istream &istream);
+    CHECK_RETURN bool load_descriptor_map(const std::vector<clspv::version0::DescriptorMapEntry> &entries);
     void insert_descriptor_map(const spir_binary &other);
     CHECK_RETURN bool save_spir(const char *fname) const;
     CHECK_RETURN bool load(std::istream &istream);

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -21,7 +21,9 @@
 
 #include <vulkan/vulkan.h>
 
+#ifdef CLSPV_ONLINE_COMPILER
 #include "clspv/DescriptorMap.h"
+#endif
 #include "spirv-tools/libspirv.h"
 #include "spirv/1.0/spirv.hpp"
 
@@ -72,7 +74,9 @@ public:
     CHECK_RETURN bool load_spir(std::istream &istream, uint32_t size);
     CHECK_RETURN bool load_descriptor_map(const char *fname);
     CHECK_RETURN bool load_descriptor_map(std::istream &istream);
+#ifdef CLSPV_ONLINE_COMPILER
     CHECK_RETURN bool load_descriptor_map(const std::vector<clspv::version0::DescriptorMapEntry> &entries);
+#endif
     void insert_descriptor_map(const spir_binary &other);
     CHECK_RETURN bool save_spir(const char *fname) const;
     CHECK_RETURN bool load(std::istream &istream);

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -88,6 +88,7 @@ public:
     CHECK_RETURN bool validate() const;
     size_t num_kernels() const { return m_dmaps.size(); }
     const kernels_arguments_map& kernels_arguments() const { return m_dmaps; }
+    std::vector<uint32_t> *raw_binary() { return &m_code; }
 
 private:
     spv_context m_context;


### PR DESCRIPTION
Adds Cmake option to select compile style:
 * default remains separate process
 * new option uses Clspv API

Changes:
* Changes to support using Clspv API
* update UBO test to meet std140 rules

I've tested the simple tests using both compiler options.