### PR TITLE
Remove deleted move special member functions

### DIFF
--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -76,8 +76,6 @@ template <typename T> struct refcounted_holder {
         }
     }
 
-    refcounted_holder(const refcounted_holder&& other) = delete;
-
     ~refcounted_holder() {
         if (m_refcounted != nullptr) {
             m_refcounted->release();
@@ -88,7 +86,6 @@ template <typename T> struct refcounted_holder {
 
     operator T*() const { return m_refcounted; }
 
-    refcounted_holder& operator=(const refcounted_holder&) = delete;
     refcounted_holder& operator=(const refcounted_holder&&) = delete;
 
     void reset(T* refc) {


### PR DESCRIPTION
Fixes a build error occurring with vectors of `refcounted_holder` objects. The `push_back`/`emplace_back` methods require the element type to be [MoveInsertable](https://en.cppreference.com/w/cpp/named_req/MoveInsertable), and will try to use the move constructor if it is declared. This produces an error if the move constructor is deleted, but if it is left undeclared the compiler can use the copy constructor instead.

The build error was introduced with the recent change to support literal samplers, which added a vector of `cvk_sampler_holder` objects.

Full disclosure: my knowledge of this corner of C++ is hairy at best, and I couldn't work out the motivation for marking these as deleted in the first place.