### PR TITLE
Fix linker flags when setting --version-script

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,8 +19,8 @@ if(NOT MSVC)
 endif()
 
 if (UNIX AND NOT APPLE)
-    set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS}
-        "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports.map")
+    set(CMAKE_SHARED_LINKER_FLAGS
+        "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports.map")
 endif()
 
 option(CLVK_CLSPV_ONLINE_COMPILER "Use the Clspv C++ API for compilation of kernels")


### PR DESCRIPTION
When `CMAKE_SHARED_LINKER_FLAGS` is non-empty, this `set` command was creating a list and inserting a semi-colon, which broke the link line.