### PR TITLE
Add ICD support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,9 @@ if (UNIX AND NOT APPLE)
         "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports.map")
 endif()
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
+    # Bind global symbol references to definitions within the shared library,
+    # to allow the ICD dispatch table to be statically defined.
     set(CMAKE_SHARED_LINKER_FLAGS
         "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,11 @@ if (UNIX AND NOT APPLE)
         "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports.map")
 endif()
 
+if (UNIX)
+    set(CMAKE_SHARED_LINKER_FLAGS
+        "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
+endif()
+
 option(CLVK_CLSPV_ONLINE_COMPILER "Use the Clspv C++ API for compilation of kernels")
 if (CLVK_CLSPV_ONLINE_COMPILER)
   add_compile_options(-DCLSPV_ONLINE_COMPILER)

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -256,13 +256,12 @@ cl_int clGetDeviceIDs(cl_platform_id platform, cl_device_type device_type,
     return CL_SUCCESS;
 }
 
-cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
+cl_int clGetDeviceInfo(cl_device_id dev, cl_device_info param_name,
                        size_t param_value_size, void* param_value,
                        size_t* param_value_size_ret) {
     LOG_API_CALL(
         "device = %p, param_name = %d, size = %zu, value = %p, size_ret = %p",
-        device, param_name, param_value_size, param_value,
-        param_value_size_ret);
+        dev, param_name, param_value_size, param_value, param_value_size_ret);
     cl_int ret = CL_SUCCESS;
 
     size_t size_ret = 0;
@@ -284,11 +283,11 @@ cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
     cl_platform_id val_platform;
     cl_device_id val_deviceid;
 
+    auto device = icd_downcast(dev);
+
     if (!is_valid_device(device)) {
         return CL_INVALID_DEVICE;
     }
-
-    auto dev = icd_downcast(device);
 
     switch (param_name) {
     case CL_DEVICE_PLATFORM:
@@ -297,12 +296,12 @@ cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
         size_ret = sizeof(val_platform);
         break;
     case CL_DEVICE_TYPE:
-        val_devicetype = dev->type();
+        val_devicetype = device->type();
         copy_ptr = &val_devicetype;
         size_ret = sizeof(val_devicetype);
         break;
     case CL_DEVICE_NAME:
-        val_string = dev->name();
+        val_string = device->name();
         copy_ptr = val_string.c_str();
         size_ret = val_string.size_with_null();
         break;
@@ -312,25 +311,25 @@ cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
         size_ret = val_string.size_with_null();
         break;
     case CL_DEVICE_VENDOR_ID:
-        val_uint = dev->vendor_id();
+        val_uint = device->vendor_id();
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;
     case CL_DRIVER_VERSION:
         val_string = "1.2 ";
-        val_string += dev->version_string();
+        val_string += device->version_string();
         copy_ptr = val_string.c_str();
         size_ret = val_string.size_with_null();
         break;
     case CL_DEVICE_VERSION:
         val_string = "OpenCL 1.2 ";
-        val_string += dev->version_string();
+        val_string += device->version_string();
         copy_ptr = val_string.c_str();
         size_ret = val_string.size_with_null();
         break;
     case CL_DEVICE_OPENCL_C_VERSION:
         val_string = "OpenCL C 1.2 ";
-        val_string += dev->version_string();
+        val_string += device->version_string();
         copy_ptr = val_string.c_str();
         size_ret = val_string.size_with_null();
         break;
@@ -345,7 +344,7 @@ cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
         size_ret = val_string.size_with_null();
         break;
     case CL_DEVICE_EXTENSIONS:
-        val_string = dev->extensions();
+        val_string = device->extensions();
         copy_ptr = val_string.c_str();
         size_ret = val_string.size_with_null();
         break;
@@ -357,30 +356,30 @@ cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
         size_ret = sizeof(val_bool);
         break;
     case CL_DEVICE_IMAGE_SUPPORT:
-        val_bool = dev->supports_images();
+        val_bool = device->supports_images();
         copy_ptr = &val_bool;
         size_ret = sizeof(val_bool);
         break;
     case CL_DEVICE_IMAGE2D_MAX_WIDTH:
     case CL_DEVICE_IMAGE2D_MAX_HEIGHT:
-        val_sizet = dev->vulkan_limits().maxImageDimension2D;
+        val_sizet = device->vulkan_limits().maxImageDimension2D;
         copy_ptr = &val_sizet;
         size_ret = sizeof(val_sizet);
         break;
     case CL_DEVICE_IMAGE3D_MAX_WIDTH:
     case CL_DEVICE_IMAGE3D_MAX_HEIGHT:
     case CL_DEVICE_IMAGE3D_MAX_DEPTH:
-        val_sizet = dev->vulkan_limits().maxImageDimension3D;
+        val_sizet = device->vulkan_limits().maxImageDimension3D;
         copy_ptr = &val_sizet;
         size_ret = sizeof(val_sizet);
         break;
     case CL_DEVICE_SINGLE_FP_CONFIG:
-        val_fpconfig = dev->fp_config(CL_DEVICE_SINGLE_FP_CONFIG);
+        val_fpconfig = device->fp_config(CL_DEVICE_SINGLE_FP_CONFIG);
         copy_ptr = &val_fpconfig;
         size_ret = sizeof(val_fpconfig);
         break;
     case CL_DEVICE_DOUBLE_FP_CONFIG:
-        val_fpconfig = dev->fp_config(CL_DEVICE_DOUBLE_FP_CONFIG);
+        val_fpconfig = device->fp_config(CL_DEVICE_DOUBLE_FP_CONFIG);
         copy_ptr = &val_fpconfig;
         size_ret = sizeof(val_fpconfig);
         break;
@@ -390,7 +389,7 @@ cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
         size_ret = sizeof(val_uint);
         break;
     case CL_DEVICE_MEM_BASE_ADDR_ALIGN:
-        val_uint = dev->mem_base_addr_align();
+        val_uint = device->mem_base_addr_align();
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;
@@ -409,7 +408,7 @@ cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
         size_ret = sizeof(val_ulong);
         break;
     case CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE:
-        val_uint = dev->vulkan_limits().nonCoherentAtomSize;
+        val_uint = device->vulkan_limits().nonCoherentAtomSize;
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;
@@ -424,12 +423,12 @@ cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
         size_ret = sizeof(val_bool);
         break;
     case CL_DEVICE_HOST_UNIFIED_MEMORY:
-        val_bool = dev->has_host_unified_memory();
+        val_bool = device->has_host_unified_memory();
         copy_ptr = &val_bool;
         size_ret = sizeof(val_bool);
         break;
     case CL_DEVICE_MAX_WORK_GROUP_SIZE:
-        val_sizet = dev->vulkan_limits().maxComputeWorkGroupInvocations;
+        val_sizet = device->vulkan_limits().maxComputeWorkGroupInvocations;
         copy_ptr = &val_sizet;
         size_ret = sizeof(val_sizet);
         break;
@@ -444,9 +443,9 @@ cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
         size_ret = sizeof(val_uint);
         break;
     case CL_DEVICE_MAX_WORK_ITEM_SIZES:
-        work_item_sizes[0] = dev->vulkan_limits().maxComputeWorkGroupSize[0];
-        work_item_sizes[1] = dev->vulkan_limits().maxComputeWorkGroupSize[1];
-        work_item_sizes[2] = dev->vulkan_limits().maxComputeWorkGroupSize[2];
+        work_item_sizes[0] = device->vulkan_limits().maxComputeWorkGroupSize[0];
+        work_item_sizes[1] = device->vulkan_limits().maxComputeWorkGroupSize[1];
+        work_item_sizes[2] = device->vulkan_limits().maxComputeWorkGroupSize[2];
         copy_ptr = work_item_sizes;
         size_ret = sizeof(work_item_sizes);
         break;
@@ -490,17 +489,17 @@ cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
         size_ret = sizeof(val_sizet);
         break;
     case CL_DEVICE_GLOBAL_MEM_SIZE:
-        val_ulong = dev->memory_size();
+        val_ulong = device->memory_size();
         copy_ptr = &val_ulong;
         size_ret = sizeof(val_ulong);
         break;
     case CL_DEVICE_MAX_MEM_ALLOC_SIZE:
-        val_ulong = dev->max_alloc_size();
+        val_ulong = device->max_alloc_size();
         copy_ptr = &val_ulong;
         size_ret = sizeof(val_ulong);
         break;
     case CL_DEVICE_LOCAL_MEM_SIZE:
-        val_ulong = dev->vulkan_limits().maxComputeSharedMemorySize;
+        val_ulong = device->vulkan_limits().maxComputeSharedMemorySize;
         copy_ptr = &val_ulong;
         size_ret = sizeof(val_ulong);
         break;
@@ -561,27 +560,27 @@ cl_int clGetDeviceInfo(cl_device_id device, cl_device_info param_name,
         size_ret = sizeof(val_sizet);
         break;
     case CL_DEVICE_MAX_SAMPLERS:
-        val_uint = dev->vulkan_limits().maxPerStageDescriptorSamplers;
+        val_uint = device->vulkan_limits().maxPerStageDescriptorSamplers;
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;
     case CL_DEVICE_IMAGE_MAX_BUFFER_SIZE:
-        val_sizet = dev->vulkan_limits().maxImageDimension1D;
+        val_sizet = device->vulkan_limits().maxImageDimension1D;
         copy_ptr = &val_sizet;
         size_ret = sizeof(val_sizet);
         break;
     case CL_DEVICE_IMAGE_MAX_ARRAY_SIZE:
-        val_sizet = dev->vulkan_limits().maxImageArrayLayers;
+        val_sizet = device->vulkan_limits().maxImageArrayLayers;
         copy_ptr = &val_sizet;
         size_ret = sizeof(val_sizet);
         break;
     case CL_DEVICE_MAX_READ_IMAGE_ARGS:
-        val_uint = dev->vulkan_limits().maxPerStageDescriptorSampledImages;
+        val_uint = device->vulkan_limits().maxPerStageDescriptorSampledImages;
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;
     case CL_DEVICE_MAX_WRITE_IMAGE_ARGS:
-        val_uint = dev->vulkan_limits().maxPerStageDescriptorStorageImages;
+        val_uint = device->vulkan_limits().maxPerStageDescriptorStorageImages;
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;
@@ -709,13 +708,12 @@ cl_int clReleaseContext(cl_context context) {
     return CL_SUCCESS;
 }
 
-cl_int clGetContextInfo(cl_context context, cl_context_info param_name,
+cl_int clGetContextInfo(cl_context ctx, cl_context_info param_name,
                         size_t param_value_size, void* param_value,
                         size_t* param_value_size_ret) {
     LOG_API_CALL(
         "context = %p, param_name = %u, size = %zu, value = %p, size_ret = %p",
-        context, param_name, param_value_size, param_value,
-        param_value_size_ret);
+        ctx, param_name, param_value_size, param_value, param_value_size_ret);
 
     cl_int ret = CL_SUCCESS;
     size_t size_ret = 0;
@@ -723,31 +721,32 @@ cl_int clGetContextInfo(cl_context context, cl_context_info param_name,
     cl_uint val_uint;
     cl_device_id val_device;
 
-    auto ctx = icd_downcast(context);
+    auto context = icd_downcast(ctx);
 
     switch (param_name) {
     case CL_CONTEXT_REFERENCE_COUNT:
-        val_uint = ctx->refcount();
+        val_uint = context->refcount();
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;
     case CL_CONTEXT_DEVICES:
-        val_device = ctx->device();
+        val_device = context->device();
         copy_ptr = &val_device;
         size_ret = sizeof(val_device);
         break;
     case CL_CONTEXT_NUM_DEVICES:
-        val_uint = ctx->num_devices();
+        val_uint = context->num_devices();
         copy_ptr = &val_uint;
         size_ret = sizeof(cl_uint);
         break;
     case CL_CONTEXT_PROPERTIES:
-        if (ctx->properties().size() == 0) {
+        if (context->properties().size() == 0) {
             size_ret = 0;
             copy_ptr = nullptr;
         } else {
-            copy_ptr = ctx->properties().data();
-            size_ret = ctx->properties().size() * sizeof(cl_context_properties);
+            copy_ptr = context->properties().data();
+            size_ret =
+                context->properties().size() * sizeof(cl_context_properties);
         }
         break;
     default:
@@ -969,12 +968,12 @@ cl_int clEnqueueBarrier(cl_command_queue command_queue) {
                                               nullptr, nullptr);
 }
 
-cl_int clGetEventInfo(cl_event event, cl_event_info param_name,
+cl_int clGetEventInfo(cl_event evt, cl_event_info param_name,
                       size_t param_value_size, void* param_value,
                       size_t* param_value_size_ret) {
     LOG_API_CALL("event = %p, param_name = %x, param_value_size = %zu, "
                  "param_value = %p, param_value_size_ret = %p",
-                 event, param_name, param_value_size, param_value,
+                 evt, param_name, param_value_size, param_value,
                  param_value_size_ret);
 
     cl_int ret = CL_SUCCESS;
@@ -986,43 +985,43 @@ cl_int clGetEventInfo(cl_event event, cl_event_info param_name,
     cl_command_type val_command_type;
     cl_command_queue val_command_queue;
 
+    auto event = icd_downcast(evt);
+
     if (!is_valid_event(event)) {
         return CL_INVALID_VALUE;
     }
 
-    auto evt = icd_downcast(event);
-
     switch (param_name) {
     case CL_EVENT_REFERENCE_COUNT:
-        val_uint = evt->refcount();
+        val_uint = event->refcount();
         copy_ptr = &val_uint;
         ret_size = sizeof(val_uint);
         break;
     case CL_EVENT_COMMAND_EXECUTION_STATUS:
-        val_int = evt->get_status();
+        val_int = event->get_status();
         copy_ptr = &val_int;
         ret_size = sizeof(val_int);
         break;
     case CL_EVENT_COMMAND_QUEUE:
-        if (evt->is_user_event()) {
+        if (event->is_user_event()) {
             val_command_queue = nullptr;
         } else {
-            val_command_queue = evt->queue();
+            val_command_queue = event->queue();
         }
         copy_ptr = &val_command_queue;
         ret_size = sizeof(val_command_queue);
         break;
     case CL_EVENT_COMMAND_TYPE:
-        if (evt->is_user_event()) {
+        if (event->is_user_event()) {
             val_command_type = CL_COMMAND_USER;
         } else {
-            val_command_type = evt->command_type();
+            val_command_type = event->command_type();
         }
         copy_ptr = &val_command_type;
         ret_size = sizeof(val_command_type);
         break;
     case CL_EVENT_CONTEXT:
-        val_context = evt->context();
+        val_context = event->context();
         copy_ptr = &val_context;
         ret_size = sizeof(val_context);
         break;
@@ -1097,13 +1096,13 @@ cl_int clRetainCommandQueue(cl_command_queue command_queue) {
     return CL_SUCCESS;
 }
 
-cl_int clGetCommandQueueInfo(cl_command_queue command_queue,
+cl_int clGetCommandQueueInfo(cl_command_queue cq,
                              cl_command_queue_info param_name,
                              size_t param_value_size, void* param_value,
                              size_t* param_value_size_ret) {
     LOG_API_CALL("command_queue = %p, param_name = %x, param_value_size = %zu, "
                  "param_value = %p, param_value_size_ret = %p",
-                 command_queue, param_name, param_value_size, param_value,
+                 cq, param_name, param_value_size, param_value,
                  param_value_size_ret);
 
     cl_int ret = CL_SUCCESS;
@@ -1114,30 +1113,30 @@ cl_int clGetCommandQueueInfo(cl_command_queue command_queue,
     cl_device_id val_device;
     cl_command_queue_properties val_properties;
 
+    auto command_queue = icd_downcast(cq);
+
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
     }
 
-    auto cq = icd_downcast(command_queue);
-
     switch (param_name) {
     case CL_QUEUE_REFERENCE_COUNT:
-        val_uint = cq->refcount();
+        val_uint = command_queue->refcount();
         copy_ptr = &val_uint;
         ret_size = sizeof(val_uint);
         break;
     case CL_QUEUE_CONTEXT:
-        val_context = cq->context();
+        val_context = command_queue->context();
         copy_ptr = &val_context;
         ret_size = sizeof(val_context);
         break;
     case CL_QUEUE_DEVICE:
-        val_device = cq->device();
+        val_device = command_queue->device();
         copy_ptr = &val_device;
         ret_size = sizeof(val_device);
         break;
     case CL_QUEUE_PROPERTIES:
-        val_properties = cq->properties();
+        val_properties = command_queue->properties();
         copy_ptr = &val_properties;
         ret_size = sizeof(val_properties);
         break;
@@ -1181,17 +1180,17 @@ cl_mem clCreateBuffer(cl_context context, cl_mem_flags flags, size_t size,
     }
 }
 
-cl_mem clCreateSubBuffer(cl_mem buffer, cl_mem_flags flags,
+cl_mem clCreateSubBuffer(cl_mem buf, cl_mem_flags flags,
                          cl_buffer_create_type buffer_create_type,
                          const void* buffer_create_info, cl_int* errcode_ret) {
     LOG_API_CALL("buffer = %p, flags = %lu, buffer_create_type = %u, "
                  "buffer_create_info = %p, errcode_ret = %p",
-                 buffer, flags, buffer_create_type, buffer_create_info,
+                 buf, flags, buffer_create_type, buffer_create_info,
                  errcode_ret);
 
-    auto buf = static_cast<cvk_buffer*>(buffer);
+    auto buffer = static_cast<cvk_buffer*>(buf);
 
-    if (!is_valid_buffer(buffer) || buf->is_sub_buffer()) {
+    if (!is_valid_buffer(buffer) || buffer->is_sub_buffer()) {
         if (errcode_ret != nullptr) {
             *errcode_ret = CL_INVALID_MEM_OBJECT;
         }
@@ -1232,7 +1231,7 @@ cl_mem clCreateSubBuffer(cl_mem buffer, cl_mem_flags flags,
                  region->origin, region->size);
 
     cl_int err = CL_SUCCESS;
-    auto sub = buf->create_subbuffer(flags, region->origin, region->size);
+    auto sub = buffer->create_subbuffer(flags, region->origin, region->size);
 
     if (sub == nullptr) {
         err = CL_OUT_OF_RESOURCES;
@@ -1289,8 +1288,7 @@ cl_int clSetMemObjectDestructorCallback(
     return CL_SUCCESS;
 }
 
-cl_int clEnqueueMigrateMemObjects(cl_command_queue command_queue,
-                                  cl_uint num_mem_objects,
+cl_int clEnqueueMigrateMemObjects(cl_command_queue cq, cl_uint num_mem_objects,
                                   const cl_mem* mem_objects,
                                   cl_mem_migration_flags flags,
                                   cl_uint num_events_in_wait_list,
@@ -1299,7 +1297,7 @@ cl_int clEnqueueMigrateMemObjects(cl_command_queue command_queue,
     LOG_API_CALL("command_queue = %p, num_mem_objects = %u, mem_objects = %p, "
                  "flags = %lx, num_events_in_wait_list = %u, "
                  "event_wait_list = %p, event = %p",
-                 command_queue, num_mem_objects, mem_objects, flags,
+                 cq, num_mem_objects, mem_objects, flags,
                  num_events_in_wait_list, event_wait_list, event);
 
     if ((num_mem_objects == 0) || (mem_objects == nullptr)) {
@@ -1316,6 +1314,8 @@ cl_int clEnqueueMigrateMemObjects(cl_command_queue command_queue,
     // described in the table above.
     // TODO CL_MEM_OBJECT_ALLOCATION_FAILURE if there is a failure to allocate
     // memory for the specified set of memory objects in mem_objects.
+
+    auto command_queue = icd_downcast(cq);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -1336,21 +1336,21 @@ cl_int clEnqueueMigrateMemObjects(cl_command_queue command_queue,
         }
     }
 
-    auto cq = icd_downcast(command_queue);
-    auto cmd = new cvk_command_dep(cq, CL_COMMAND_MIGRATE_MEM_OBJECTS);
+    auto cmd =
+        new cvk_command_dep(command_queue, CL_COMMAND_MIGRATE_MEM_OBJECTS);
 
-    cq->enqueue_command_with_deps(cmd, num_events_in_wait_list, event_wait_list,
-                                  event);
+    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+                                             event_wait_list, event);
 
     return CL_SUCCESS;
 }
 
-cl_int clGetMemObjectInfo(cl_mem memobj, cl_mem_info param_name,
+cl_int clGetMemObjectInfo(cl_mem mem, cl_mem_info param_name,
                           size_t param_value_size, void* param_value,
                           size_t* param_value_size_ret) {
     LOG_API_CALL("memobj = %p, param_name = %x, param_value_size = %zu, "
                  "param_value = %p, param_value_size_ret = %p",
-                 memobj, param_name, param_value_size, param_value,
+                 mem, param_name, param_value_size, param_value,
                  param_value_size_ret);
 
     cl_int ret = CL_SUCCESS;
@@ -1364,55 +1364,55 @@ cl_int clGetMemObjectInfo(cl_mem memobj, cl_mem_info param_name,
     cl_mem val_memobj;
     void* val_ptr;
 
+    auto memobj = icd_downcast(mem);
+
     if (!is_valid_mem_object(memobj)) {
         return CL_INVALID_MEM_OBJECT;
     }
 
-    auto mem = icd_downcast(memobj);
-
     switch (param_name) {
     case CL_MEM_REFERENCE_COUNT:
-        val_uint = mem->refcount();
+        val_uint = memobj->refcount();
         copy_ptr = &val_uint;
         ret_size = sizeof(val_uint);
         break;
     case CL_MEM_CONTEXT:
-        val_context = mem->context();
+        val_context = memobj->context();
         copy_ptr = &val_context;
         ret_size = sizeof(val_context);
         break;
     case CL_MEM_TYPE:
-        val_object_type = mem->type();
+        val_object_type = memobj->type();
         copy_ptr = &val_object_type;
         ret_size = sizeof(val_object_type);
         break;
     case CL_MEM_FLAGS:
-        val_flags = mem->flags();
+        val_flags = memobj->flags();
         copy_ptr = &val_flags;
         ret_size = sizeof(val_flags);
         break;
     case CL_MEM_SIZE:
-        val_sizet = mem->size();
+        val_sizet = memobj->size();
         copy_ptr = &val_sizet;
         ret_size = sizeof(val_sizet);
         break;
     case CL_MEM_MAP_COUNT:
-        val_uint = mem->map_count();
+        val_uint = memobj->map_count();
         copy_ptr = &val_uint;
         ret_size = sizeof(val_uint);
         break;
     case CL_MEM_ASSOCIATED_MEMOBJECT:
-        val_memobj = mem->parent();
+        val_memobj = memobj->parent();
         copy_ptr = &val_memobj;
         ret_size = sizeof(val_memobj);
         break;
     case CL_MEM_OFFSET:
-        val_sizet = mem->parent_offset();
+        val_sizet = memobj->parent_offset();
         copy_ptr = &val_sizet;
         ret_size = sizeof(val_sizet);
         break;
     case CL_MEM_HOST_PTR:
-        val_ptr = mem->host_ptr();
+        val_ptr = memobj->host_ptr();
         copy_ptr = &val_ptr;
         ret_size = sizeof(val_ptr);
         break;
@@ -1465,7 +1465,7 @@ cl_program clCreateProgramWithSource(cl_context context, cl_uint count,
     return prog;
 }
 
-cl_program clCreateProgramWithBinary(cl_context context, cl_uint num_devices,
+cl_program clCreateProgramWithBinary(cl_context ctx, cl_uint num_devices,
                                      const cl_device_id* device_list,
                                      const size_t* lengths,
                                      const unsigned char** binaries,
@@ -1473,8 +1473,10 @@ cl_program clCreateProgramWithBinary(cl_context context, cl_uint num_devices,
                                      cl_int* errcode_ret) {
     LOG_API_CALL("context = %p, num_devices = %u, device_list = %p, lengths = "
                  "%p, binaries = %p, binary_status = %p, errcode_ret = %p",
-                 context, num_devices, device_list, lengths, binaries,
+                 ctx, num_devices, device_list, lengths, binaries,
                  binary_status, errcode_ret);
+
+    auto context = icd_downcast(ctx);
 
     if (!is_valid_context(context)) {
         if (errcode_ret != nullptr) {
@@ -1490,9 +1492,7 @@ cl_program clCreateProgramWithBinary(cl_context context, cl_uint num_devices,
         return nullptr;
     }
 
-    auto ctx = icd_downcast(context);
-
-    if (icd_downcast(device_list[0]) != ctx->device()) {
+    if (icd_downcast(device_list[0]) != context->device()) {
         if (errcode_ret != nullptr) {
             *errcode_ret = CL_INVALID_DEVICE;
         }
@@ -1533,15 +1533,17 @@ cl_program clCreateProgramWithBinary(cl_context context, cl_uint num_devices,
     return prog;
 }
 
-cl_int clBuildProgram(cl_program program, cl_uint num_devices,
+cl_int clBuildProgram(cl_program prog, cl_uint num_devices,
                       const cl_device_id* device_list, const char* options,
                       void(CL_CALLBACK* pfn_notify)(cl_program /* program */,
                                                     void* /* user_data */),
                       void* user_data) {
     LOG_API_CALL("program = %p, num_device = %d, device_list = %p, options = "
                  "%s, pfn_notify = %p, user_data = %p",
-                 program, num_devices, device_list, options, pfn_notify,
+                 prog, num_devices, device_list, options, pfn_notify,
                  user_data);
+
+    auto program = icd_downcast(prog);
 
     if (!is_valid_program(program)) {
         return CL_INVALID_PROGRAM;
@@ -1576,18 +1578,16 @@ cl_int clBuildProgram(cl_program program, cl_uint num_devices,
     // clCreateProgramWithSource or clCreateProgramWithBinary or
     // clCreateProgramWithILKHR.
 
-    auto prog = icd_downcast(program);
-
-    if (!prog->build(build_operation::build, num_devices, device_list, options,
-                     0, nullptr, nullptr, pfn_notify, user_data)) {
+    if (!program->build(build_operation::build, num_devices, device_list,
+                        options, 0, nullptr, nullptr, pfn_notify, user_data)) {
         return CL_INVALID_OPERATION;
     }
 
     if (pfn_notify == nullptr) {
 
-        prog->wait_for_operation();
+        program->wait_for_operation();
 
-        if (prog->build_status() != CL_BUILD_SUCCESS) {
+        if (program->build_status() != CL_BUILD_SUCCESS) {
             return CL_BUILD_PROGRAM_FAILURE;
         }
     }
@@ -1596,7 +1596,7 @@ cl_int clBuildProgram(cl_program program, cl_uint num_devices,
 }
 
 cl_int clCompileProgram(
-    cl_program program, cl_uint num_devices, const cl_device_id* device_list,
+    cl_program prog, cl_uint num_devices, const cl_device_id* device_list,
     const char* options, cl_uint num_input_headers,
     const cl_program* input_headers, const char** header_include_names,
     void(CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
@@ -1604,8 +1604,10 @@ cl_int clCompileProgram(
     LOG_API_CALL("program = %p, num_devices = %u, device_list = %p, options = "
                  "%p, num_input_headers = %u, input_headers = %p, "
                  "header_include_names = %p, pfn_notify = %p, user_data = %p",
-                 program, num_devices, device_list, options, num_input_headers,
+                 prog, num_devices, device_list, options, num_input_headers,
                  input_headers, header_include_names, pfn_notify, user_data);
+
+    auto program = icd_downcast(prog);
 
     if (!is_valid_program(program)) {
         return CL_INVALID_PROGRAM;
@@ -1627,8 +1629,6 @@ cl_int clCompileProgram(
         return CL_INVALID_VALUE;
     }
 
-    auto prog = icd_downcast(program);
-
     // TODO CL_INVALID_DEVICE if OpenCL devices listed in device_list are not in
     // the list of devices associated with program.
     // TODO CL_INVALID_COMPILER_OPTIONS if the compiler options specified by
@@ -1642,22 +1642,22 @@ cl_int clCompileProgram(
     // return until the compile has completed.
     // TODO CL_INVALID_OPERATION if there are kernel objects attached to
     // program.
-    if (prog->loaded_from_binary()) {
+    if (program->loaded_from_binary()) {
         return CL_INVALID_OPERATION;
     }
 
     // TODO Validate program
-    if (!prog->build(build_operation::compile, num_devices, device_list,
-                     options, num_input_headers, input_headers,
-                     header_include_names, pfn_notify, user_data)) {
+    if (!program->build(build_operation::compile, num_devices, device_list,
+                        options, num_input_headers, input_headers,
+                        header_include_names, pfn_notify, user_data)) {
         return CL_INVALID_OPERATION;
     }
 
     if (pfn_notify == nullptr) {
 
-        prog->wait_for_operation();
+        program->wait_for_operation();
 
-        if (prog->build_status() != CL_BUILD_SUCCESS) {
+        if (program->build_status() != CL_BUILD_SUCCESS) {
             return CL_BUILD_PROGRAM_FAILURE;
         }
     }
@@ -1780,12 +1780,12 @@ cl_int clUnloadCompiler() {
     return CL_SUCCESS;
 }
 
-cl_int clGetProgramInfo(cl_program program, cl_program_info param_name,
+cl_int clGetProgramInfo(cl_program prog, cl_program_info param_name,
                         size_t param_value_size, void* param_value,
                         size_t* param_value_size_ret) {
     LOG_API_CALL("program = %p, param_name = %x, param_value_size = %zu, "
                  "param_value = %p, param_value_size_ret = %p",
-                 program, param_name, param_value_size, param_value,
+                 prog, param_name, param_value_size, param_value,
                  param_value_size_ret);
 
     cl_int ret = CL_SUCCESS;
@@ -1798,6 +1798,8 @@ cl_int clGetProgramInfo(cl_program program, cl_program_info param_name,
     std::vector<size_t> val_sizet_vec;
     std::vector<cl_device_id> val_devices;
 
+    auto program = icd_downcast(prog);
+
     if (!is_valid_program(program)) {
         return CL_INVALID_PROGRAM;
     }
@@ -1807,44 +1809,42 @@ cl_int clGetProgramInfo(cl_program program, cl_program_info param_name,
     // program executable has not been built for at least one device in the list
     // of devices associated with program.
 
-    auto prog = icd_downcast(program);
-
     switch (param_name) {
     case CL_PROGRAM_NUM_DEVICES:
-        val_uint = prog->num_devices();
+        val_uint = program->num_devices();
         copy_ptr = &val_uint;
         ret_size = sizeof(val_uint);
         break;
     case CL_PROGRAM_REFERENCE_COUNT:
-        val_uint = prog->refcount();
+        val_uint = program->refcount();
         copy_ptr = &val_uint;
         ret_size = sizeof(val_uint);
         break;
     case CL_PROGRAM_CONTEXT:
-        val_context = prog->context();
+        val_context = program->context();
         copy_ptr = &val_context;
         ret_size = sizeof(val_context);
         break;
     case CL_PROGRAM_DEVICES:
-        for (auto dev : prog->devices()) {
+        for (auto dev : program->devices()) {
             val_devices.push_back(const_cast<cvk_device*>(dev));
         }
         copy_ptr = val_devices.data();
         ret_size = sizeof(cl_device_id) * val_devices.size();
         break;
     case CL_PROGRAM_NUM_KERNELS:
-        val_sizet = prog->num_kernels();
+        val_sizet = program->num_kernels();
         copy_ptr = &val_sizet;
         ret_size = sizeof(val_sizet);
         break;
     case CL_PROGRAM_SOURCE:
-        copy_ptr = prog->source().c_str();
-        ret_size = prog->source().size() + 1;
+        copy_ptr = program->source().c_str();
+        ret_size = program->source().size() + 1;
         break;
     case CL_PROGRAM_KERNEL_NAMES: {
         val_string = "";
         std::string sep = "";
-        for (auto kname : prog->kernel_names()) {
+        for (auto kname : program->kernel_names()) {
             val_string += sep + kname;
             sep = ";";
         }
@@ -1853,19 +1853,19 @@ cl_int clGetProgramInfo(cl_program program, cl_program_info param_name,
         break;
     }
     case CL_PROGRAM_BINARY_SIZES:
-        for (uint32_t i = 0; i < prog->num_devices(); i++) {
-            val_sizet_vec.push_back(prog->binary_size());
+        for (uint32_t i = 0; i < program->num_devices(); i++) {
+            val_sizet_vec.push_back(program->binary_size());
         }
         copy_ptr = val_sizet_vec.data();
         ret_size = val_sizet_vec.size() * sizeof(size_t);
         break;
     case CL_PROGRAM_BINARIES:
-        ret_size = prog->num_devices() * sizeof(unsigned char*);
+        ret_size = program->num_devices() * sizeof(unsigned char*);
         if (param_value != nullptr) {
-            for (uint32_t i = 0; i < prog->num_devices(); i++) {
+            for (uint32_t i = 0; i < program->num_devices(); i++) {
                 auto dst = static_cast<unsigned char**>(param_value)[i];
                 if (dst != nullptr) {
-                    auto success = prog->write(dst);
+                    auto success = program->write(dst);
                     if (!success) {
                         ret = CL_OUT_OF_RESOURCES;
                         break;
@@ -1875,8 +1875,8 @@ cl_int clGetProgramInfo(cl_program program, cl_program_info param_name,
         }
         break;
     case CL_PROGRAM_IL_KHR:
-        copy_ptr = prog->il().data();
-        ret_size = prog->il().size();
+        copy_ptr = program->il().data();
+        ret_size = program->il().size();
         break;
     default:
         ret = CL_INVALID_VALUE;
@@ -1897,13 +1897,13 @@ cl_int clGetProgramInfo(cl_program program, cl_program_info param_name,
     return ret;
 }
 
-cl_int clGetProgramBuildInfo(cl_program program, cl_device_id device,
+cl_int clGetProgramBuildInfo(cl_program prog, cl_device_id dev,
                              cl_program_build_info param_name,
                              size_t param_value_size, void* param_value,
                              size_t* param_value_size_ret) {
     LOG_API_CALL("program = %p, device = %p, param_name = %x, param_value_size "
                  "= %zu, param_value = %p, param_value_size_ret = %p",
-                 program, device, param_name, param_value_size, param_value,
+                 prog, dev, param_name, param_value_size, param_value,
                  param_value_size_ret);
     cl_int ret = CL_SUCCESS;
     size_t ret_size = 0;
@@ -1911,6 +1911,9 @@ cl_int clGetProgramBuildInfo(cl_program program, cl_device_id device,
     cl_build_status val_status;
     api_query_string val_string;
     cl_program_binary_type val_binarytype;
+
+    auto device = icd_downcast(dev);
+    auto program = icd_downcast(prog);
 
     if (!is_valid_program(program)) {
         return CL_INVALID_PROGRAM;
@@ -1920,12 +1923,9 @@ cl_int clGetProgramBuildInfo(cl_program program, cl_device_id device,
         return CL_INVALID_DEVICE;
     }
 
-    auto dev = icd_downcast(device);
-    auto prog = icd_downcast(program);
-
     switch (param_name) {
     case CL_PROGRAM_BUILD_STATUS:
-        val_status = prog->build_status(dev);
+        val_status = program->build_status(device);
         copy_ptr = &val_status;
         ret_size = sizeof(val_status);
         break;
@@ -1935,11 +1935,11 @@ cl_int clGetProgramBuildInfo(cl_program program, cl_device_id device,
         ret_size = val_string.size_with_null();
         break;
     case CL_PROGRAM_BUILD_OPTIONS:
-        copy_ptr = prog->build_options().c_str();
-        ret_size = prog->build_options().size() + 1;
+        copy_ptr = program->build_options().c_str();
+        ret_size = program->build_options().size() + 1;
         break;
     case CL_PROGRAM_BINARY_TYPE:
-        val_binarytype = prog->binary_type(dev);
+        val_binarytype = program->binary_type(device);
         copy_ptr = &val_binarytype;
         ret_size = sizeof(val_binarytype);
         break;
@@ -1995,9 +1995,11 @@ cl_kernel cvk_create_kernel(cl_program program, const char* kernel_name,
     }
 }
 
-cl_kernel clCreateKernel(cl_program program, const char* kernel_name,
+cl_kernel clCreateKernel(cl_program prog, const char* kernel_name,
                          cl_int* errcode_ret) {
-    LOG_API_CALL("program = %p, kernel_name = %s", program, kernel_name);
+    LOG_API_CALL("program = %p, kernel_name = %s", prog, kernel_name);
+
+    auto program = icd_downcast(prog);
 
     if (!is_valid_program(program)) {
         if (errcode_ret != nullptr) {
@@ -2006,9 +2008,7 @@ cl_kernel clCreateKernel(cl_program program, const char* kernel_name,
         return nullptr;
     }
 
-    auto prog = icd_downcast(program);
-
-    if (prog->build_status() != CL_BUILD_SUCCESS) {
+    if (program->build_status() != CL_BUILD_SUCCESS) {
         if (errcode_ret != nullptr) {
             *errcode_ret = CL_INVALID_PROGRAM_EXECUTABLE;
         }
@@ -2025,23 +2025,23 @@ cl_kernel clCreateKernel(cl_program program, const char* kernel_name,
     return ret;
 }
 
-cl_int clCreateKernelsInProgram(cl_program program, cl_uint num_kernels,
+cl_int clCreateKernelsInProgram(cl_program prog, cl_uint num_kernels,
                                 cl_kernel* kernels, cl_uint* num_kernels_ret) {
     LOG_API_CALL(
         "program = %p, num_kernels = %u, kernels = %p, num_kernels_ret = %p",
-        program, num_kernels, kernels, num_kernels_ret);
+        prog, num_kernels, kernels, num_kernels_ret);
+
+    auto program = icd_downcast(prog);
 
     if (!is_valid_program(program)) {
         return CL_INVALID_PROGRAM;
     }
 
-    auto prog = icd_downcast(program);
-
-    if (prog->build_status() != CL_BUILD_SUCCESS) {
+    if (program->build_status() != CL_BUILD_SUCCESS) {
         return CL_INVALID_PROGRAM_EXECUTABLE;
     }
 
-    cl_uint num_kernels_in_program = prog->num_kernels();
+    cl_uint num_kernels_in_program = program->num_kernels();
 
     if ((kernels != nullptr) && (num_kernels < num_kernels_in_program)) {
         return CL_INVALID_VALUE;
@@ -2050,7 +2050,7 @@ cl_int clCreateKernelsInProgram(cl_program program, cl_uint num_kernels,
     if (kernels != nullptr) {
         cl_uint i = 0;
         cl_int err;
-        for (auto& kname : prog->kernel_names()) {
+        for (auto& kname : program->kernel_names()) {
             kernels[i] = cvk_create_kernel(program, kname, &err);
             if (err != CL_SUCCESS) {
                 return err;
@@ -2066,11 +2066,13 @@ cl_int clCreateKernelsInProgram(cl_program program, cl_uint num_kernels,
     return CL_SUCCESS;
 }
 
-cl_int clSetKernelArg(cl_kernel kernel, cl_uint arg_index, size_t arg_size,
+cl_int clSetKernelArg(cl_kernel kern, cl_uint arg_index, size_t arg_size,
                       const void* arg_value) {
 
     LOG_API_CALL("kernel = %p, arg_index = %u, arg_size = %zu, arg_value = %p",
-                 kernel, arg_index, arg_size, arg_value);
+                 kern, arg_index, arg_size, arg_value);
+
+    auto kernel = icd_downcast(kern);
 
     if (!is_valid_kernel(kernel)) {
         return CL_INVALID_KERNEL;
@@ -2096,29 +2098,27 @@ cl_int clSetKernelArg(cl_kernel kernel, cl_uint arg_index, size_t arg_size,
     // TODO CL_OUT_OF_HOST_MEMORY if there is a failure to allocate resources
     // required by the OpenCL implementation on the host.
 
-    auto kern = icd_downcast(kernel);
-
-    if (arg_index >= kern->num_args()) {
-        cvk_error_fn("the program has only %u arguments", kern->num_args());
+    if (arg_index >= kernel->num_args()) {
+        cvk_error_fn("the program has only %u arguments", kernel->num_args());
         return CL_INVALID_ARG_INDEX;
     }
 
     if ((arg_value == nullptr) &&
-        (kern->arg_kind(arg_index) != kernel_argument_kind::local)) {
+        (kernel->arg_kind(arg_index) != kernel_argument_kind::local)) {
         cvk_error_fn("passing a null pointer to clSetKernelArg is only "
                      "supported for local arguments");
         return CL_INVALID_ARG_VALUE;
     }
 
-    return kern->set_arg(arg_index, arg_size, arg_value);
+    return kernel->set_arg(arg_index, arg_size, arg_value);
 }
 
-cl_int clGetKernelInfo(cl_kernel kernel, cl_kernel_info param_name,
+cl_int clGetKernelInfo(cl_kernel kern, cl_kernel_info param_name,
                        size_t param_value_size, void* param_value,
                        size_t* param_value_size_ret) {
     LOG_API_CALL("kernel = %p, param_name = %x, param_value_size = %zu, "
                  "param_value = %p, param_value_size_ret = %p",
-                 kernel, param_name, param_value_size, param_value,
+                 kern, param_name, param_value_size, param_value,
                  param_value_size_ret);
 
     cl_int ret = CL_SUCCESS;
@@ -2128,34 +2128,34 @@ cl_int clGetKernelInfo(cl_kernel kernel, cl_kernel_info param_name,
     cl_context val_context;
     cl_program val_program;
 
+    auto kernel = icd_downcast(kern);
+
     if (!is_valid_kernel(kernel)) {
         return CL_INVALID_KERNEL;
     }
 
-    auto kern = icd_downcast(kernel);
-
     switch (param_name) {
     case CL_KERNEL_REFERENCE_COUNT:
-        val_uint = kern->refcount();
+        val_uint = kernel->refcount();
         copy_ptr = &val_uint;
         ret_size = sizeof(val_uint);
         break;
     case CL_KERNEL_CONTEXT:
-        val_context = kern->context();
+        val_context = kernel->context();
         copy_ptr = &val_context;
         ret_size = sizeof(val_context);
         break;
     case CL_KERNEL_FUNCTION_NAME:
-        copy_ptr = kern->name().c_str();
-        ret_size = kern->name().size() + 1;
+        copy_ptr = kernel->name().c_str();
+        ret_size = kernel->name().size() + 1;
         break;
     case CL_KERNEL_NUM_ARGS:
-        val_uint = kern->num_args();
+        val_uint = kernel->num_args();
         copy_ptr = &val_uint;
         ret_size = sizeof(val_uint);
         break;
     case CL_KERNEL_PROGRAM:
-        val_program = kern->program();
+        val_program = kernel->program();
         copy_ptr = &val_program;
         ret_size = sizeof(val_program);
         break;
@@ -2191,14 +2191,14 @@ cl_int clGetKernelArgInfo(cl_kernel kernel, cl_uint arg_indx,
     return CL_INVALID_OPERATION;
 }
 
-cl_int clGetKernelWorkGroupInfo(cl_kernel kernel, cl_device_id device,
+cl_int clGetKernelWorkGroupInfo(cl_kernel kern, cl_device_id dev,
                                 cl_kernel_work_group_info param_name,
                                 size_t param_value_size, void* param_value,
                                 size_t* param_value_size_ret) {
     LOG_API_CALL(
         "kernel = %p, device = %p, param_name = %x, param_value_size = %zu, "
         "param_value = %p, param_value_size_ret = %p",
-        kernel, device, param_name, param_value_size, param_value,
+        kern, dev, param_name, param_value_size, param_value,
         param_value_size_ret);
 
     cl_int ret = CL_SUCCESS;
@@ -2206,16 +2206,16 @@ cl_int clGetKernelWorkGroupInfo(cl_kernel kernel, cl_device_id device,
     size_t val_sizet, ret_size = 0;
     cl_ulong val_ulong;
 
+    auto device = icd_downcast(dev);
+    auto kernel = icd_downcast(kern);
+
     if (!is_valid_kernel(kernel)) {
         return CL_INVALID_KERNEL;
     }
 
-    auto dev = icd_downcast(device);
-    auto kern = icd_downcast(kernel);
-
     switch (param_name) {
     case CL_KERNEL_WORK_GROUP_SIZE:
-        val_sizet = dev->vulkan_limits().maxComputeWorkGroupInvocations;
+        val_sizet = device->vulkan_limits().maxComputeWorkGroupInvocations;
         copy_ptr = &val_sizet;
         ret_size = sizeof(val_sizet);
         break;
@@ -2226,7 +2226,7 @@ cl_int clGetKernelWorkGroupInfo(cl_kernel kernel, cl_device_id device,
         ret_size = sizeof(val_sizet);
         break;
     case CL_KERNEL_LOCAL_MEM_SIZE:
-        val_ulong = kern->local_mem_size();
+        val_ulong = kernel->local_mem_size();
         copy_ptr = &val_ulong;
         ret_size = sizeof(val_ulong);
         break;
@@ -2277,13 +2277,15 @@ cl_int clReleaseKernel(cl_kernel kernel) {
 }
 
 /* Profiling APIs  */
-cl_int clGetEventProfilingInfo(cl_event event, cl_profiling_info param_name,
+cl_int clGetEventProfilingInfo(cl_event evt, cl_profiling_info param_name,
                                size_t param_value_size, void* param_value,
                                size_t* param_value_size_ret) {
     LOG_API_CALL("event = %p, param_name = %x, param_value_size = %zu, "
                  "param_value = %p, param_value_size_ret = %p",
-                 event, param_name, param_value_size, param_value,
+                 evt, param_name, param_value_size, param_value,
                  param_value_size_ret);
+
+    auto event = icd_downcast(evt);
 
     if (!is_valid_event(event)) {
         return CL_INVALID_EVENT;
@@ -2303,13 +2305,11 @@ cl_int clGetEventProfilingInfo(cl_event event, cl_profiling_info param_name,
         return CL_INVALID_VALUE;
     }
 
-    auto evt = icd_downcast(event);
-
-    if (evt->is_user_event() || (evt->get_status() != CL_COMPLETE)) {
+    if (event->is_user_event() || (event->get_status() != CL_COMPLETE)) {
         return CL_PROFILING_INFO_NOT_AVAILABLE;
     }
 
-    if (!evt->queue()->has_property(CL_QUEUE_PROFILING_ENABLE)) {
+    if (!event->queue()->has_property(CL_QUEUE_PROFILING_ENABLE)) {
         return CL_PROFILING_INFO_NOT_AVAILABLE;
     }
 
@@ -2318,7 +2318,7 @@ cl_int clGetEventProfilingInfo(cl_event event, cl_profiling_info param_name,
     }
 
     if (param_value != nullptr) {
-        cl_ulong value = evt->get_profiling_info(param_name);
+        cl_ulong value = event->get_profiling_info(param_name);
         memcpy(param_value, &value, sizeof(cl_ulong));
     }
 
@@ -2356,13 +2356,16 @@ cl_int clFinish(cl_command_queue command_queue) {
 
 /* Enqueued Commands APIs */
 
-cl_int clEnqueueReadBuffer(cl_command_queue command_queue, cl_mem buffer,
+cl_int clEnqueueReadBuffer(cl_command_queue cq, cl_mem buf,
                            cl_bool blocking_read, size_t offset, size_t size,
                            void* ptr, cl_uint num_events_in_wait_list,
                            const cl_event* event_wait_list, cl_event* event) {
     LOG_API_CALL("command_queue = %p, buffer = %p, blocking = %d, offset = "
                  "%zu, size = %zu, ptr = %p",
-                 command_queue, buffer, blocking_read, offset, size, ptr);
+                 cq, buf, blocking_read, offset, size, ptr);
+
+    auto buffer = icd_downcast(buf);
+    auto command_queue = icd_downcast(cq);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -2372,9 +2375,7 @@ cl_int clEnqueueReadBuffer(cl_command_queue command_queue, cl_mem buffer,
         return CL_INVALID_MEM_OBJECT;
     }
 
-    auto buf = icd_downcast(buffer);
-
-    if (buf->has_any_flag(CL_MEM_HOST_WRITE_ONLY | CL_MEM_HOST_NO_ACCESS)) {
+    if (buffer->has_any_flag(CL_MEM_HOST_WRITE_ONLY | CL_MEM_HOST_NO_ACCESS)) {
         return CL_INVALID_OPERATION;
     }
 
@@ -2382,24 +2383,25 @@ cl_int clEnqueueReadBuffer(cl_command_queue command_queue, cl_mem buffer,
         return CL_INVALID_EVENT_WAIT_LIST;
     }
 
-    auto cq = icd_downcast(command_queue);
+    auto cmd = new cvk_command_copy(command_queue, CL_COMMAND_READ_BUFFER,
+                                    buffer, ptr, offset, size);
 
-    auto cmd = new cvk_command_copy(cq, CL_COMMAND_READ_BUFFER, buf, ptr,
-                                    offset, size);
-
-    auto err = cq->enqueue_command_with_deps(
+    auto err = command_queue->enqueue_command_with_deps(
         cmd, blocking_read, num_events_in_wait_list, event_wait_list, event);
 
     return err;
 }
 
-cl_int clEnqueueWriteBuffer(cl_command_queue command_queue, cl_mem buffer,
+cl_int clEnqueueWriteBuffer(cl_command_queue cq, cl_mem buf,
                             cl_bool blocking_write, size_t offset, size_t size,
                             const void* ptr, cl_uint num_events_in_wait_list,
                             const cl_event* event_wait_list, cl_event* event) {
     LOG_API_CALL("command_queue = %p, buffer = %p, blocking = %d, offset = "
                  "%zu, size = %zu, ptr = %p",
-                 command_queue, buffer, blocking_write, offset, size, ptr);
+                 cq, buf, blocking_write, offset, size, ptr);
+
+    auto buffer = icd_downcast(buf);
+    auto command_queue = icd_downcast(cq);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -2411,9 +2413,7 @@ cl_int clEnqueueWriteBuffer(cl_command_queue command_queue, cl_mem buffer,
         return CL_INVALID_MEM_OBJECT;
     }
 
-    auto buf = icd_downcast(buffer);
-
-    if (buf->has_any_flag(CL_MEM_HOST_READ_ONLY | CL_MEM_HOST_NO_ACCESS)) {
+    if (buffer->has_any_flag(CL_MEM_HOST_READ_ONLY | CL_MEM_HOST_NO_ACCESS)) {
         return CL_INVALID_OPERATION;
     }
 
@@ -2421,27 +2421,25 @@ cl_int clEnqueueWriteBuffer(cl_command_queue command_queue, cl_mem buffer,
         return CL_INVALID_EVENT_WAIT_LIST;
     }
 
-    auto cq = icd_downcast(command_queue);
+    auto cmd = new cvk_command_copy(command_queue, CL_COMMAND_WRITE_BUFFER,
+                                    buffer, ptr, offset, size);
 
-    auto cmd = new cvk_command_copy(cq, CL_COMMAND_WRITE_BUFFER, buf, ptr,
-                                    offset, size);
-
-    auto err = cq->enqueue_command_with_deps(
+    auto err = command_queue->enqueue_command_with_deps(
         cmd, blocking_write, num_events_in_wait_list, event_wait_list, event);
 
     return err;
 }
 
 cl_int
-clEnqueueReadBufferRect(cl_command_queue command_queue, cl_mem buffer,
-                        cl_bool blocking_read, const size_t* buffer_origin,
-                        const size_t* host_origin, const size_t* region,
-                        size_t buffer_row_pitch, size_t buffer_slice_pitch,
-                        size_t host_row_pitch, size_t host_slice_pitch,
-                        void* ptr, cl_uint num_events_in_wait_list,
+clEnqueueReadBufferRect(cl_command_queue cq, cl_mem buf, cl_bool blocking_read,
+                        const size_t* buffer_origin, const size_t* host_origin,
+                        const size_t* region, size_t buffer_row_pitch,
+                        size_t buffer_slice_pitch, size_t host_row_pitch,
+                        size_t host_slice_pitch, void* ptr,
+                        cl_uint num_events_in_wait_list,
                         const cl_event* event_wait_list, cl_event* event) {
-    LOG_API_CALL("command_queue = %p, buffer = %p, blocking = %d",
-                 command_queue, buffer, blocking_read);
+    LOG_API_CALL("command_queue = %p, buffer = %p, blocking = %d", cq, buf,
+                 blocking_read);
     LOG_API_CALL("buffer_origin = {%zu,%zu,%zu}, host_origin = {%zu,%zu,%zu}, "
                  "region = {%zu,%zu,%zu}",
                  buffer_origin[0], buffer_origin[1], buffer_origin[2],
@@ -2454,6 +2452,9 @@ clEnqueueReadBufferRect(cl_command_queue command_queue, cl_mem buffer,
     LOG_API_CALL("ptr = %p, num_events = %u, event_wait_list = %p, event = %p",
                  ptr, num_events_in_wait_list, event_wait_list, event);
 
+    auto command_queue = icd_downcast(cq);
+    auto buffer = static_cast<cvk_buffer*>(buf);
+
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
     }
@@ -2462,9 +2463,7 @@ clEnqueueReadBufferRect(cl_command_queue command_queue, cl_mem buffer,
         return CL_INVALID_MEM_OBJECT;
     }
 
-    auto buf = static_cast<cvk_buffer*>(buffer);
-
-    if (buf->has_any_flag(CL_MEM_HOST_WRITE_ONLY | CL_MEM_HOST_NO_ACCESS)) {
+    if (buffer->has_any_flag(CL_MEM_HOST_WRITE_ONLY | CL_MEM_HOST_NO_ACCESS)) {
         return CL_INVALID_OPERATION;
     }
 
@@ -2472,29 +2471,27 @@ clEnqueueReadBufferRect(cl_command_queue command_queue, cl_mem buffer,
         return CL_INVALID_EVENT_WAIT_LIST;
     }
 
-    auto cq = icd_downcast(command_queue);
-
     auto cmd = new cvk_command_copy_host_buffer_rect(
-        cq, CL_COMMAND_READ_BUFFER_RECT, buf, ptr, host_origin, buffer_origin,
-        region, host_row_pitch, host_slice_pitch, buffer_row_pitch,
-        buffer_slice_pitch);
+        command_queue, CL_COMMAND_READ_BUFFER_RECT, buffer, ptr, host_origin,
+        buffer_origin, region, host_row_pitch, host_slice_pitch,
+        buffer_row_pitch, buffer_slice_pitch);
 
-    auto err = cq->enqueue_command_with_deps(
+    auto err = command_queue->enqueue_command_with_deps(
         cmd, blocking_read, num_events_in_wait_list, event_wait_list, event);
 
     return err;
 }
 
 cl_int
-clEnqueueWriteBufferRect(cl_command_queue command_queue, cl_mem buffer,
+clEnqueueWriteBufferRect(cl_command_queue cq, cl_mem buf,
                          cl_bool blocking_write, const size_t* buffer_origin,
                          const size_t* host_origin, const size_t* region,
                          size_t buffer_row_pitch, size_t buffer_slice_pitch,
                          size_t host_row_pitch, size_t host_slice_pitch,
                          const void* ptr, cl_uint num_events_in_wait_list,
                          const cl_event* event_wait_list, cl_event* event) {
-    LOG_API_CALL("command_queue = %p, buffer = %p, blocking = %d",
-                 command_queue, buffer, blocking_write);
+    LOG_API_CALL("command_queue = %p, buffer = %p, blocking = %d", cq, buf,
+                 blocking_write);
     LOG_API_CALL("buffer_origin = {%zu,%zu,%zu}, host_origin = {%zu,%zu,%zu}, "
                  "region = {%zu,%zu,%zu}",
                  buffer_origin[0], buffer_origin[1], buffer_origin[2],
@@ -2507,6 +2504,9 @@ clEnqueueWriteBufferRect(cl_command_queue command_queue, cl_mem buffer,
     LOG_API_CALL("ptr = %p, num_events = %u, event_wait_list = %p, event = %p",
                  ptr, num_events_in_wait_list, event_wait_list, event);
 
+    auto command_queue = icd_downcast(cq);
+    auto buffer = static_cast<cvk_buffer*>(buf);
+
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
     }
@@ -2515,9 +2515,7 @@ clEnqueueWriteBufferRect(cl_command_queue command_queue, cl_mem buffer,
         return CL_INVALID_MEM_OBJECT;
     }
 
-    auto buf = static_cast<cvk_buffer*>(buffer);
-
-    if (buf->has_any_flag(CL_MEM_HOST_READ_ONLY | CL_MEM_HOST_NO_ACCESS)) {
+    if (buffer->has_any_flag(CL_MEM_HOST_READ_ONLY | CL_MEM_HOST_NO_ACCESS)) {
         return CL_INVALID_OPERATION;
     }
 
@@ -2525,30 +2523,30 @@ clEnqueueWriteBufferRect(cl_command_queue command_queue, cl_mem buffer,
         return CL_INVALID_EVENT_WAIT_LIST;
     }
 
-    auto cq = icd_downcast(command_queue);
-
     auto cmd = new cvk_command_copy_host_buffer_rect(
-        cq, CL_COMMAND_WRITE_BUFFER_RECT, buf, const_cast<void*>(ptr),
-        host_origin, buffer_origin, region, host_row_pitch, host_slice_pitch,
-        buffer_row_pitch, buffer_slice_pitch);
+        command_queue, CL_COMMAND_WRITE_BUFFER_RECT, buffer,
+        const_cast<void*>(ptr), host_origin, buffer_origin, region,
+        host_row_pitch, host_slice_pitch, buffer_row_pitch, buffer_slice_pitch);
 
-    auto err = cq->enqueue_command_with_deps(
+    auto err = command_queue->enqueue_command_with_deps(
         cmd, blocking_write, num_events_in_wait_list, event_wait_list, event);
 
     return err;
 }
 
-cl_int clEnqueueFillBuffer(cl_command_queue command_queue, cl_mem buffer,
-                           const void* pattern, size_t pattern_size,
-                           size_t offset, size_t size,
+cl_int clEnqueueFillBuffer(cl_command_queue cq, cl_mem buf, const void* pattern,
+                           size_t pattern_size, size_t offset, size_t size,
                            cl_uint num_events_in_wait_list,
                            const cl_event* event_wait_list, cl_event* event) {
     LOG_API_CALL(
         "command_queue = %p, buffer = %p, pattern = %p, pattern_size = %zu,"
         "offset = %zu, size = %zu, num_events = %u, event_wait_list = %p, "
         "event = %p",
-        command_queue, buffer, pattern, pattern_size, offset, size,
-        num_events_in_wait_list, event_wait_list, event);
+        cq, buf, pattern, pattern_size, offset, size, num_events_in_wait_list,
+        event_wait_list, event);
+
+    auto buffer = icd_downcast(buf);
+    auto command_queue = icd_downcast(cq);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -2560,8 +2558,6 @@ cl_int clEnqueueFillBuffer(cl_command_queue command_queue, cl_mem buffer,
 
     // TODO check context
     // TODO check buffer bounds
-
-    auto buf = icd_downcast(buffer);
 
     if (pattern == nullptr) {
         return CL_INVALID_VALUE;
@@ -2591,28 +2587,29 @@ cl_int clEnqueueFillBuffer(cl_command_queue command_queue, cl_mem buffer,
 
     // TODO check sub-buffer alignment
 
-    auto cq = icd_downcast(command_queue);
+    auto cmd = new cvk_command_fill_buffer(command_queue, buffer, offset, size,
+                                           pattern, pattern_size);
 
-    auto cmd = new cvk_command_fill_buffer(cq, buf, offset, size, pattern,
-                                           pattern_size);
-
-    cq->enqueue_command_with_deps(cmd, num_events_in_wait_list, event_wait_list,
-                                  event);
+    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+                                             event_wait_list, event);
 
     return CL_SUCCESS;
 }
 
-cl_int clEnqueueCopyBuffer(cl_command_queue command_queue, cl_mem src_buffer,
-                           cl_mem dst_buffer, size_t src_offset,
-                           size_t dst_offset, size_t size,
+cl_int clEnqueueCopyBuffer(cl_command_queue cq, cl_mem srcbuf, cl_mem dstbuf,
+                           size_t src_offset, size_t dst_offset, size_t size,
                            cl_uint num_events_in_wait_list,
                            const cl_event* event_wait_list, cl_event* event) {
     LOG_API_CALL("command_queue = %p, src_buffer = %p, dst_buffer = %p, "
                  "src_offset = %zu,"
                  "dst_offset = %zu, size = %zu, num_events = %u, "
                  "event_wait_list = %p, event = %p",
-                 command_queue, src_buffer, dst_buffer, src_offset, dst_offset,
-                 size, num_events_in_wait_list, event_wait_list, event);
+                 cq, srcbuf, dstbuf, src_offset, dst_offset, size,
+                 num_events_in_wait_list, event_wait_list, event);
+
+    auto command_queue = icd_downcast(cq);
+    auto src_buffer = icd_downcast(srcbuf);
+    auto dst_buffer = icd_downcast(dstbuf);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -2628,37 +2625,37 @@ cl_int clEnqueueCopyBuffer(cl_command_queue command_queue, cl_mem src_buffer,
         return CL_INVALID_EVENT_WAIT_LIST;
     }
 
-    auto cq = icd_downcast(command_queue);
-    auto srcbuf = icd_downcast(src_buffer);
-    auto dstbuf = icd_downcast(dst_buffer);
+    auto cmd = new cvk_command_copy_buffer(
+        command_queue, CL_COMMAND_COPY_BUFFER, src_buffer, dst_buffer,
+        src_offset, dst_offset, size);
 
-    auto cmd =
-        new cvk_command_copy_buffer(cq, CL_COMMAND_COPY_BUFFER, srcbuf, dstbuf,
-                                    src_offset, dst_offset, size);
-
-    cq->enqueue_command_with_deps(cmd, num_events_in_wait_list, event_wait_list,
-                                  event);
+    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+                                             event_wait_list, event);
 
     return CL_SUCCESS;
 }
 
-cl_int clEnqueueCopyBufferRect(
-    cl_command_queue command_queue, cl_mem src_buffer, cl_mem dst_buffer,
-    const size_t* src_origin, const size_t* dst_origin, const size_t* region,
-    size_t src_row_pitch, size_t src_slice_pitch, size_t dst_row_pitch,
-    size_t dst_slice_pitch, cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list, cl_event* event) {
+cl_int clEnqueueCopyBufferRect(cl_command_queue cq, cl_mem src_buffer,
+                               cl_mem dst_buffer, const size_t* src_origin,
+                               const size_t* dst_origin, const size_t* region,
+                               size_t src_row_pitch, size_t src_slice_pitch,
+                               size_t dst_row_pitch, size_t dst_slice_pitch,
+                               cl_uint num_events_in_wait_list,
+                               const cl_event* event_wait_list,
+                               cl_event* event) {
     LOG_API_CALL("command_queue = %p, src_buffer = %p, dst_buffer = %p, "
                  "src_origin = {%zu,%zu,%zu}, dst_origin = {%zu,%zu,%zu}, "
                  "region = {%zu,%zu,%zu}, src_row_pitch = %zu, "
                  "src_slice_pitch = %zu, dst_row_pitch = %zu, "
                  "dst_slice_pitch = %zu, num_events_in_wait_list = %u, "
                  "event_wait_list = %p, event = %p",
-                 command_queue, src_buffer, dst_buffer, src_origin[0],
-                 src_origin[1], src_origin[2], dst_origin[0], dst_origin[1],
-                 dst_origin[2], region[0], region[1], region[2], src_row_pitch,
+                 cq, src_buffer, dst_buffer, src_origin[0], src_origin[1],
+                 src_origin[2], dst_origin[0], dst_origin[1], dst_origin[2],
+                 region[0], region[1], region[2], src_row_pitch,
                  src_slice_pitch, dst_row_pitch, dst_slice_pitch,
                  num_events_in_wait_list, event_wait_list, event);
+
+    auto command_queue = icd_downcast(cq);
 
     // TODO CL_INVALID_COMMAND_QUEUE if command_queue is not a valid
     // command-queue.
@@ -2713,26 +2710,27 @@ cl_int clEnqueueCopyBufferRect(
     // TODO CL_OUT_OF_HOST_MEMORY if there is a failure to allocate resources
     // required by the OpenCL implementation on the host.
     //
-    auto cq = icd_downcast(command_queue);
     auto srcbuf = static_cast<cvk_buffer*>(src_buffer);
     auto dstbuf = static_cast<cvk_buffer*>(dst_buffer);
     auto cmd = new cvk_command_copy_buffer_rect(
-        cq, srcbuf, dstbuf, src_origin, dst_origin, region, src_row_pitch,
-        src_slice_pitch, dst_row_pitch, dst_slice_pitch);
-    cq->enqueue_command_with_deps(cmd, num_events_in_wait_list, event_wait_list,
-                                  event);
+        command_queue, srcbuf, dstbuf, src_origin, dst_origin, region,
+        src_row_pitch, src_slice_pitch, dst_row_pitch, dst_slice_pitch);
+    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+                                             event_wait_list, event);
 
     return CL_SUCCESS;
 }
 
-void* clEnqueueMapBuffer(cl_command_queue command_queue, cl_mem buffer,
-                         cl_bool blocking_map, cl_map_flags map_flags,
-                         size_t offset, size_t size,
+void* clEnqueueMapBuffer(cl_command_queue cq, cl_mem buf, cl_bool blocking_map,
+                         cl_map_flags map_flags, size_t offset, size_t size,
                          cl_uint num_events_in_wait_list,
                          const cl_event* event_wait_list, cl_event* event,
                          cl_int* errcode_ret) {
     LOG_API_CALL("command_queue = %p, buffer = %p, offset = %zu, size = %zu",
-                 command_queue, buffer, offset, size);
+                 cq, buf, offset, size);
+
+    auto command_queue = icd_downcast(cq);
+    auto buffer = static_cast<cvk_buffer*>(buf);
 
     if (!is_valid_command_queue(command_queue)) {
         if (errcode_ret != nullptr) {
@@ -2762,10 +2760,7 @@ void* clEnqueueMapBuffer(cl_command_queue command_queue, cl_mem buffer,
         return nullptr;
     }
 
-    auto cq = icd_downcast(command_queue);
-    auto buf = static_cast<cvk_buffer*>(buffer);
-
-    if ((size == 0) || (offset + size > buf->size())) {
+    if ((size == 0) || (offset + size > buffer->size())) {
         if (errcode_ret != nullptr) {
             *errcode_ret = CL_INVALID_VALUE;
         }
@@ -2784,7 +2779,8 @@ void* clEnqueueMapBuffer(cl_command_queue command_queue, cl_mem buffer,
     // CL_DEVICE_MEM_BASE_ADDR_ALIGN value for device associated with queue.
 
     if ((map_flags & CL_MAP_READ) &&
-        (buf->has_any_flag(CL_MEM_HOST_WRITE_ONLY | CL_MEM_HOST_NO_ACCESS))) {
+        (buffer->has_any_flag(CL_MEM_HOST_WRITE_ONLY |
+                              CL_MEM_HOST_NO_ACCESS))) {
         if (errcode_ret != nullptr) {
             *errcode_ret = CL_INVALID_OPERATION;
         }
@@ -2793,7 +2789,7 @@ void* clEnqueueMapBuffer(cl_command_queue command_queue, cl_mem buffer,
 
     if (((map_flags & CL_MAP_WRITE) ||
          (map_flags & CL_MAP_WRITE_INVALIDATE_REGION)) &&
-        (buf->has_any_flag(CL_MEM_HOST_READ_ONLY | CL_MEM_HOST_NO_ACCESS))) {
+        (buffer->has_any_flag(CL_MEM_HOST_READ_ONLY | CL_MEM_HOST_NO_ACCESS))) {
         if (errcode_ret != nullptr) {
             *errcode_ret = CL_INVALID_OPERATION;
         }
@@ -2805,21 +2801,21 @@ void* clEnqueueMapBuffer(cl_command_queue command_queue, cl_mem buffer,
 
     // FIXME This error cannot occur for objects created with
     // CL_MEM_USE_HOST_PTR or CL_MEM_ALLOC_HOST_PTR.
-    if (!buf->map()) {
+    if (!buffer->map()) {
         if (errcode_ret != nullptr) {
             *errcode_ret = CL_MAP_FAILURE;
         }
         return nullptr;
     }
 
-    auto map_ptr = buf->map_ptr(offset);
-    auto cmd = new cvk_command_map_buffer(cq, buf, offset, size);
+    auto map_ptr = buffer->map_ptr(offset);
+    auto cmd = new cvk_command_map_buffer(command_queue, buffer, offset, size);
 
-    auto err = cq->enqueue_command_with_deps(
+    auto err = command_queue->enqueue_command_with_deps(
         cmd, blocking_map, num_events_in_wait_list, event_wait_list, event);
 
     if (err != CL_SUCCESS) {
-        buf->unmap();
+        buffer->unmap();
     }
 
     if (errcode_ret != nullptr) {
@@ -2829,13 +2825,16 @@ void* clEnqueueMapBuffer(cl_command_queue command_queue, cl_mem buffer,
     return map_ptr;
 }
 
-cl_int clEnqueueUnmapMemObject(cl_command_queue command_queue, cl_mem memobj,
+cl_int clEnqueueUnmapMemObject(cl_command_queue cq, cl_mem mem,
                                void* mapped_ptr,
                                cl_uint num_events_in_wait_list,
                                const cl_event* event_wait_list,
                                cl_event* event) {
-    LOG_API_CALL("command_queue = %p, memobj = %p, mapped_ptr = %p",
-                 command_queue, memobj, mapped_ptr);
+    LOG_API_CALL("command_queue = %p, memobj = %p, mapped_ptr = %p", cq, mem,
+                 mapped_ptr);
+
+    auto command_queue = icd_downcast(cq);
+    auto memobj = icd_downcast(mem);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -2845,15 +2844,12 @@ cl_int clEnqueueUnmapMemObject(cl_command_queue command_queue, cl_mem memobj,
         return CL_INVALID_MEM_OBJECT;
     }
 
-    auto cq = icd_downcast(command_queue);
-    auto mem = icd_downcast(memobj);
-
     cvk_command* cmd;
 
-    if (mem->is_image_type()) {
+    if (memobj->is_image_type()) {
         auto image = static_cast<cvk_image*>(memobj);
-        auto cmd_unmap =
-            std::make_unique<cvk_command_unmap_image>(cq, image, mapped_ptr);
+        auto cmd_unmap = std::make_unique<cvk_command_unmap_image>(
+            command_queue, image, mapped_ptr);
 
         auto err = cmd_unmap->build();
         if (err != CL_SUCCESS) {
@@ -2862,11 +2858,11 @@ cl_int clEnqueueUnmapMemObject(cl_command_queue command_queue, cl_mem memobj,
         cmd = cmd_unmap.release();
     } else {
         auto buffer = static_cast<cvk_buffer*>(memobj);
-        cmd = new cvk_command_unmap_buffer(cq, buffer);
+        cmd = new cvk_command_unmap_buffer(command_queue, buffer);
     }
 
-    cq->enqueue_command_with_deps(cmd, num_events_in_wait_list, event_wait_list,
-                                  event);
+    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+                                             event_wait_list, event);
 
     return CL_SUCCESS;
 }
@@ -3033,12 +3029,12 @@ cl_int clReleaseSampler(cl_sampler sampler) {
     return CL_SUCCESS;
 }
 
-cl_int clGetSamplerInfo(cl_sampler sampler, cl_sampler_info param_name,
+cl_int clGetSamplerInfo(cl_sampler samp, cl_sampler_info param_name,
                         size_t param_value_size, void* param_value,
                         size_t* param_value_size_ret) {
     LOG_API_CALL("sampler = %p, param_name = %d, param_value_size = %zu, "
                  "param_value = %p, param_value_size_ret = %p",
-                 sampler, param_name, param_value_size, param_value,
+                 samp, param_name, param_value_size, param_value,
                  param_value_size_ret);
 
     cl_int ret = CL_SUCCESS;
@@ -3050,35 +3046,35 @@ cl_int clGetSamplerInfo(cl_sampler sampler, cl_sampler_info param_name,
     cl_addressing_mode val_addressing_mode;
     cl_filter_mode val_filter_mode;
 
+    auto sampler = icd_downcast(samp);
+
     if (!is_valid_sampler(sampler)) {
         return CL_INVALID_SAMPLER;
     }
 
-    auto samp = icd_downcast(sampler);
-
     switch (param_name) {
     case CL_SAMPLER_REFERENCE_COUNT:
-        val_uint = samp->refcount();
+        val_uint = sampler->refcount();
         copy_ptr = &val_uint;
         ret_size = sizeof(val_uint);
         break;
     case CL_SAMPLER_CONTEXT:
-        val_context = samp->context();
+        val_context = sampler->context();
         copy_ptr = &val_context;
         ret_size = sizeof(val_context);
         break;
     case CL_SAMPLER_NORMALIZED_COORDS:
-        val_bool = samp->normalized_coords();
+        val_bool = sampler->normalized_coords();
         copy_ptr = &val_bool;
         ret_size = sizeof(val_bool);
         break;
     case CL_SAMPLER_ADDRESSING_MODE:
-        val_addressing_mode = samp->addressing_mode();
+        val_addressing_mode = sampler->addressing_mode();
         copy_ptr = &val_addressing_mode;
         ret_size = sizeof(val_addressing_mode);
         break;
     case CL_SAMPLER_FILTER_MODE:
-        val_filter_mode = samp->filter_mode();
+        val_filter_mode = sampler->filter_mode();
         copy_ptr = &val_filter_mode;
         ret_size = sizeof(val_filter_mode);
         break;
@@ -3553,7 +3549,7 @@ cl_int cvk_enqueue_image_copy(
         cmd, blocking, num_events_in_wait_list, event_wait_list, event);
 }
 
-cl_int clEnqueueReadImage(cl_command_queue command_queue, cl_mem image,
+cl_int clEnqueueReadImage(cl_command_queue cq, cl_mem img,
                           cl_bool blocking_read, const size_t* origin,
                           const size_t* region, size_t row_pitch,
                           size_t slice_pitch, void* ptr,
@@ -3564,10 +3560,12 @@ cl_int clEnqueueReadImage(cl_command_queue command_queue, cl_mem image,
                  "row_pitch = %zu, slice_pitch = %zu, ptr = %p, "
                  "num_events_in_wait_list = %u, event_wait_list = %p, "
                  "event = %p",
-                 command_queue, image, blocking_read, origin[0], origin[1],
-                 origin[2], region[0], region[1], region[2], row_pitch,
-                 slice_pitch, ptr, num_events_in_wait_list, event_wait_list,
-                 event);
+                 cq, img, blocking_read, origin[0], origin[1], origin[2],
+                 region[0], region[1], region[2], row_pitch, slice_pitch, ptr,
+                 num_events_in_wait_list, event_wait_list, event);
+
+    auto command_queue = icd_downcast(cq);
+    auto image = icd_downcast(img);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -3586,10 +3584,6 @@ cl_int clEnqueueReadImage(cl_command_queue command_queue, cl_mem image,
                          event_wait_list)) {
         return CL_INVALID_CONTEXT;
     }
-
-    auto cq = icd_downcast(command_queue);
-    auto img = icd_downcast(image);
-
     // TODO CL_INVALID_VALUE if the region being read specified by origin and
     // region is out of bounds or if ptr is a NULL value.
     // TODO CL_INVALID_VALUE if values in origin and region do not follow rules
@@ -3601,21 +3595,21 @@ cl_int clEnqueueReadImage(cl_command_queue command_queue, cl_mem image,
     // data type) for image are not supported by device associated with queue.
     // TODO CL_MEM_OBJECT_ALLOCATION_FAILURE if there is a failure to allocate
     // memory for data store associated with image.
-    if (!cq->device()->supports_images()) {
+    if (!command_queue->device()->supports_images()) {
         return CL_INVALID_OPERATION;
     }
 
-    if (img->has_any_flag(CL_MEM_HOST_WRITE_ONLY | CL_MEM_HOST_NO_ACCESS)) {
+    if (image->has_any_flag(CL_MEM_HOST_WRITE_ONLY | CL_MEM_HOST_NO_ACCESS)) {
         return CL_INVALID_OPERATION;
     }
 
-    return cvk_enqueue_image_copy(cq, CL_COMMAND_READ_IMAGE, img, blocking_read,
-                                  origin, region, row_pitch, slice_pitch, ptr,
-                                  num_events_in_wait_list, event_wait_list,
-                                  event);
+    return cvk_enqueue_image_copy(command_queue, CL_COMMAND_READ_IMAGE, image,
+                                  blocking_read, origin, region, row_pitch,
+                                  slice_pitch, ptr, num_events_in_wait_list,
+                                  event_wait_list, event);
 }
 
-cl_int clEnqueueWriteImage(cl_command_queue command_queue, cl_mem image,
+cl_int clEnqueueWriteImage(cl_command_queue cq, cl_mem img,
                            cl_bool blocking_write, const size_t* origin,
                            const size_t* region, size_t input_row_pitch,
                            size_t input_slice_pitch, const void* ptr,
@@ -3626,10 +3620,13 @@ cl_int clEnqueueWriteImage(cl_command_queue command_queue, cl_mem image,
                  "input_row_pitch = %zu, input_slice_pitch = %zu, ptr = %p, "
                  "num_events_in_wait_list = %u, event_wait_list = %p, "
                  "event = %p",
-                 command_queue, image, blocking_write, origin[0], origin[1],
-                 origin[2], region[0], region[1], region[2], input_row_pitch,
+                 cq, img, blocking_write, origin[0], origin[1], origin[2],
+                 region[0], region[1], region[2], input_row_pitch,
                  input_slice_pitch, ptr, num_events_in_wait_list,
                  event_wait_list, event);
+
+    auto command_queue = icd_downcast(cq);
+    auto image = icd_downcast(img);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -3648,9 +3645,6 @@ cl_int clEnqueueWriteImage(cl_command_queue command_queue, cl_mem image,
                          event_wait_list)) {
         return CL_INVALID_CONTEXT;
     }
-
-    auto cq = icd_downcast(command_queue);
-    auto img = icd_downcast(image);
 
     // TODO CL_INVALID_VALUE if the region being written specified by origin and
     // region is out of bounds or if ptr is a NULL value.
@@ -3663,21 +3657,21 @@ cl_int clEnqueueWriteImage(cl_command_queue command_queue, cl_mem image,
     // data type) for image are not supported by device associated with queue.
     // TODO CL_MEM_OBJECT_ALLOCATION_FAILURE if there is a failure to allocate
     // memory for data store associated with image.
-    if (!cq->device()->supports_images()) {
+    if (!command_queue->device()->supports_images()) {
         return CL_INVALID_OPERATION;
     }
 
-    if (img->has_any_flag(CL_MEM_HOST_READ_ONLY | CL_MEM_HOST_NO_ACCESS)) {
+    if (image->has_any_flag(CL_MEM_HOST_READ_ONLY | CL_MEM_HOST_NO_ACCESS)) {
         return CL_INVALID_OPERATION;
     }
 
     return cvk_enqueue_image_copy(
-        cq, CL_COMMAND_WRITE_IMAGE, img, blocking_write, origin, region,
-        input_row_pitch, input_slice_pitch, const_cast<void*>(ptr),
+        command_queue, CL_COMMAND_WRITE_IMAGE, image, blocking_write, origin,
+        region, input_row_pitch, input_slice_pitch, const_cast<void*>(ptr),
         num_events_in_wait_list, event_wait_list, event);
 }
 
-cl_int clEnqueueCopyImage(cl_command_queue command_queue, cl_mem src_image,
+cl_int clEnqueueCopyImage(cl_command_queue cq, cl_mem src_image,
                           cl_mem dst_image, const size_t* src_origin,
                           const size_t* dst_origin, const size_t* region,
                           cl_uint num_events_in_wait_list,
@@ -3687,10 +3681,12 @@ cl_int clEnqueueCopyImage(cl_command_queue command_queue, cl_mem src_image,
                  "region = {%zu, %zu, %zu}, "
                  "num_events_in_wait_list = %u, event_wait_list = %p, "
                  "event = %p",
-                 command_queue, src_image, dst_image, src_origin[0],
-                 src_origin[1], src_origin[2], dst_origin[0], dst_origin[1],
-                 dst_origin[2], region[0], region[1], region[2],
-                 num_events_in_wait_list, event_wait_list, event);
+                 cq, src_image, dst_image, src_origin[0], src_origin[1],
+                 src_origin[2], dst_origin[0], dst_origin[1], dst_origin[2],
+                 region[0], region[1], region[2], num_events_in_wait_list,
+                 event_wait_list, event);
+
+    auto command_queue = icd_downcast(cq);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -3711,7 +3707,6 @@ cl_int clEnqueueCopyImage(cl_command_queue command_queue, cl_mem src_image,
         return CL_INVALID_EVENT_WAIT_LIST;
     }
 
-    auto cq = icd_downcast(command_queue);
     auto src_img = static_cast<cvk_image*>(src_image);
     auto dst_img = static_cast<cvk_image*>(dst_image);
 
@@ -3730,7 +3725,7 @@ cl_int clEnqueueCopyImage(cl_command_queue command_queue, cl_mem src_image,
     // associated with queue.
     // TODO CL_MEM_OBJECT_ALLOCATION_FAILURE if there is a failure to allocate
     // memory for data store associated with src_image or dst_image.
-    if (!cq->device()->supports_images()) {
+    if (!command_queue->device()->supports_images()) {
         return CL_INVALID_OPERATION;
     }
 
@@ -3748,19 +3743,19 @@ cl_int clEnqueueCopyImage(cl_command_queue command_queue, cl_mem src_image,
     std::array<size_t, 3> reg = {region[0], region[1], region[2]};
 
     auto cmd = std::make_unique<cvk_command_image_image_copy>(
-        cq, src_img, dst_img, src_orig, dst_orig, reg);
+        command_queue, src_img, dst_img, src_orig, dst_orig, reg);
     auto err = cmd->build();
     if (err != CL_SUCCESS) {
         return err;
     }
 
-    cq->enqueue_command_with_deps(cmd.release(), num_events_in_wait_list,
-                                  event_wait_list, event);
+    command_queue->enqueue_command_with_deps(
+        cmd.release(), num_events_in_wait_list, event_wait_list, event);
 
     return CL_SUCCESS;
 }
 
-cl_int clEnqueueFillImage(cl_command_queue command_queue, cl_mem image,
+cl_int clEnqueueFillImage(cl_command_queue cq, cl_mem image,
                           const void* fill_color, const size_t* origin,
                           const size_t* region, cl_uint num_events_in_wait_list,
                           const cl_event* event_wait_list, cl_event* event) {
@@ -3768,9 +3763,11 @@ cl_int clEnqueueFillImage(cl_command_queue command_queue, cl_mem image,
                  "origin = {%zu,%zu,%zu}, region = {%zu, %zu, %zu}, "
                  "num_events_in_wait_list = %u, event_wait_list = %p, "
                  "event = %p",
-                 command_queue, image, fill_color, origin[0], origin[1],
-                 origin[2], region[0], region[1], region[2],
-                 num_events_in_wait_list, event_wait_list, event);
+                 cq, image, fill_color, origin[0], origin[1], origin[2],
+                 region[0], region[1], region[2], num_events_in_wait_list,
+                 event_wait_list, event);
+
+    auto command_queue = icd_downcast(cq);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -3812,11 +3809,9 @@ cl_int clEnqueueFillImage(cl_command_queue command_queue, cl_mem image,
     std::array<size_t, 3> orig = {origin[0], origin[1], origin[2]};
     std::array<size_t, 3> reg = {region[0], region[1], region[2]};
 
-    auto cq = icd_downcast(command_queue);
     auto img = static_cast<cvk_image*>(image);
-
     auto cmd_map = std::make_unique<cvk_command_map_image>(
-        cq, img, orig, reg, CL_MAP_WRITE_INVALIDATE_REGION);
+        command_queue, img, orig, reg, CL_MAP_WRITE_INVALIDATE_REGION);
     void* map_ptr;
     cl_int err = cmd_map->build(&map_ptr);
     if (err != CL_SUCCESS) {
@@ -3829,11 +3824,11 @@ cl_int clEnqueueFillImage(cl_command_queue command_queue, cl_mem image,
     img->prepare_fill_pattern(fill_color, pattern, &pattern_size);
 
     auto cmd_fill = std::make_unique<cvk_command_fill_image>(
-        cq, map_ptr, pattern, pattern_size, reg);
+        command_queue, map_ptr, pattern, pattern_size, reg);
 
     // Create unmap command
     auto cmd_unmap =
-        std::make_unique<cvk_command_unmap_image>(cq, img, map_ptr);
+        std::make_unique<cvk_command_unmap_image>(command_queue, img, map_ptr);
     err = cmd_unmap->build();
     if (err != CL_SUCCESS) {
         return err;
@@ -3845,19 +3840,17 @@ cl_int clEnqueueFillImage(cl_command_queue command_queue, cl_mem image,
     commands.emplace_back(std::move(cmd_fill));
     commands.emplace_back(std::move(cmd_unmap));
 
-    auto cmd =
-        new cvk_command_combine(cq, CL_COMMAND_FILL_IMAGE, std::move(commands));
+    auto cmd = new cvk_command_combine(command_queue, CL_COMMAND_FILL_IMAGE,
+                                       std::move(commands));
 
     // Enqueue combined command
-    cq->enqueue_command_with_deps(cmd, num_events_in_wait_list, event_wait_list,
-                                  event);
-
+    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+                                             event_wait_list, event);
     return CL_SUCCESS;
 }
 
-cl_int clEnqueueCopyImageToBuffer(cl_command_queue command_queue,
-                                  cl_mem src_image, cl_mem dst_buffer,
-                                  const size_t* src_origin,
+cl_int clEnqueueCopyImageToBuffer(cl_command_queue cq, cl_mem src_image,
+                                  cl_mem dst_buffer, const size_t* src_origin,
                                   const size_t* region, size_t dst_offset,
                                   cl_uint num_events_in_wait_list,
                                   const cl_event* event_wait_list,
@@ -3866,9 +3859,11 @@ cl_int clEnqueueCopyImageToBuffer(cl_command_queue command_queue,
                  "src_origin = {%zu,%zu,%zu}, region = {%zu, %zu, %zu}, "
                  "dst_offset = %zu, num_events_in_wait_list = %u, "
                  "event_wait_list = %p, event = %p",
-                 command_queue, src_image, dst_buffer, src_origin[0],
-                 src_origin[1], src_origin[2], region[0], region[1], region[2],
-                 dst_offset, num_events_in_wait_list, event_wait_list, event);
+                 cq, src_image, dst_buffer, src_origin[0], src_origin[1],
+                 src_origin[2], region[0], region[1], region[2], dst_offset,
+                 num_events_in_wait_list, event_wait_list, event);
+
+    auto command_queue = icd_downcast(cq);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -3909,11 +3904,10 @@ cl_int clEnqueueCopyImageToBuffer(cl_command_queue command_queue,
     // TODO CL_MEM_OBJECT_ALLOCATION_FAILURE if there is a failure to allocate
     // memory for data store associated with src_image or dst_buffer.
 
-    auto cq = icd_downcast(command_queue);
     auto image = static_cast<cvk_image*>(src_image);
     auto buffer = static_cast<cvk_buffer*>(dst_buffer);
 
-    if (!cq->device()->supports_images()) {
+    if (!command_queue->device()->supports_images()) {
         return CL_INVALID_OPERATION;
     }
 
@@ -3922,22 +3916,22 @@ cl_int clEnqueueCopyImageToBuffer(cl_command_queue command_queue,
     std::array<size_t, 3> reg = {region[0], region[1], region[2]};
 
     auto cmd = std::make_unique<cvk_command_buffer_image_copy>(
-        CL_COMMAND_COPY_IMAGE_TO_BUFFER, cq, buffer, image, dst_offset, origin,
-        reg);
+        CL_COMMAND_COPY_IMAGE_TO_BUFFER, command_queue, buffer, image,
+        dst_offset, origin, reg);
     auto err = cmd->build();
     if (err != CL_SUCCESS) {
         return err;
     }
 
-    cq->enqueue_command_with_deps(cmd.release(), num_events_in_wait_list,
-                                  event_wait_list, event);
+    command_queue->enqueue_command_with_deps(
+        cmd.release(), num_events_in_wait_list, event_wait_list, event);
 
     return CL_SUCCESS;
 }
 
-cl_int clEnqueueCopyBufferToImage(cl_command_queue command_queue,
-                                  cl_mem src_buffer, cl_mem dst_image,
-                                  size_t src_offset, const size_t* dst_origin,
+cl_int clEnqueueCopyBufferToImage(cl_command_queue cq, cl_mem src_buffer,
+                                  cl_mem dst_image, size_t src_offset,
+                                  const size_t* dst_origin,
                                   const size_t* region,
                                   cl_uint num_events_in_wait_list,
                                   const cl_event* event_wait_list,
@@ -3947,10 +3941,11 @@ cl_int clEnqueueCopyBufferToImage(cl_command_queue command_queue,
                  "dst_origin = {%zu,%zu,%zu}, region = {%zu, %zu, %zu}, "
                  "num_events_in_wait_list = %u, event_wait_list = %p, "
                  "event = %p",
-                 command_queue, src_buffer, dst_image, src_offset,
-                 dst_origin[0], dst_origin[1], dst_origin[2], region[0],
-                 region[1], region[2], num_events_in_wait_list, event_wait_list,
-                 event);
+                 cq, src_buffer, dst_image, src_offset, dst_origin[0],
+                 dst_origin[1], dst_origin[2], region[0], region[1], region[2],
+                 num_events_in_wait_list, event_wait_list, event);
+
+    auto command_queue = icd_downcast(cq);
 
     if (!is_valid_command_queue(command_queue)) {
         return CL_INVALID_COMMAND_QUEUE;
@@ -3990,11 +3985,10 @@ cl_int clEnqueueCopyBufferToImage(cl_command_queue command_queue,
     // TODO CL_MEM_OBJECT_ALLOCATION_FAILURE if there is a failure to allocate
     // memory for data store associated with src_buffer or dst_image.
 
-    auto cq = icd_downcast(command_queue);
     auto image = static_cast<cvk_image*>(dst_image);
     auto buffer = static_cast<cvk_buffer*>(src_buffer);
 
-    if (!cq->device()->supports_images()) {
+    if (!command_queue->device()->supports_images()) {
         return CL_INVALID_OPERATION;
     }
 
@@ -4003,26 +3997,29 @@ cl_int clEnqueueCopyBufferToImage(cl_command_queue command_queue,
     std::array<size_t, 3> reg = {region[0], region[1], region[2]};
 
     auto cmd = std::make_unique<cvk_command_buffer_image_copy>(
-        CL_COMMAND_COPY_BUFFER_TO_IMAGE, cq, buffer, image, src_offset, origin,
-        reg);
+        CL_COMMAND_COPY_BUFFER_TO_IMAGE, command_queue, buffer, image,
+        src_offset, origin, reg);
     auto err = cmd->build();
     if (err != CL_SUCCESS) {
         return err;
     }
 
-    cq->enqueue_command_with_deps(cmd.release(), num_events_in_wait_list,
-                                  event_wait_list, event);
+    command_queue->enqueue_command_with_deps(
+        cmd.release(), num_events_in_wait_list, event_wait_list, event);
 
     return CL_SUCCESS;
 }
 
-void* cvk_enqueue_map_image(cl_command_queue command_queue, cl_mem image,
+void* cvk_enqueue_map_image(cl_command_queue cq, cl_mem img,
                             cl_bool blocking_map, cl_map_flags map_flags,
                             const size_t* origin, const size_t* region,
                             size_t* image_row_pitch, size_t* image_slice_pitch,
                             cl_uint num_events_in_wait_list,
                             const cl_event* event_wait_list, cl_event* event,
                             cl_int* errcode_ret) {
+    auto command_queue = icd_downcast(cq);
+    auto image = static_cast<cvk_image*>(img);
+
     if (!is_valid_command_queue(command_queue)) {
         *errcode_ret = CL_INVALID_COMMAND_QUEUE;
         return nullptr;
@@ -4059,10 +4056,7 @@ void* cvk_enqueue_map_image(cl_command_queue command_queue, cl_mem image,
         return nullptr;
     }
 
-    auto cq = icd_downcast(command_queue);
-    auto img = static_cast<cvk_image*>(image);
-
-    switch (img->type()) {
+    switch (image->type()) {
     case CL_MEM_OBJECT_IMAGE3D:
     case CL_MEM_OBJECT_IMAGE1D_ARRAY:
     case CL_MEM_OBJECT_IMAGE2D_ARRAY:
@@ -4084,28 +4078,28 @@ void* cvk_enqueue_map_image(cl_command_queue command_queue, cl_mem image,
     // created with CL_MEM_USE_HOST_PTR or CL_MEM_ALLOC_HOST_PTR.
     // TODO CL_MEM_OBJECT_ALLOCATION_FAILURE if there is a failure to allocate
     // memory for data store associated with buffer.
-    if (!cq->device()->supports_images()) {
+    if (!command_queue->device()->supports_images()) {
         *errcode_ret = CL_INVALID_OPERATION;
         return nullptr;
     }
 
     if ((map_flags & CL_MAP_READ) &&
-        (img->has_any_flag(CL_MEM_HOST_WRITE_ONLY | CL_MEM_HOST_NO_ACCESS))) {
+        (image->has_any_flag(CL_MEM_HOST_WRITE_ONLY | CL_MEM_HOST_NO_ACCESS))) {
         *errcode_ret = CL_INVALID_OPERATION;
         return nullptr;
     }
 
     if (((map_flags & CL_MAP_WRITE) ||
          (map_flags & CL_MAP_WRITE_INVALIDATE_REGION)) &&
-        (img->has_any_flag(CL_MEM_HOST_READ_ONLY | CL_MEM_HOST_NO_ACCESS))) {
+        (image->has_any_flag(CL_MEM_HOST_READ_ONLY | CL_MEM_HOST_NO_ACCESS))) {
         *errcode_ret = CL_INVALID_OPERATION;
         return nullptr;
     }
 
     std::array<size_t, 3> orig = {origin[0], origin[1], origin[2]};
     std::array<size_t, 3> reg = {region[0], region[1], region[2]};
-    auto cmd =
-        std::make_unique<cvk_command_map_image>(cq, img, orig, reg, map_flags);
+    auto cmd = std::make_unique<cvk_command_map_image>(command_queue, image,
+                                                       orig, reg, map_flags);
 
     void* map_ptr;
     cl_int err = cmd->build(&map_ptr);
@@ -4120,19 +4114,19 @@ void* cvk_enqueue_map_image(cl_command_queue command_queue, cl_mem image,
         *image_slice_pitch = cmd->map_buffer_slice_pitch();
     }
 
-    err = cq->enqueue_command_with_deps(cmd.release(), blocking_map,
-                                        num_events_in_wait_list,
-                                        event_wait_list, event);
+    err = command_queue->enqueue_command_with_deps(cmd.release(), blocking_map,
+                                                   num_events_in_wait_list,
+                                                   event_wait_list, event);
 
     *errcode_ret = err;
 
     return map_ptr;
 }
 
-void* clEnqueueMapImage(cl_command_queue command_queue, cl_mem image,
-                        cl_bool blocking_map, cl_map_flags map_flags,
-                        const size_t* origin, const size_t* region,
-                        size_t* image_row_pitch, size_t* image_slice_pitch,
+void* clEnqueueMapImage(cl_command_queue cq, cl_mem image, cl_bool blocking_map,
+                        cl_map_flags map_flags, const size_t* origin,
+                        const size_t* region, size_t* image_row_pitch,
+                        size_t* image_slice_pitch,
                         cl_uint num_events_in_wait_list,
                         const cl_event* event_wait_list, cl_event* event,
                         cl_int* errcode_ret) {
@@ -4142,18 +4136,18 @@ void* clEnqueueMapImage(cl_command_queue command_queue, cl_mem image,
                  "image_row_pitch = %p, image_slice_pitch = %p, "
                  "num_events_in_wait_list = %u, event_wait_list = %p, "
                  "event = %p, errcode_ret = %p",
-                 command_queue, image, blocking_map, map_flags, origin[0],
-                 origin[1], origin[2], region[0], region[1], region[2],
-                 image_row_pitch, image_slice_pitch, num_events_in_wait_list,
-                 event_wait_list, event, errcode_ret);
+                 cq, image, blocking_map, map_flags, origin[0], origin[1],
+                 origin[2], region[0], region[1], region[2], image_row_pitch,
+                 image_slice_pitch, num_events_in_wait_list, event_wait_list,
+                 event, errcode_ret);
 
-    auto cq = icd_downcast(command_queue);
+    auto command_queue = icd_downcast(cq);
 
     cl_int err;
-    auto ret = cvk_enqueue_map_image(cq, image, blocking_map, map_flags, origin,
-                                     region, image_row_pitch, image_slice_pitch,
-                                     num_events_in_wait_list, event_wait_list,
-                                     event, &err);
+    auto ret = cvk_enqueue_map_image(command_queue, image, blocking_map,
+                                     map_flags, origin, region, image_row_pitch,
+                                     image_slice_pitch, num_events_in_wait_list,
+                                     event_wait_list, event, &err);
 
     if (errcode_ret != nullptr) {
         *errcode_ret = err;

--- a/src/cl_headers.hpp
+++ b/src/cl_headers.hpp
@@ -15,5 +15,8 @@
 #pragma once
 
 #define CL_TARGET_OPENCL_VERSION 120
+#define CL_USE_DEPRECATED_OPENCL_1_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #include "CL/cl.h"
 #include "CL/cl_ext.h"
+#include "CL/cl_icd.h"

--- a/src/icd.hpp
+++ b/src/icd.hpp
@@ -1,0 +1,35 @@
+// Copyright 2020 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "cl_headers.hpp"
+
+extern cl_icd_dispatch gDispatchTable;
+
+namespace clvk {
+struct icd_object {
+    cl_icd_dispatch* m_dispatch = &gDispatchTable;
+};
+} // namespace clvk
+
+struct _cl_platform_id : clvk::icd_object {};
+struct _cl_device_id : clvk::icd_object {};
+struct _cl_context : clvk::icd_object {};
+struct _cl_command_queue : clvk::icd_object {};
+struct _cl_program : clvk::icd_object {};
+struct _cl_kernel : clvk::icd_object {};
+struct _cl_mem : clvk::icd_object {};
+struct _cl_sampler : clvk::icd_object {};
+struct _cl_event : clvk::icd_object {};

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -456,8 +456,7 @@ bool cvk_kernel::setup_descriptor_set(
     // Setup literal samplers
     for (size_t i = 0; i < program()->literal_sampler_descs().size(); i++) {
         auto desc = program()->literal_sampler_descs()[i];
-        auto clsampler =
-            static_cast<cvk_sampler*>(program()->literal_samplers()[i]);
+        auto clsampler = icd_downcast(program()->literal_samplers()[i]);
         auto sampler = clsampler->vulkan_sampler();
 
         VkDescriptorImageInfo imageInfo = {

--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -106,9 +106,9 @@ private:
     T* m_refcounted;
 };
 
-typedef struct _cl_context : public refcounted {
+struct cvk_context : public _cl_context, refcounted {
 
-    _cl_context(cvk_device* device, const cl_context_properties* props)
+    cvk_context(cvk_device* device, const cl_context_properties* props)
         : m_device(device) {
 
         if (props) {
@@ -123,7 +123,7 @@ typedef struct _cl_context : public refcounted {
         }
     }
 
-    virtual ~_cl_context() {}
+    virtual ~cvk_context() {}
 
     const std::vector<cl_context_properties>& properties() const {
         return m_properties;
@@ -135,8 +135,11 @@ typedef struct _cl_context : public refcounted {
 private:
     cvk_device* m_device;
     std::vector<cl_context_properties> m_properties;
+};
 
-} cvk_context;
+static inline cvk_context* icd_downcast(cl_context context) {
+    return static_cast<cvk_context*>(context);
+}
 
 using cvk_context_holder = refcounted_holder<cvk_context>;
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -958,9 +958,9 @@ void cvk_program::do_build() {
 }
 
 bool cvk_program::build(build_operation operation, cl_uint num_devices,
-                        const cvk_device* const* device_list,
-                        const char* options, cl_uint num_input_programs,
-                        const cvk_program* const* input_programs,
+                        const cl_device_id* device_list, const char* options,
+                        cl_uint num_input_programs,
+                        const cl_program* input_programs,
                         const char** header_include_names,
                         cvk_program_callback cb, void* data) {
     if (!m_lock.try_lock()) {
@@ -970,7 +970,8 @@ bool cvk_program::build(build_operation operation, cl_uint num_devices,
     retain();
 
     for (cl_uint i = 0; i < num_input_programs; i++) {
-        cvk_program* iprog = const_cast<cvk_program*>(input_programs[i]);
+        cvk_program* iprog =
+            const_cast<cvk_program*>(icd_downcast(input_programs[i]));
         iprog->retain();
         m_input_programs.push_back(iprog);
         if (header_include_names != nullptr) {
@@ -985,7 +986,7 @@ bool cvk_program::build(build_operation operation, cl_uint num_devices,
     } else {
         m_num_devices = num_devices;
         for (cl_uint i = 0; i < num_devices; i++) {
-            m_dev_status[device_list[i]] = CL_BUILD_IN_PROGRESS;
+            m_dev_status[icd_downcast(device_list[i])] = CL_BUILD_IN_PROGRESS;
         }
     }
 

--- a/tests/travis/step-install.sh
+++ b/tests/travis/step-install.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+    sudo apt update
+    sudo apt install ocl-icd-libopencl1
+fi
+
 if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
     brew install ccache bash
     export PATH="/usr/local/opt/ccache/libexec:$PATH"

--- a/tests/travis/step-script.sh
+++ b/tests/travis/step-script.sh
@@ -46,3 +46,10 @@ fi
 ./simple_test
 ./simple_test_static
 ./api_tests
+
+if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+    echo $PWD/libOpenCL.so >clvk.icd
+    export OCL_ICD_VENDORS=$PWD
+    LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH ./simple_test
+    LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH ./api_tests
+fi


### PR DESCRIPTION
All OpenCL API objects now inherit from an `icd_object` base class which contains the dispatch table. Downcasts have been introduced as necessary to convert to the clvk subclasses.

Linking to clvk directly is still supported. The dispatch table function pointers are obtained by calling `dlsym()` on the clvk library, which circumvents having to rename the API definitions to avoid clashing with the definitions provided by the ICD loader.

This is perhaps a slightly strange approach, so let me know if you'd rather I just rename the APIs and set the function pointers directly (e.g. `m_dispatch->clFoo() = clvk::clFoo()`, which then requires an another definition of `clFoo()` which calls `clvk::clFoo()` to make direct linking work). 

The many `static_cast` calls are a little ugly; I couldn't see an easy way to make them nicer. We could shorten them a bit by adding a conversion method to `icd_object`, which would lead to (e.g.) `context.as<cvk_context*>()`, but this only saves a few characters. Let me know what you think.

Tested this with OpenCL CTS -  no regressions.