### PR TITLE
Support for buffer/image copies

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -389,7 +389,8 @@ bool cvk_image::init()
         array_layers, // arrayLayers
         VK_SAMPLE_COUNT_1_BIT, // samples
         VK_IMAGE_TILING_OPTIMAL, // tiling
-        VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT, // usage TODO transfers
+        VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT |
+            VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
         VK_SHARING_MODE_EXCLUSIVE, // sharingMode
         0, // queueFamilyIndexCount
         nullptr, // pQueueFamilyIndices

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -355,3 +355,6 @@ private:
     VkImage m_image;
     VkImageView m_image_view;
 };
+
+using cvk_image_holder = refcounted_holder<cvk_image>;
+

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -597,3 +597,30 @@ struct cvk_command_dep : public cvk_command {
     }
 };
 
+struct cvk_command_buffer_image_copy : public cvk_command {
+    cvk_command_buffer_image_copy(cl_command_type type, cvk_command_queue *queue,
+                                  cvk_buffer *buffer, cvk_image *image, size_t offset,
+                                  const std::array<size_t, 3> &origin,
+                                  const std::array<size_t, 3> &region)
+        : cvk_command(type, queue),
+          m_command_buffer(queue),
+          m_buffer(buffer),
+          m_image(image),
+          m_offset(offset),
+          m_origin(origin),
+          m_region(region) {}
+
+    void build_inner_image_to_buffer(const VkBufferImageCopy &region);
+    void build_inner_buffer_to_image(const VkBufferImageCopy &region);
+    CHECK_RETURN cl_int build();
+    virtual cl_int do_action() override;
+
+private:
+    cvk_command_buffer m_command_buffer;
+    cvk_buffer_holder m_buffer;
+    cvk_image_holder m_image;
+    size_t m_offset;
+    std::array<size_t, 3> m_origin;
+    std::array<size_t, 3> m_region;
+};
+


### PR DESCRIPTION
Good enough for the conformance tests but missing
some error checking.

Closes #91.
Closes #92.

Signed-off-by: Kévin Petit <kpet@free.fr>