### PR TITLE
Change how kernel args are retained and released

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -322,6 +322,7 @@ bool cvk_kernel::setup_descriptor_sets(
 
     // Transfer ownership of the argument values to the command
     arg_values = std::move(m_argument_values);
+    arg_values->retain_resources();
 
     // Create a new set, copy the argument values
     m_argument_values = cvk_kernel_argument_values::create(*arg_values.get());
@@ -481,40 +482,6 @@ bool cvk_kernel::setup_descriptor_sets(
     }
 
     return true;
-}
-
-void cvk_kernel::retain_arguments() const {
-    for (cl_uint i = 0; i < m_args.size(); i++) {
-        auto const& arg = m_args[i];
-        switch (arg.kind) {
-        case kernel_argument_kind::buffer:
-        case kernel_argument_kind::buffer_ubo:
-        case kernel_argument_kind::sampler:
-        case kernel_argument_kind::ro_image:
-        case kernel_argument_kind::wo_image:
-            m_argument_values->get_arg_value(arg)->retain();
-            break;
-        default:
-            break;
-        }
-    }
-}
-
-void cvk_kernel::release_arguments() const {
-    for (cl_uint i = 0; i < m_args.size(); i++) {
-        auto const& arg = m_args[i];
-        switch (arg.kind) {
-        case kernel_argument_kind::buffer:
-        case kernel_argument_kind::buffer_ubo:
-        case kernel_argument_kind::sampler:
-        case kernel_argument_kind::ro_image:
-        case kernel_argument_kind::wo_image:
-            m_argument_values->get_arg_value(arg)->release();
-            break;
-        default:
-            break;
-        }
-    }
 }
 
 VkPipeline

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -483,6 +483,40 @@ bool cvk_kernel::setup_descriptor_sets(
     return true;
 }
 
+void cvk_kernel::retain_arguments() const {
+    for (cl_uint i = 0; i < m_args.size(); i++) {
+        auto const& arg = m_args[i];
+        switch (arg.kind) {
+        case kernel_argument_kind::buffer:
+        case kernel_argument_kind::buffer_ubo:
+        case kernel_argument_kind::sampler:
+        case kernel_argument_kind::ro_image:
+        case kernel_argument_kind::wo_image:
+            m_argument_values->get_arg_value(arg)->retain();
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+void cvk_kernel::release_arguments() const {
+    for (cl_uint i = 0; i < m_args.size(); i++) {
+        auto const& arg = m_args[i];
+        switch (arg.kind) {
+        case kernel_argument_kind::buffer:
+        case kernel_argument_kind::buffer_ubo:
+        case kernel_argument_kind::sampler:
+        case kernel_argument_kind::ro_image:
+        case kernel_argument_kind::wo_image:
+            m_argument_values->get_arg_value(arg)->release();
+            break;
+        default:
+            break;
+        }
+    }
+}
+
 VkPipeline
 cvk_kernel::create_pipeline(const VkSpecializationInfo& specializationInfo) {
     const VkComputePipelineCreateInfo createInfo = {

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -81,6 +81,12 @@ struct cvk_kernel : public _cl_kernel, api_object {
 
     cl_ulong local_mem_size() const;
 
+    // Retain all the refcounted arguments for this kernel.
+    void retain_arguments() const;
+
+    // Release all the refcounted arguments for this kernel.
+    void release_arguments() const;
+
 private:
     using binding_stat_map = std::unordered_map<VkDescriptorType, uint32_t>;
     bool build_descriptor_set_layout(
@@ -198,10 +204,10 @@ struct cvk_kernel_argument_values {
             }
             if (arg.kind == kernel_argument_kind::sampler) {
                 auto sampler = *reinterpret_cast<const cl_sampler*>(value);
-                m_kernel_resources[arg.binding].reset(icd_downcast(sampler));
+                m_kernel_resources[arg.binding] = icd_downcast(sampler);
             } else {
                 auto mem = *reinterpret_cast<const cl_mem*>(value);
-                m_kernel_resources[arg.binding].reset(icd_downcast(mem));
+                m_kernel_resources[arg.binding] = icd_downcast(mem);
             }
         }
 
@@ -224,7 +230,7 @@ struct cvk_kernel_argument_values {
 private:
     cvk_kernel* m_kernel;
     std::unique_ptr<cvk_buffer> m_pod_buffer;
-    std::vector<refcounted_holder<refcounted>> m_kernel_resources;
+    std::vector<refcounted*> m_kernel_resources;
     std::vector<size_t> m_local_args_size;
     std::unordered_map<uint32_t, uint32_t> m_specialization_constants;
 };

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -318,10 +318,6 @@ cl_int cvk_command_kernel::build() {
     // TODO CL_INVALID_KERNEL_ARGS if the kernel argument values have not been
     // specified.
 
-    // Retain all the refcounted arguments prior to setting up the descriptor
-    // sets and enqueueing the kernel.
-    m_kernel->retain_arguments();
-
     // Setup descriptors
     if (!m_kernel->setup_descriptor_sets(m_descriptor_sets.data(),
                                          m_argument_values)) {
@@ -435,9 +431,6 @@ cl_int cvk_command_kernel::do_action() {
     if (!m_command_buffer.submit_and_wait()) {
         return CL_OUT_OF_RESOURCES;
     }
-
-    // Kernel has completed, release the refcounted arguments.
-    m_kernel->release_arguments();
 
     bool profiling = m_queue->has_property(CL_QUEUE_PROFILING_ENABLE);
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -318,6 +318,10 @@ cl_int cvk_command_kernel::build() {
     // TODO CL_INVALID_KERNEL_ARGS if the kernel argument values have not been
     // specified.
 
+    // Retain all the refcounted arguments prior to setting up the descriptor
+    // sets and enqueueing the kernel.
+    m_kernel->retain_arguments();
+
     // Setup descriptors
     if (!m_kernel->setup_descriptor_sets(m_descriptor_sets.data(),
                                          m_argument_values)) {
@@ -431,6 +435,9 @@ cl_int cvk_command_kernel::do_action() {
     if (!m_command_buffer.submit_and_wait()) {
         return CL_OUT_OF_RESOURCES;
     }
+
+    // Kernel has completed, release the refcounted arguments.
+    m_kernel->release_arguments();
 
     bool profiling = m_queue->has_property(CL_QUEUE_PROFILING_ENABLE);
 


### PR DESCRIPTION
Fixes #157

* Changed cvk_kernel_argument_values to hold raw refcounted pointers
* Add new methods to cvk_kernel to retain and release arguments
  * retain args prior to setting up descriptor sets and enqueueing
  * release upon completion of the kernel

This is the simplest change to address #157 and I'd like some feedback on it if possible. I think I've made the changes suggested in the issue. I also have the suggested test with the destructor callback, but am not sure it belongs in this repo. 

I have tested this against the app that previously ran OOM due to not free'ing buffers and it passes now.