### PR TITLE
Check formatting via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ env:
     - JOB_CMAKE_CONFIG="-DCLVK_CLSPV_ONLINE_COMPILER=1"
     - JOB_CMAKE_CONFIG="-DCLVK_CLSPV_ONLINE_COMPILER=0"
 
+jobs:
+  include:
+  - os: linux
+    env: JOB_CHECK_FORMAT=1
+
 branches:
   only:
     - master

--- a/tests/travis/check-format.sh
+++ b/tests/travis/check-format.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Run git-clang-format to check for violations
+CLANG_FORMAT_OUTPUT=/tmp/clvk-clang-format-output.txt
+git-clang-format --diff origin/master --extensions cpp,hpp >$CLANG_FORMAT_OUTPUT
+
+# Check for no-ops
+grep '^no modified files to format$' "$CLANG_FORMAT_OUTPUT" && exit 0
+grep '^clang-format did not modify any files$' "$CLANG_FORMAT_OUTPUT" && exit 0
+
+# Dump formatting diff and signal failure
+echo -e "\n==== FORMATTING VIOLATIONS DETECTED ====\n"
+cat "$CLANG_FORMAT_OUTPUT"
+exit 1

--- a/tests/travis/step-before-install.sh
+++ b/tests/travis/step-before-install.sh
@@ -4,5 +4,7 @@ set -ex
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    sudo add-apt-repository -y 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main'
+    wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
     sudo apt-get update -qq
 fi

--- a/tests/travis/step-install.sh
+++ b/tests/travis/step-install.sh
@@ -3,7 +3,7 @@
 set -ex
 
 if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-    sudo apt-get install -qq g++-7
+    sudo apt-get install -qq g++-7 clang-format
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
 fi
 

--- a/tests/travis/step-script.sh
+++ b/tests/travis/step-script.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+if [ "${JOB_CHECK_FORMAT}" -eq 1 ]; then
+    ./tests/travis/check-format.sh
+    exit $?
+fi
+
 if [ "${TRAVIS_OS_NAME}" != "windows" ]; then
     ccache --max-size=2G
     ccache --show-stats


### PR DESCRIPTION
Adds a Linux-only config which runs a script that checks for formatting violations on any `.cpp` or `.hpp` files that have changed. The script can also be run locally before committing.

Note that one of the entries in the `.clang-format` config requires clang-format version 10, which isn't available by default on many platforms at present (hence the need to pull in the LLVM apt repository in the Travis script).

Example Travis CI job that fails due to bad formatting:
https://travis-ci.org/jrprice/clvk/jobs/620166482