### PR TITLE
Allow samplers in descriptor map for online Clspv

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -407,6 +407,9 @@ bool spir_binary::load_descriptor_map(const std::vector<clspv::version0::Descrip
         case clspv::ArgKind::WriteOnlyImage:
           arg.kind = kernel_argument_kind::wo_image;
           break;
+        case clspv::ArgKind::Sampler:
+          arg.kind = kernel_argument_kind::sampler;
+          break;
         default:
           return false;
       }


### PR DESCRIPTION
Without this the `simple_image` test crashes when using online Clspv compilation. The `sampler` case is included in the other variant of `load_descriptor_map`, and I couldn't see any obvious reason why this couldn't be supported for online.

CC @alan-baker just to check there wasn't any particular reason why this was left out of PR #34 ?