### PR TITLE
Add missing <array> include

### DIFF
--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 
 #include "objects.hpp"


### PR DESCRIPTION
PR #117 introduced uses of `std::array` without adding this include.