### PR TITLE
Perform fine-grained SPIR-V capability checks

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -248,3 +248,27 @@ bool cvk_device::init()
     return true;
 }
 
+bool cvk_device::supports_capability(spv::Capability capability) const {
+    switch (capability) {
+    // Capabilities required by all Vulkan implementations:
+    case spv::CapabilityShader:
+        return true;
+    // Optional capabilities:
+    case spv::CapabilityFloat64:
+        return m_features.shaderFloat64;
+    case spv::CapabilityInt16:
+        return m_features.shaderInt16;
+    case spv::CapabilityInt64:
+        return m_features.shaderInt64;
+    case spv::CapabilityStorageImageWriteWithoutFormat:
+        return m_features.shaderStorageImageWriteWithoutFormat;
+    case spv::CapabilityVariablePointers:
+        return m_features_variable_pointers.variablePointers;
+    case spv::CapabilityVariablePointersStorageBuffer:
+        return m_features_variable_pointers.variablePointersStorageBuffer;
+    // Capabilities that have not yet been mapped to Vulkan features:
+    default:
+        cvk_warn_fn("Capability %d not yet mapped to a feature.", capability);
+        return false;
+    }
+}

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -85,11 +85,11 @@ bool cvk_device::init_extensions()
 
     m_vulkan_device_extensions = {
         "VK_KHR_storage_buffer_storage_class",
-        "VK_KHR_variable_pointers",
     };
 
     const std::vector<const char *> desired_extensions = {
         "VK_KHR_16bit_storage",
+        "VK_KHR_variable_pointers",
     };
 
     for (size_t i = 0; i < numext; i++) {
@@ -110,22 +110,35 @@ bool cvk_device::init_extensions()
 
 void cvk_device::init_features()
 {
-    VkPhysicalDeviceFeatures supported_features;
-    vkGetPhysicalDeviceFeatures(m_pdev, &supported_features);
+    // Query supported features.
+    VkPhysicalDeviceFeatures2 supported_features;
+    VkPhysicalDeviceVariablePointerFeatures supported_features_variable_pointers;
+    supported_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    supported_features.pNext = &supported_features_variable_pointers;
+    vkGetPhysicalDeviceFeatures2(m_pdev, &supported_features);
 
     memset(&m_features, 0, sizeof(m_features));
+    memset(&m_features_variable_pointers, 0,
+           sizeof(m_features_variable_pointers));
 
-    if (supported_features.shaderInt16) {
+    if (supported_features.features.shaderInt16) {
         m_features.shaderInt16 = VK_TRUE;
     }
-    if (supported_features.shaderInt64) {
+    if (supported_features.features.shaderInt64) {
         m_features.shaderInt64 = VK_TRUE;
     }
-    if (supported_features.shaderFloat64) {
+    if (supported_features.features.shaderFloat64) {
         m_features.shaderFloat64 = VK_TRUE;
     }
-    if (supported_features.shaderStorageImageWriteWithoutFormat) {
+    if (supported_features.features.shaderStorageImageWriteWithoutFormat) {
         m_features.shaderStorageImageWriteWithoutFormat = VK_TRUE;
+    }
+
+    if (supported_features_variable_pointers.variablePointers) {
+        m_features_variable_pointers.variablePointers = VK_TRUE;
+    }
+    if (supported_features_variable_pointers.variablePointersStorageBuffer) {
+        m_features_variable_pointers.variablePointersStorageBuffer = VK_TRUE;
     }
 }
 

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include <spirv/1.0/spirv.hpp>
 #include <vulkan/vulkan.h>
 
 #include "cl_headers.hpp"
@@ -102,6 +103,9 @@ typedef struct _cl_device_id {
     bool supports_images() const {
         return devices_support_images() ? CL_TRUE : CL_FALSE;
     }
+
+    /// Returns true if the device supports the given SPIR-V capability.
+    bool supports_capability(spv::Capability capability) const;
 
     std::string version_string() const {
         std::string ret = "CLVK on Vulkan v";

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -188,6 +188,7 @@ private:
     VkPhysicalDeviceProperties m_properties;
     VkPhysicalDeviceMemoryProperties m_mem_properties;
     VkPhysicalDeviceFeatures m_features;
+    VkPhysicalDeviceVariablePointerFeatures m_features_variable_pointers;
     VkDevice m_dev;
     std::vector<const char*> m_vulkan_device_extensions;
     cl_uint m_mem_base_addr_align;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -105,6 +105,7 @@ public:
     const kernels_arguments_map& kernels_arguments() const { return m_dmaps; }
     std::vector<uint32_t> *raw_binary() { return &m_code; }
     const std::vector<sampler_desc>& literal_samplers() { return m_literal_samplers; }
+    CHECK_RETURN bool get_capabilities(std::vector<spv::Capability> &capabilities) const;
 
 private:
     CHECK_RETURN bool parse_sampler(const std::vector<std::string> &tokens, int toknum);
@@ -268,6 +269,10 @@ private:
     void do_build();
     CHECK_RETURN cl_build_status compile_source();
     CHECK_RETURN cl_build_status link();
+
+    /// Check if all of the capabilities required by the SPIR-V module are
+    /// supported by `device`.
+    CHECK_RETURN bool check_capabilities(const cvk_device *device) const;
 
     uint32_t m_num_devices;
     cl_uint m_num_input_programs;


### PR DESCRIPTION
This produces more useful errors when a SPIR-V module produced by Clspv uses capabilities that  are not supported by the Vulkan device. These errors currently just go to the logging system, but we should also be able to put these in the build log that goes back to the application as well.

As part of this, I've made `VK_KHR_variable_pointers` an optional extension, and query which of its features are supported by the device (if any), using `vkGetPhysicalDeviceFeatures2()`. This allows Clvk to run on top of SwiftShader for kernels that do not require support for the variable pointers extension.