### PR TITLE
Basic implementation of clEnqueueFillImage

### DIFF
--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -375,6 +375,12 @@ struct cvk_image : public cvk_mem {
         return mapping;
     }
 
+    static constexpr int MAX_NUM_CHANNELS = 4;
+    static constexpr int MAX_CHANNEL_SIZE = 4;
+    static constexpr int FILL_PATTERN_MAX_SIZE = MAX_NUM_CHANNELS * MAX_CHANNEL_SIZE;
+    using fill_pattern_array = std::array<char, FILL_PATTERN_MAX_SIZE>;
+    void prepare_fill_pattern(const void *input_pattern, fill_pattern_array& pattern, size_t *size_ret) const;
+
 private:
 
     bool init();

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1005,3 +1005,16 @@ cl_int cvk_command_image_image_copy::do_action()
 
     return CL_COMPLETE;
 }
+
+cl_int cvk_command_fill_image::do_action()
+{
+    // TODO use bigger memcpy's when possible
+    size_t num_elems = m_region[2] * m_region[1] * m_region[0];
+    for (size_t elem = 0; elem < num_elems; elem++) {
+        auto dst = pointer_offset(m_ptr, elem * m_pattern_size);
+        memcpy(dst, m_pattern.data(), m_pattern_size);
+    }
+
+    return CL_COMPLETE;
+}
+

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -796,3 +796,23 @@ private:
     std::array<size_t, 3> m_region;
     cvk_command_buffer m_command_buffer;
 };
+
+struct cvk_command_fill_image : public cvk_command {
+
+    cvk_command_fill_image(cvk_command_queue *queue, void *ptr,
+                           const cvk_image::fill_pattern_array &pattern,
+                           size_t pattern_size,
+                           std::array<size_t, 3> region)
+                         : cvk_command(CL_COMMAND_FILL_IMAGE, queue),
+                           m_ptr(ptr),
+                           m_pattern(pattern),
+                           m_pattern_size(pattern_size),
+                           m_region(region) {}
+    cl_int do_action() override;
+private:
+    void *m_ptr;
+    cvk_image::fill_pattern_array m_pattern;
+    size_t m_pattern_size;
+    std::array<size_t, 3> m_region;
+};
+

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -89,7 +89,7 @@ static inline std::string vulkan_version_string(uint32_t version) {
 
 std::string pretty_size(uint64_t size);
 
-static inline void* pointer_offset(void *ptr, size_t offset) {
+static inline void* pointer_offset(const void *ptr, size_t offset) {
     auto ptrint = reinterpret_cast<uintptr_t>(ptr);
     return reinterpret_cast<void*>(ptrint + offset);
 }


### PR DESCRIPTION
Doesn't support CL_HALF_FLOAT channel data type.

Certainly not the fastest.

Closes #89.

Signed-off-by: Kévin Petit <kpet@free.fr>