### PR TITLE
Skip SPIRV-LLVM-Translator build with online Clspv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,13 @@ add_subdirectory(${CLSPV_SOURCE_DIR} ${PROJECT_BINARY_DIR}/external/clspv
                  EXCLUDE_FROM_ALL)
 
 # SPIRV-LLVM-Translator
-set(LLVM_DIR
-    ${CMAKE_BINARY_DIR}/external/clspv/third_party/llvm/lib/cmake/llvm)
-set(LLVM_SPIRV_SOURCE ${PROJECT_SOURCE_DIR}/external/SPIRV-LLVM-Translator)
-set(LLVM_SPIRV_BUILD_EXTERNAL YES)
-add_subdirectory(${LLVM_SPIRV_SOURCE} EXCLUDE_FROM_ALL)
+if (NOT CLVK_CLSPV_ONLINE_COMPILER)
+  set(LLVM_DIR
+      ${CMAKE_BINARY_DIR}/external/clspv/third_party/llvm/lib/cmake/llvm)
+  set(LLVM_SPIRV_SOURCE ${PROJECT_SOURCE_DIR}/external/SPIRV-LLVM-Translator)
+  set(LLVM_SPIRV_BUILD_EXTERNAL YES)
+  add_subdirectory(${LLVM_SPIRV_SOURCE} EXCLUDE_FROM_ALL)
+endif()
 
 # Vulkan
 set(


### PR DESCRIPTION
Aside from building stuff that wasn't actually used, this was also breaking our bots since SPIRV-LLVM-Translator doesn't yet accept LLVM 11 (which Clspv is now targeting since LLVM branched for the upcoming 10.0 release).