### PR TITLE
Allow user to specify external Clspv source dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,10 @@ set(SPIRV-Headers_SOURCE_DIR ${SPIRV_HEADERS_SOURCE_DIR})
 add_subdirectory(${SPIRV_TOOLS_SOURCE_DIR} EXCLUDE_FROM_ALL)
 
 # clspv
-set(CLSPV_SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/clspv)
-add_subdirectory(${CLSPV_SOURCE_DIR} EXCLUDE_FROM_ALL)
+set(CLSPV_SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/clspv
+    CACHE STRING "Clspv source directory")
+add_subdirectory(${CLSPV_SOURCE_DIR} ${PROJECT_BINARY_DIR}/external/clspv
+                 EXCLUDE_FROM_ALL)
 
 # SPIRV-LLVM-Translator
 set(LLVM_DIR

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ separate process.
 * `-DCLVK_CLSPV_ONLINE_COMPILER=1` will cause clvk to compile kernels
 in the same process via the Clspv C++ API.
 
+You can build clvk using an external Clspv source tree by setting
+`-DCLSPV_SOURCE_DIR=/path/to/clspv/source/`.
+
 # Using
 
 To use clvk to run an OpenCL application, you just need to make sure


### PR DESCRIPTION
We will shortly be setting up a Clspv test bot that will use Clvk to run tests driven via the OpenCL API.