### PR TITLE
Fix build error for CMAKE_BUILD_TYPE=Debug

### DIFF
--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -352,7 +352,7 @@ struct cvk_image : public cvk_mem {
         mapping.ptr = mapping.buffer->map_ptr(0);
         mapping.flags = flags;
 
-        CVK_ASSERT(m_mappings.count(ptr) == 0);
+        CVK_ASSERT(m_mappings.count(mapping.ptr) == 0);
         m_mappings[mapping.ptr] = mapping;
 
         return true;


### PR DESCRIPTION
I'd recommend making all CI configs use a Debug build, both to catch this sort of thing and also so that the tests run with all assertions enabled.