### PR TITLE
Fix data race in queue shutdown

### DIFF
--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -150,8 +150,8 @@ struct cvk_executor_thread {
     void shutdown() {
 
         // Tell the executor to shutdown
-        m_shutdown = true;
         m_lock.lock();
+        m_shutdown = true;
         m_cv.notify_one();
         m_lock.unlock();
 


### PR DESCRIPTION
The `cvk_executor_thread::shutdown()` method was setting `m_shutdown` outside of the mutexed region, which causes TSAN to flag a potential data race.

 I don't /think/ this is actually a problem given that `m_shutdown` is being tested again after the condition variable is signaled, but still nice to squelch the TSAN error.