### PR TITLE
Support the Sampled1D and Image1D capabilities

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -299,6 +299,8 @@ bool cvk_device::supports_capability(spv::Capability capability) const {
     switch (capability) {
     // Capabilities required by all Vulkan implementations:
     case spv::CapabilityShader:
+    case spv::CapabilitySampled1D:
+    case spv::CapabilityImage1D:
     case spv::CapabilityImageQuery:
         return true;
     // Optional capabilities:


### PR DESCRIPTION
These are required for all Vulkan implementations and are now
generated by Clspv.