### PR TITLE
Fix descriptor pool creation and add test

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -263,10 +263,10 @@ cl_int cvk_kernel::init() {
     VkDescriptorPoolCreateInfo descriptorPoolCreateInfo = {
         VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
         nullptr,
-        VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT, // flags
-        cvk_kernel::MAX_INSTANCES,                         // maxSets
-        static_cast<uint32_t>(poolSizes.size()),           // poolSizeCount
-        poolSizes.data(),                                  // pPoolSizes
+        VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,            // flags
+        cvk_kernel::MAX_INSTANCES * spir_binary::MAX_DESCRIPTOR_SETS, // maxSets
+        static_cast<uint32_t>(poolSizes.size()), // poolSizeCount
+        poolSizes.data(),                        // pPoolSizes
     };
 
     res = vkCreateDescriptorPool(vkdev, &descriptorPoolCreateInfo, 0,
@@ -296,7 +296,7 @@ cl_int cvk_kernel::init() {
     return CL_SUCCESS;
 }
 
-bool cvk_kernel::setup_descriptor_set(
+bool cvk_kernel::setup_descriptor_sets(
     VkDescriptorSet* ds,
     std::unique_ptr<cvk_kernel_argument_values>& arg_values) {
     std::lock_guard<std::mutex> lock(m_lock);

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -55,7 +55,7 @@ struct cvk_kernel : public _cl_kernel, api_object {
         m_program->release();
     }
 
-    CHECK_RETURN bool setup_descriptor_set(
+    CHECK_RETURN bool setup_descriptor_sets(
         VkDescriptorSet* ds,
         std::unique_ptr<cvk_kernel_argument_values>& arg_values);
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -319,8 +319,8 @@ cl_int cvk_command_kernel::build() {
     // specified.
 
     // Setup descriptors
-    if (!m_kernel->setup_descriptor_set(m_descriptor_sets.data(),
-                                        m_argument_values)) {
+    if (!m_kernel->setup_descriptor_sets(m_descriptor_sets.data(),
+                                         m_argument_values)) {
         return CL_OUT_OF_RESOURCES;
     }
 

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -18,6 +18,7 @@ set(BINARY_NAME api_tests)
 add_executable(
     ${BINARY_NAME}
     dependencies.cpp
+    enqueue.cpp
     images.cpp
     main.cpp
     profiling.cpp

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -1,0 +1,67 @@
+// Copyright 2018 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testcl.hpp"
+
+static const unsigned NUM_INSTANCES = 10000;
+
+static const char* program_source = R"(
+kernel void test_simple(global uint* out, uint id)
+{
+    out[id] = id;
+}
+)";
+
+TEST_F(WithCommandQueue, ManyInstancesInFlight) {
+    // Create kernel
+    auto kernel = CreateKernel(program_source, "test_simple");
+
+    // Create buffer
+    size_t buffer_size = NUM_INSTANCES * sizeof(cl_uint);
+    auto buffer = CreateBuffer(CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR,
+                               buffer_size, nullptr);
+
+    // Dispatch kernel
+    size_t gws = 1;
+    size_t lws = 1;
+
+    auto ts_start = sampleTime();
+    SetKernelArg(kernel, 0, buffer);
+    for (cl_uint i = 0; i < NUM_INSTANCES; i++) {
+        SetKernelArg(kernel, 1, &i);
+        EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, &lws);
+    }
+    auto ts_end = sampleTime();
+    RecordProperty("enqueue-time", ts_end - ts_start);
+
+    // Complete execution
+    Finish();
+
+    // Map the buffer
+    auto data =
+        EnqueueMapBuffer<cl_uint>(buffer, CL_TRUE, CL_MAP_READ, 0, buffer_size);
+
+    // Check the expected result
+    for (cl_uint i = 0; i < NUM_INSTANCES; ++i) {
+        EXPECT_EQ(data[i], static_cast<cl_uint>(i));
+        if (data[i] != static_cast<cl_uint>(i)) {
+            printf("Failed comparison at data[%u]: expected %u != got %u\n", i,
+                   i, data[i]);
+        }
+    }
+
+    // Unmap the buffer
+    EnqueueUnmapMemObject(buffer, data);
+    Finish();
+}

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -94,6 +94,15 @@ static inline const char* cl_code_to_string(cl_int code) {
 }
 // clang-format on
 
+#include <chrono>
+
+static inline uint64_t sampleTime() {
+    auto now = std::chrono::steady_clock::now();
+    auto duration = now.time_since_epoch();
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(duration)
+        .count();
+}
+
 extern cl_device_id gDevice;
 
 #include "gtest/gtest.h"
@@ -309,6 +318,10 @@ protected:
     }
 
     void SetKernelArg(cl_kernel kernel, cl_uint arg_index, cl_int* val) {
+        SetKernelArg(kernel, arg_index, sizeof(*val), val);
+    }
+
+    void SetKernelArg(cl_kernel kernel, cl_uint arg_index, cl_uint* val) {
         SetKernelArg(kernel, arg_index, sizeof(*val), val);
     }
 };


### PR DESCRIPTION
The max number of descriptor sets was wrong.

Add a test exercising many instances in flight that measures the time
spent enqueueing the kernels.

Fixes #153

Signed-off-by: Kévin Petit <kpet@free.fr>