### PR TITLE
Build fixes

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -587,6 +587,7 @@ void cvk_image::prepare_fill_pattern(const void* input_pattern,
                pointer_offset(cast_pattern, 0 * csize), csize);
         memcpy(pattern.data() + 3 * csize,
                pointer_offset(cast_pattern, 3 * csize), csize);
+        break;
     default:
         CVK_ASSERT(false);
     }

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -17,6 +17,7 @@
 #include <array>
 #include <memory>
 
+#include "init.hpp"
 #include "kernel.hpp"
 #include "objects.hpp"
 


### PR DESCRIPTION
Caught by an internal build platform that enables more warnings and `-Werror`.