### PR TITLE
Implement a program scope pipeline cache

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -17,120 +17,10 @@
 #include "kernel.hpp"
 #include "memory.hpp"
 
-bool cvk_kernel::build_descriptor_set_layout(
-    VkDevice vkdev, const std::vector<VkDescriptorSetLayoutBinding>& bindings) {
-    VkDescriptorSetLayoutCreateInfo createInfo = {
-        VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr,
-        0,                                      // flags
-        static_cast<uint32_t>(bindings.size()), // bindingCount
-        bindings.data()                         // pBindings
-    };
-
-    VkResult res;
-    if (bindings.size() > 0) {
-        VkDescriptorSetLayout setLayout;
-        res = vkCreateDescriptorSetLayout(vkdev, &createInfo, 0, &setLayout);
-        if (res != VK_SUCCESS) {
-            cvk_error("Could not create descriptor set layout");
-            return false;
-        }
-        m_descriptor_set_layouts.push_back(setLayout);
-    }
-
-    return true;
-}
-
-bool cvk_kernel::build_descriptor_sets_layout_bindings_for_arguments(
-    VkDevice vkdev, binding_stat_map& smap, uint32_t& num_resources) {
-    bool pod_found = false;
-
-    std::vector<VkDescriptorSetLayoutBinding> layoutBindings;
-    for (auto& arg : m_args) {
-        VkDescriptorType dt = VK_DESCRIPTOR_TYPE_MAX_ENUM;
-
-        switch (arg.kind) {
-        case kernel_argument_kind::buffer:
-            dt = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            break;
-        case kernel_argument_kind::buffer_ubo:
-            dt = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-            break;
-        case kernel_argument_kind::ro_image:
-            dt = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-            break;
-        case kernel_argument_kind::wo_image:
-            dt = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-            break;
-        case kernel_argument_kind::sampler:
-            dt = VK_DESCRIPTOR_TYPE_SAMPLER;
-            break;
-        case kernel_argument_kind::local:
-            continue;
-        case kernel_argument_kind::pod:
-        case kernel_argument_kind::pod_ubo:
-            if (!pod_found) {
-                if (arg.kind == kernel_argument_kind::pod) {
-                    dt = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                } else if (arg.kind == kernel_argument_kind::pod_ubo) {
-                    dt = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-                }
-
-                m_pod_descriptor_type = dt;
-
-                pod_found = true;
-            } else {
-                continue;
-            }
-        }
-
-        VkDescriptorSetLayoutBinding binding = {
-            arg.binding,                 // binding
-            dt,                          // descriptorType
-            1,                           // decriptorCount
-            VK_SHADER_STAGE_COMPUTE_BIT, // stageFlags
-            nullptr                      // pImmutableSamplers
-        };
-
-        layoutBindings.push_back(binding);
-        smap[binding.descriptorType]++;
-    }
-
-    num_resources = layoutBindings.size();
-
-    if (!build_descriptor_set_layout(vkdev, layoutBindings)) {
-        return false;
-    }
-
-    return true;
-}
-
-bool cvk_kernel::build_descriptor_sets_layout_bindings_for_literal_samplers(
-    VkDevice vkdev, binding_stat_map& smap) {
-
-    std::vector<VkDescriptorSetLayoutBinding> layoutBindings;
-    for (auto& desc : m_program->literal_sampler_descs()) {
-        VkDescriptorSetLayoutBinding binding = {
-            desc.binding,                // binding
-            VK_DESCRIPTOR_TYPE_SAMPLER,  // descriptorType
-            1,                           // decriptorCount
-            VK_SHADER_STAGE_COMPUTE_BIT, // stageFlags
-            nullptr                      // pImmutableSamplers
-        };
-        layoutBindings.push_back(binding);
-        smap[binding.descriptorType]++;
-    }
-
-    if (!build_descriptor_set_layout(vkdev, layoutBindings)) {
-        return false;
-    }
-
-    return true;
-}
-
 std::unique_ptr<cvk_buffer> cvk_kernel::allocate_pod_buffer() {
     cl_int err;
-    auto buffer =
-        cvk_buffer::create(m_context, 0, m_pod_buffer_size, nullptr, &err);
+    auto buffer = cvk_buffer::create(
+        m_context, 0, m_entry_point->pod_buffer_size(), nullptr, &err);
     if (err != CL_SUCCESS) {
         return nullptr;
     }
@@ -152,42 +42,14 @@ cl_ulong cvk_kernel::local_mem_size() const {
 }
 
 cl_int cvk_kernel::init() {
-    // Get a pointer to the arguments from the program
-    auto args = m_program->args_for_kernel(m_name);
-
-    if (args == nullptr) {
-        cvk_error("Kernel %s doesn't exist in program", m_name.c_str());
-        return CL_INVALID_KERNEL_NAME;
+    cl_int errcode;
+    m_entry_point = m_program->get_entry_point(m_name, &errcode);
+    if (!m_entry_point) {
+        return errcode;
     }
 
-    // Store a sorted copy of the arguments
-    m_args = *args;
-    std::sort(
-        m_args.begin(), m_args.end(),
-        [](kernel_argument a, kernel_argument b) { return a.pos < b.pos; });
-
-    // Create Descriptor Sets Layout
-    VkResult res;
-    auto vkdev = m_context->device()->vulkan_device();
-
-    std::unordered_map<VkDescriptorType, uint32_t> bindingTypes;
-    if (!build_descriptor_sets_layout_bindings_for_literal_samplers(
-            vkdev, bindingTypes)) {
-        return CL_INVALID_VALUE;
-    }
-
-    uint32_t num_resources;
-    if (!build_descriptor_sets_layout_bindings_for_arguments(
-            vkdev, bindingTypes, num_resources)) {
-        return CL_INVALID_VALUE;
-    }
-
-    // Do we have POD arguments?
-    for (auto& arg : m_args) {
-        if (arg.is_pod()) {
-            m_has_pod_arguments = true;
-        }
-    }
+    // Store a copy of the arguments
+    m_args = m_entry_point->args();
 
     // Init POD arguments
     if (has_pod_arguments()) {
@@ -203,94 +65,12 @@ cl_int cvk_kernel::init() {
         if (m_pod_arg == nullptr) {
             return CL_INVALID_PROGRAM;
         }
-
-        // Check we know the POD buffer's descriptor type
-        if (m_pod_descriptor_type == VK_DESCRIPTOR_TYPE_MAX_ENUM) {
-            return CL_INVALID_PROGRAM;
-        }
-
-        // Find how big the POD buffer should be
-        int max_offset = 0;
-        int max_offset_arg_size = 0;
-
-        for (auto& arg : m_args) {
-            if (arg.is_pod() && (arg.offset >= max_offset)) {
-                max_offset = arg.offset;
-                max_offset_arg_size = arg.size;
-            }
-        }
-
-        m_pod_buffer_size = max_offset + max_offset_arg_size;
     }
 
     // Init argument values
-    m_argument_values = cvk_kernel_argument_values::create(this, num_resources);
+    m_argument_values = cvk_kernel_argument_values::create(
+        this, m_entry_point->num_resources());
     if (m_argument_values == nullptr) {
-        return CL_OUT_OF_RESOURCES;
-    }
-
-    // Create pipeline layout
-    cvk_debug("about to create pipeline layout, number of descriptor set "
-              "layouts: %zu",
-              m_descriptor_set_layouts.size());
-
-    VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = {
-        VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
-        0,
-        0,
-        static_cast<uint32_t>(m_descriptor_set_layouts.size()),
-        m_descriptor_set_layouts.data(),
-        static_cast<uint32_t>(m_program->push_constant_ranges().size()),
-        m_program->push_constant_ranges().data()};
-
-    res = vkCreatePipelineLayout(vkdev, &pipelineLayoutCreateInfo, 0,
-                                 &m_pipeline_layout);
-    if (res != VK_SUCCESS) {
-        cvk_error("Could not create pipeline layout.");
-        return CL_INVALID_VALUE;
-    }
-
-    // Determine number and types of bindings
-    std::vector<VkDescriptorPoolSize> poolSizes(bindingTypes.size());
-
-    int bidx = 0;
-    for (auto& bt : bindingTypes) {
-        poolSizes[bidx].type = bt.first;
-        poolSizes[bidx].descriptorCount = bt.second * cvk_kernel::MAX_INSTANCES;
-        bidx++;
-    }
-
-    // Create descriptor pool
-    VkDescriptorPoolCreateInfo descriptorPoolCreateInfo = {
-        VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
-        nullptr,
-        VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,            // flags
-        cvk_kernel::MAX_INSTANCES * spir_binary::MAX_DESCRIPTOR_SETS, // maxSets
-        static_cast<uint32_t>(poolSizes.size()), // poolSizeCount
-        poolSizes.data(),                        // pPoolSizes
-    };
-
-    res = vkCreateDescriptorPool(vkdev, &descriptorPoolCreateInfo, 0,
-                                 &m_descriptor_pool);
-
-    if (res != VK_SUCCESS) {
-        cvk_error("Could not create descriptor pool.");
-        return CL_INVALID_VALUE;
-    }
-
-    // Create pipeline cache
-    VkPipelineCacheCreateInfo pipelineCacheCreateInfo = {
-        VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
-        nullptr, // pNext
-        0,       // flags
-        0,       // initialDataSize
-        nullptr, // pInitialData
-    };
-
-    res = vkCreatePipelineCache(vkdev, &pipelineCacheCreateInfo, nullptr,
-                                &m_pipeline_cache);
-    if (res != VK_SUCCESS) {
-        cvk_error("Could not create pipeline cache.");
         return CL_OUT_OF_RESOURCES;
     }
 
@@ -303,12 +83,13 @@ bool cvk_kernel::setup_descriptor_sets(
     std::lock_guard<std::mutex> lock(m_lock);
 
     // Allocate descriptor sets
+    auto& descriptor_set_layouts = m_entry_point->descriptor_set_layouts();
     VkDescriptorSetAllocateInfo descriptorSetAllocateInfo = {
         VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, nullptr,
-        m_descriptor_pool,
+        m_entry_point->descriptor_pool(),
         static_cast<uint32_t>(
-            m_descriptor_set_layouts.size()), // descriptorSetCount
-        m_descriptor_set_layouts.data()};
+            descriptor_set_layouts.size()), // descriptorSetCount
+        descriptor_set_layouts.data()};
 
     auto dev = m_context->device()->vulkan_device();
 
@@ -343,11 +124,11 @@ bool cvk_kernel::setup_descriptor_sets(
             VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
             nullptr,
             ds[m_pod_arg->descriptorSet],
-            m_pod_arg->binding,    // dstBinding
-            0,                     // dstArrayElement
-            1,                     // descriptorCount
-            m_pod_descriptor_type, // descriptorType
-            nullptr,               // pImageInfo
+            m_pod_arg->binding,                   // dstBinding
+            0,                                    // dstArrayElement
+            1,                                    // descriptorCount
+            m_entry_point->pod_descriptor_type(), // descriptorType
+            nullptr,                              // pImageInfo
             &bufferInfo,
             nullptr, // pTexelBufferView
         };
@@ -486,37 +267,8 @@ bool cvk_kernel::setup_descriptor_sets(
 }
 
 VkPipeline
-cvk_kernel::create_pipeline(const VkSpecializationInfo& specializationInfo) {
-    const VkComputePipelineCreateInfo createInfo = {
-        VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, // sType
-        nullptr,                                        // pNext
-        0,                                              // flags
-        {
-            VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, // sType
-            nullptr,                                             // pNext
-            0,                                                   // flags
-            VK_SHADER_STAGE_COMPUTE_BIT,                         // stage
-            program()->shader_module(),                          // module
-            name().c_str(),
-            &specializationInfo // pSpecializationInfo
-        },                      // stage
-        pipeline_layout(),      // layout
-        VK_NULL_HANDLE,         // basePipelineHandle
-        0                       // basePipelineIndex
-    };
-
-    VkPipeline pipeline;
-    auto vkdev = m_context->device()->vulkan_device();
-    VkResult res = vkCreateComputePipelines(vkdev, m_pipeline_cache, 1,
-                                            &createInfo, nullptr, &pipeline);
-
-    if (res != VK_SUCCESS) {
-        cvk_error_fn("Could not create compute pipeline: %s",
-                     vulkan_error_string(res));
-        return VK_NULL_HANDLE;
-    }
-
-    return pipeline;
+cvk_kernel::create_pipeline(const cvk_spec_constant_map& spec_constants) {
+    return m_entry_point->create_pipeline(spec_constants);
 }
 
 cl_int cvk_kernel::set_arg(cl_uint index, size_t size, const void* value) {

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -80,27 +80,12 @@ cl_int cvk_kernel::init() {
 bool cvk_kernel::setup_descriptor_sets(
     VkDescriptorSet* ds,
     std::unique_ptr<cvk_kernel_argument_values>& arg_values) {
-    std::lock_guard<std::mutex> lock(m_lock);
 
-    // Allocate descriptor sets
-    auto& descriptor_set_layouts = m_entry_point->descriptor_set_layouts();
-    VkDescriptorSetAllocateInfo descriptorSetAllocateInfo = {
-        VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, nullptr,
-        m_entry_point->descriptor_pool(),
-        static_cast<uint32_t>(
-            descriptor_set_layouts.size()), // descriptorSetCount
-        descriptor_set_layouts.data()};
-
-    auto dev = m_context->device()->vulkan_device();
-
-    VkResult res =
-        vkAllocateDescriptorSets(dev, &descriptorSetAllocateInfo, ds);
-
-    if (res != VK_SUCCESS) {
-        cvk_error_fn("could not allocate descriptor sets: %s",
-                     vulkan_error_string(res));
+    if (!m_entry_point->allocate_descriptor_sets(ds)) {
         return false;
     }
+
+    auto dev = m_context->device()->vulkan_device();
 
     // Transfer ownership of the argument values to the command
     arg_values = std::move(m_argument_values);

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -18,14 +18,7 @@
 #include "memory.hpp"
 
 std::unique_ptr<cvk_buffer> cvk_kernel::allocate_pod_buffer() {
-    cl_int err;
-    auto buffer = cvk_buffer::create(
-        m_context, 0, m_entry_point->pod_buffer_size(), nullptr, &err);
-    if (err != CL_SUCCESS) {
-        return nullptr;
-    }
-
-    return buffer;
+    return m_entry_point->allocate_pod_buffer();
 }
 
 cl_ulong cvk_kernel::local_mem_size() const {

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -40,9 +40,7 @@ struct cvk_kernel : public _cl_kernel, api_object {
         std::unique_ptr<cvk_kernel_argument_values>& arg_values);
 
     void free_descriptor_set(VkDescriptorSet ds) {
-        std::lock_guard<std::mutex> lock(m_lock);
-        auto vkdev = m_context->device()->vulkan_device();
-        vkFreeDescriptorSets(vkdev, m_entry_point->descriptor_pool(), 1, &ds);
+        m_entry_point->free_descriptor_set(ds);
     }
 
     CHECK_RETURN cl_int set_arg(cl_uint index, size_t size, const void* value);
@@ -55,7 +53,7 @@ struct cvk_kernel : public _cl_kernel, api_object {
     const std::string& name() const { return m_name; }
     uint32_t num_args() const { return m_args.size(); }
     uint32_t num_set_layouts() const {
-        return m_entry_point->descriptor_set_layouts().size();
+        return m_entry_point->num_set_layouts();
     }
     VkPipelineLayout pipeline_layout() const {
         return m_entry_point->pipeline_layout();

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1082,3 +1082,328 @@ bool cvk_program::build(build_operation operation, cl_uint num_devices,
 
     return true;
 }
+
+cvk_entry_point* cvk_program::get_entry_point(std::string& name,
+                                              cl_int* errcode_ret) {
+    std::lock_guard<std::mutex> lock(m_lock);
+
+    // Check for existing entry point in cache
+    if (m_entry_points.count(name)) {
+        *errcode_ret = CL_SUCCESS;
+        return m_entry_points.at(name);
+    }
+
+    // Create and initialize entry point
+    cvk_entry_point* entry_point =
+        new cvk_entry_point(m_context->device()->vulkan_device(), this, name);
+    *errcode_ret = entry_point->init();
+    if (*errcode_ret != CL_SUCCESS) {
+        delete entry_point;
+        return nullptr;
+    }
+
+    // Add to cache for reuse by other kernels
+    m_entry_points.insert({name, entry_point});
+
+    return entry_point;
+}
+
+bool cvk_entry_point::build_descriptor_set_layout(
+    const std::vector<VkDescriptorSetLayoutBinding>& bindings) {
+    VkDescriptorSetLayoutCreateInfo createInfo = {
+        VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr,
+        0,                                      // flags
+        static_cast<uint32_t>(bindings.size()), // bindingCount
+        bindings.data()                         // pBindings
+    };
+
+    VkResult res;
+    if (bindings.size() > 0) {
+        VkDescriptorSetLayout setLayout;
+        res = vkCreateDescriptorSetLayout(m_device, &createInfo, 0, &setLayout);
+        if (res != VK_SUCCESS) {
+            cvk_error("Could not create descriptor set layout");
+            return false;
+        }
+        m_descriptor_set_layouts.push_back(setLayout);
+    }
+
+    return true;
+}
+
+bool cvk_entry_point::build_descriptor_sets_layout_bindings_for_arguments(
+    binding_stat_map& smap, uint32_t& num_resources) {
+    bool pod_found = false;
+
+    std::vector<VkDescriptorSetLayoutBinding> layoutBindings;
+    for (auto& arg : m_args) {
+        VkDescriptorType dt = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+
+        switch (arg.kind) {
+        case kernel_argument_kind::buffer:
+            dt = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            break;
+        case kernel_argument_kind::buffer_ubo:
+            dt = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            break;
+        case kernel_argument_kind::ro_image:
+            dt = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+            break;
+        case kernel_argument_kind::wo_image:
+            dt = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+            break;
+        case kernel_argument_kind::sampler:
+            dt = VK_DESCRIPTOR_TYPE_SAMPLER;
+            break;
+        case kernel_argument_kind::local:
+            continue;
+        case kernel_argument_kind::pod:
+        case kernel_argument_kind::pod_ubo:
+            if (!pod_found) {
+                if (arg.kind == kernel_argument_kind::pod) {
+                    dt = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+                } else if (arg.kind == kernel_argument_kind::pod_ubo) {
+                    dt = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+                }
+
+                m_pod_descriptor_type = dt;
+
+                pod_found = true;
+            } else {
+                continue;
+            }
+        }
+
+        VkDescriptorSetLayoutBinding binding = {
+            arg.binding,                 // binding
+            dt,                          // descriptorType
+            1,                           // decriptorCount
+            VK_SHADER_STAGE_COMPUTE_BIT, // stageFlags
+            nullptr                      // pImmutableSamplers
+        };
+
+        layoutBindings.push_back(binding);
+        smap[binding.descriptorType]++;
+    }
+
+    num_resources = layoutBindings.size();
+
+    if (!build_descriptor_set_layout(layoutBindings)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool cvk_entry_point::
+    build_descriptor_sets_layout_bindings_for_literal_samplers(
+        binding_stat_map& smap) {
+
+    std::vector<VkDescriptorSetLayoutBinding> layoutBindings;
+    for (auto& desc : m_program->literal_sampler_descs()) {
+        VkDescriptorSetLayoutBinding binding = {
+            desc.binding,                // binding
+            VK_DESCRIPTOR_TYPE_SAMPLER,  // descriptorType
+            1,                           // decriptorCount
+            VK_SHADER_STAGE_COMPUTE_BIT, // stageFlags
+            nullptr                      // pImmutableSamplers
+        };
+        layoutBindings.push_back(binding);
+        smap[binding.descriptorType]++;
+    }
+
+    if (!build_descriptor_set_layout(layoutBindings)) {
+        return false;
+    }
+
+    return true;
+}
+
+cl_int cvk_entry_point::init() {
+    VkResult res;
+
+    // Get a pointer to the arguments from the program
+    auto args = m_program->args_for_kernel(m_name);
+
+    if (args == nullptr) {
+        cvk_error("Kernel %s doesn't exist in program", m_name.c_str());
+        return CL_INVALID_KERNEL_NAME;
+    }
+
+    // Store a sorted copy of the arguments
+    m_args = *args;
+    std::sort(
+        m_args.begin(), m_args.end(),
+        [](kernel_argument a, kernel_argument b) { return a.pos < b.pos; });
+
+    // Create Descriptor Sets Layout
+    std::unordered_map<VkDescriptorType, uint32_t> bindingTypes;
+    if (!build_descriptor_sets_layout_bindings_for_literal_samplers(
+            bindingTypes)) {
+        return CL_INVALID_VALUE;
+    }
+    if (!build_descriptor_sets_layout_bindings_for_arguments(bindingTypes,
+                                                             m_num_resources)) {
+        return CL_INVALID_VALUE;
+    }
+
+    // Do we have POD arguments?
+    for (auto& arg : m_args) {
+        if (arg.is_pod()) {
+            m_has_pod_arguments = true;
+        }
+    }
+
+    // Calculate POD buffer size
+    if (m_has_pod_arguments) {
+        // Check we know the POD buffer's descriptor type
+        if (m_pod_descriptor_type == VK_DESCRIPTOR_TYPE_MAX_ENUM) {
+            return CL_INVALID_PROGRAM;
+        }
+
+        // Find how big the POD buffer should be
+        int max_offset = 0;
+        int max_offset_arg_size = 0;
+
+        for (auto& arg : m_args) {
+            if (arg.is_pod() && (arg.offset >= max_offset)) {
+                max_offset = arg.offset;
+                max_offset_arg_size = arg.size;
+            }
+        }
+
+        m_pod_buffer_size = max_offset + max_offset_arg_size;
+    }
+
+    // Create pipeline layout
+    cvk_debug("about to create pipeline layout, number of descriptor set "
+              "layouts: %zu",
+              m_descriptor_set_layouts.size());
+
+    VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = {
+        VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        0,
+        0,
+        static_cast<uint32_t>(m_descriptor_set_layouts.size()),
+        m_descriptor_set_layouts.data(),
+        static_cast<uint32_t>(m_program->push_constant_ranges().size()),
+        m_program->push_constant_ranges().data()};
+
+    res = vkCreatePipelineLayout(m_device, &pipelineLayoutCreateInfo, 0,
+                                 &m_pipeline_layout);
+    if (res != VK_SUCCESS) {
+        cvk_error("Could not create pipeline layout.");
+        return CL_INVALID_VALUE;
+    }
+
+    // Determine number and types of bindings
+    std::vector<VkDescriptorPoolSize> poolSizes(bindingTypes.size());
+
+    int bidx = 0;
+    for (auto& bt : bindingTypes) {
+        poolSizes[bidx].type = bt.first;
+        poolSizes[bidx].descriptorCount = bt.second * MAX_INSTANCES;
+        bidx++;
+    }
+
+    // Create descriptor pool
+    VkDescriptorPoolCreateInfo descriptorPoolCreateInfo = {
+        VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        nullptr,
+        VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT, // flags
+        MAX_INSTANCES * spir_binary::MAX_DESCRIPTOR_SETS,  // maxSets
+        static_cast<uint32_t>(poolSizes.size()),           // poolSizeCount
+        poolSizes.data(),                                  // pPoolSizes
+    };
+
+    res = vkCreateDescriptorPool(m_device, &descriptorPoolCreateInfo, 0,
+                                 &m_descriptor_pool);
+
+    if (res != VK_SUCCESS) {
+        cvk_error("Could not create descriptor pool.");
+        return CL_INVALID_VALUE;
+    }
+
+    // Create pipeline cache
+    VkPipelineCacheCreateInfo pipelineCacheCreateInfo = {
+        VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
+        nullptr, // pNext
+        0,       // flags
+        0,       // initialDataSize
+        nullptr, // pInitialData
+    };
+
+    res = vkCreatePipelineCache(m_device, &pipelineCacheCreateInfo, nullptr,
+                                &m_pipeline_cache);
+    if (res != VK_SUCCESS) {
+        cvk_error("Could not create pipeline cache.");
+        return CL_OUT_OF_RESOURCES;
+    }
+
+    return CL_SUCCESS;
+}
+
+VkPipeline
+cvk_entry_point::create_pipeline(const cvk_spec_constant_map& spec_constants) {
+    std::lock_guard<std::mutex> lock(m_lock);
+
+    // Check for a cached pipeline using the same specialization constants
+    if (m_pipelines.count(spec_constants)) {
+        VkPipeline pipeline = m_pipelines.at(spec_constants);
+        cvk_info("reusing pipeline %p for kernel %s", pipeline, m_name.c_str());
+        return pipeline;
+    }
+
+    std::vector<VkSpecializationMapEntry> mapEntries;
+    std::vector<uint32_t> specConstantData;
+    uint32_t constantDataOffset = 0;
+    for (auto& spec_const : spec_constants) {
+        VkSpecializationMapEntry entry = {spec_const.first, constantDataOffset,
+                                          sizeof(uint32_t)};
+        mapEntries.push_back(entry);
+        specConstantData.push_back(spec_const.second);
+        constantDataOffset += sizeof(uint32_t);
+    }
+
+    VkSpecializationInfo specializationInfo = {
+        static_cast<uint32_t>(mapEntries.size()),
+        mapEntries.data(),
+        specConstantData.size() * sizeof(uint32_t),
+        specConstantData.data(),
+    };
+
+    const VkComputePipelineCreateInfo createInfo = {
+        VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, // sType
+        nullptr,                                        // pNext
+        0,                                              // flags
+        {
+            VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, // sType
+            nullptr,                                             // pNext
+            0,                                                   // flags
+            VK_SHADER_STAGE_COMPUTE_BIT,                         // stage
+            m_program->shader_module(),                          // module
+            m_name.c_str(),
+            &specializationInfo // pSpecializationInfo
+        },                      // stage
+        m_pipeline_layout,      // layout
+        VK_NULL_HANDLE,         // basePipelineHandle
+        0                       // basePipelineIndex
+    };
+
+    VkPipeline pipeline;
+    VkResult res = vkCreateComputePipelines(m_device, m_pipeline_cache, 1,
+                                            &createInfo, nullptr, &pipeline);
+
+    if (res != VK_SUCCESS) {
+        cvk_error_fn("Could not create compute pipeline: %s",
+                     vulkan_error_string(res));
+        return VK_NULL_HANDLE;
+    }
+
+    // Add to pipeline cache
+    m_pipelines[spec_constants] = pipeline;
+
+    cvk_info("created pipeline %p for kernel %s", pipeline, m_name.c_str());
+
+    return pipeline;
+}

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1083,6 +1083,14 @@ bool cvk_program::build(build_operation operation, cl_uint num_devices,
     return true;
 }
 
+cvk_entry_point::cvk_entry_point(VkDevice dev, cvk_program* program,
+                                 const std::string& name)
+    : m_device(dev), m_context(program->context()), m_program(program),
+      m_name(name), m_pod_descriptor_type(VK_DESCRIPTOR_TYPE_MAX_ENUM),
+      m_pod_buffer_size(0u), m_has_pod_arguments(false),
+      m_descriptor_pool(VK_NULL_HANDLE), m_pipeline_layout(VK_NULL_HANDLE),
+      m_pipeline_cache(VK_NULL_HANDLE) {}
+
 cvk_entry_point* cvk_program::get_entry_point(std::string& name,
                                               cl_int* errcode_ret) {
     std::lock_guard<std::mutex> lock(m_lock);
@@ -1429,4 +1437,15 @@ bool cvk_entry_point::allocate_descriptor_sets(VkDescriptorSet* ds) {
     }
 
     return true;
+}
+
+std::unique_ptr<cvk_buffer> cvk_entry_point::allocate_pod_buffer() {
+    cl_int err;
+    auto buffer =
+        cvk_buffer::create(m_context, 0, m_pod_buffer_size, nullptr, &err);
+    if (err != CL_SUCCESS) {
+        return nullptr;
+    }
+
+    return buffer;
 }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1090,7 +1090,7 @@ cvk_entry_point* cvk_program::get_entry_point(std::string& name,
     // Check for existing entry point in cache
     if (m_entry_points.count(name)) {
         *errcode_ret = CL_SUCCESS;
-        return m_entry_points.at(name);
+        return m_entry_points.at(name).get();
     }
 
     // Create and initialize entry point
@@ -1103,7 +1103,8 @@ cvk_entry_point* cvk_program::get_entry_point(std::string& name,
     }
 
     // Add to cache for reuse by other kernels
-    m_entry_points.insert({name, entry_point});
+    m_entry_points.insert(
+        {name, std::unique_ptr<cvk_entry_point>(entry_point)});
 
     return entry_point;
 }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -295,9 +295,6 @@ struct cvk_program : public _cl_program, api_object {
     }
 
     virtual ~cvk_program() {
-        for (auto& entry_point : m_entry_points) {
-            delete entry_point.second;
-        }
         if (m_shader_module != VK_NULL_HANDLE) {
             auto vkdev = m_context->device()->vulkan_device();
             vkDestroyShaderModule(vkdev, m_shader_module, nullptr);
@@ -462,7 +459,8 @@ private:
     spir_binary m_binary{SPV_ENV_VULKAN_1_0};
     std::vector<cvk_sampler_holder> m_literal_samplers;
     std::vector<VkPushConstantRange> m_push_constant_ranges;
-    std::unordered_map<std::string, cvk_entry_point*> m_entry_points;
+    std::unordered_map<std::string, std::unique_ptr<cvk_entry_point>>
+        m_entry_points;
 };
 
 static inline cvk_program* icd_downcast(cl_program program) {

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -170,12 +170,8 @@ struct cvk_program;
 
 class cvk_entry_point {
 public:
-    cvk_entry_point(VkDevice dev, cvk_program* program, const std::string& name)
-        : m_device(dev), m_program(program), m_name(name),
-          m_pod_descriptor_type(VK_DESCRIPTOR_TYPE_MAX_ENUM),
-          m_pod_buffer_size(0u), m_has_pod_arguments(false),
-          m_descriptor_pool(VK_NULL_HANDLE), m_pipeline_layout(VK_NULL_HANDLE),
-          m_pipeline_cache(VK_NULL_HANDLE) {}
+    cvk_entry_point(VkDevice dev, cvk_program* program,
+                    const std::string& name);
 
     ~cvk_entry_point() {
         for (auto pipeline : m_pipelines) {
@@ -211,6 +207,8 @@ public:
 
     uint32_t num_set_layouts() const { return m_descriptor_set_layouts.size(); }
 
+    std::unique_ptr<cvk_buffer> allocate_pod_buffer();
+
     const std::vector<kernel_argument>& args() const { return m_args; }
 
     bool has_pod_arguments() const { return m_has_pod_arguments; }
@@ -218,8 +216,6 @@ public:
     uint32_t num_resources() const { return m_num_resources; }
 
     VkPipelineLayout pipeline_layout() const { return m_pipeline_layout; }
-
-    uint32_t pod_buffer_size() const { return m_pod_buffer_size; }
 
     VkDescriptorType pod_descriptor_type() const {
         return m_pod_descriptor_type;
@@ -229,6 +225,7 @@ private:
     const uint32_t MAX_INSTANCES = 16 * 1024; // FIXME find a better definition
 
     VkDevice m_device;
+    cvk_context* m_context;
     cvk_program* m_program;
     std::string m_name;
     VkDescriptorType m_pod_descriptor_type;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <fstream>
+#include <map>
 #include <unordered_map>
 #include <vector>
 
@@ -163,6 +164,121 @@ enum class build_operation
 
 using cvk_program_callback = void (*)(cl_program, void*);
 
+using cvk_spec_constant_map = std::map<uint32_t, uint32_t>;
+
+struct cvk_program;
+
+class cvk_entry_point {
+public:
+    cvk_entry_point(VkDevice dev, cvk_program* program, const std::string& name)
+        : m_device(dev), m_program(program), m_name(name),
+          m_pod_descriptor_type(VK_DESCRIPTOR_TYPE_MAX_ENUM),
+          m_pod_buffer_size(0u), m_has_pod_arguments(false),
+          m_descriptor_pool(VK_NULL_HANDLE), m_pipeline_layout(VK_NULL_HANDLE),
+          m_pipeline_cache(VK_NULL_HANDLE) {}
+
+    ~cvk_entry_point() {
+        for (auto pipeline : m_pipelines) {
+            cvk_info("destroying pipeline %p for kernel %s", pipeline.second,
+                     m_name.c_str());
+            vkDestroyPipeline(m_device, pipeline.second, nullptr);
+        }
+        if (m_pipeline_cache != VK_NULL_HANDLE) {
+            vkDestroyPipelineCache(m_device, m_pipeline_cache, nullptr);
+        }
+        if (m_descriptor_pool != VK_NULL_HANDLE) {
+            vkDestroyDescriptorPool(m_device, m_descriptor_pool, nullptr);
+        }
+        if (m_pipeline_layout != VK_NULL_HANDLE) {
+            vkDestroyPipelineLayout(m_device, m_pipeline_layout, nullptr);
+        }
+        for (auto layout : m_descriptor_set_layouts) {
+            vkDestroyDescriptorSetLayout(m_device, layout, nullptr);
+        }
+    }
+
+    CHECK_RETURN cl_int init();
+
+    CHECK_RETURN VkPipeline
+    create_pipeline(const cvk_spec_constant_map& spec_constants);
+
+    const std::vector<kernel_argument>& args() const { return m_args; }
+
+    VkDescriptorPool descriptor_pool() const { return m_descriptor_pool; }
+
+    const std::vector<VkDescriptorSetLayout>& descriptor_set_layouts() const {
+        return m_descriptor_set_layouts;
+    }
+
+    bool has_pod_arguments() const { return m_has_pod_arguments; }
+
+    uint32_t num_resources() const { return m_num_resources; }
+
+    VkPipelineLayout pipeline_layout() const { return m_pipeline_layout; }
+
+    uint32_t pod_buffer_size() const { return m_pod_buffer_size; }
+
+    VkDescriptorType pod_descriptor_type() const {
+        return m_pod_descriptor_type;
+    }
+
+private:
+    const uint32_t MAX_INSTANCES = 16 * 1024; // FIXME find a better definition
+
+    VkDevice m_device;
+    cvk_program* m_program;
+    std::string m_name;
+    VkDescriptorType m_pod_descriptor_type;
+    uint32_t m_pod_buffer_size;
+    bool m_has_pod_arguments;
+    std::vector<kernel_argument> m_args;
+    uint32_t m_num_resources;
+    VkDescriptorPool m_descriptor_pool;
+    std::vector<VkDescriptorSetLayout> m_descriptor_set_layouts;
+    VkPipelineLayout m_pipeline_layout;
+    VkPipelineCache m_pipeline_cache;
+
+    std::mutex m_lock;
+
+    using binding_stat_map = std::unordered_map<VkDescriptorType, uint32_t>;
+    bool build_descriptor_set_layout(
+        const std::vector<VkDescriptorSetLayoutBinding>& bindings);
+    bool build_descriptor_sets_layout_bindings_for_arguments(
+        binding_stat_map& smap, uint32_t& num_resources);
+    bool build_descriptor_sets_layout_bindings_for_literal_samplers(
+        binding_stat_map& smap);
+
+    // Structures for caching pipelines based on specialization constants
+    struct SpecConstantMapHash {
+        size_t operator()(const cvk_spec_constant_map& spec_constants) const {
+            // TODO: better hash?
+            size_t result = 0;
+            for (auto& entry : spec_constants) {
+                result ^= std::hash<uint32_t>{}(entry.first) * 31;
+                result ^= std::hash<uint32_t>{}(entry.second) * 59;
+            }
+            return result;
+        }
+    };
+    struct SpecConstantMapEqual {
+        bool operator()(const cvk_spec_constant_map& lhs,
+                        const cvk_spec_constant_map& rhs) const {
+            if (lhs.size() != rhs.size())
+                return false;
+            for (auto& lhs_entry : lhs) {
+                if (!rhs.count(lhs_entry.first))
+                    return false;
+                if (lhs_entry.second != rhs.at(lhs_entry.first))
+                    return false;
+            }
+            return true;
+        }
+    };
+    std::unordered_map<cvk_spec_constant_map, VkPipeline, SpecConstantMapHash,
+                       SpecConstantMapEqual>
+        m_pipelines;
+};
+
 struct cvk_program : public _cl_program, api_object {
 
     cvk_program(cvk_context* ctx)
@@ -179,6 +295,9 @@ struct cvk_program : public _cl_program, api_object {
     }
 
     virtual ~cvk_program() {
+        for (auto& entry_point : m_entry_points) {
+            delete entry_point.second;
+        }
         if (m_shader_module != VK_NULL_HANDLE) {
             auto vkdev = m_context->device()->vulkan_device();
             vkDestroyShaderModule(vkdev, m_shader_module, nullptr);
@@ -313,6 +432,9 @@ struct cvk_program : public _cl_program, api_object {
         return m_binary.push_constant(pc);
     }
 
+    CHECK_RETURN cvk_entry_point* get_entry_point(std::string& name,
+                                                  cl_int* errcode_ret);
+
 private:
     void do_build();
     CHECK_RETURN cl_build_status compile_source(const cvk_device* device);
@@ -340,6 +462,7 @@ private:
     spir_binary m_binary{SPV_ENV_VULKAN_1_0};
     std::vector<cvk_sampler_holder> m_literal_samplers;
     std::vector<VkPushConstantRange> m_push_constant_ranges;
+    std::unordered_map<std::string, cvk_entry_point*> m_entry_points;
 };
 
 static inline cvk_program* icd_downcast(cl_program program) {

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -349,34 +349,17 @@ cl_int cvk_command_kernel::build() {
         return CL_OUT_OF_RESOURCES;
     }
 
-    std::vector<VkSpecializationMapEntry> mapEntries = {
-        {0, 0 * sizeof(uint32_t), sizeof(uint32_t)},
-        {1, 1 * sizeof(uint32_t), sizeof(uint32_t)},
-        {2, 2 * sizeof(uint32_t), sizeof(uint32_t)},
+    cvk_spec_constant_map specConstants = {
+        {0, m_wg_size[0]},
+        {1, m_wg_size[1]},
+        {2, m_wg_size[2]},
     };
-
-    std::vector<uint32_t> specConstantData = {m_wg_size[0], m_wg_size[1],
-                                              m_wg_size[2]};
-
-    uint32_t constantDataOffset = specConstantData.size() * sizeof(uint32_t);
-
     for (auto const& spec_value :
          m_argument_values->specialization_constants()) {
-        VkSpecializationMapEntry entry = {spec_value.first, constantDataOffset,
-                                          sizeof(uint32_t)};
-        mapEntries.push_back(entry);
-        specConstantData.push_back(spec_value.second);
-        constantDataOffset += sizeof(uint32_t);
+        specConstants[spec_value.first] = spec_value.second;
     }
 
-    VkSpecializationInfo specializationInfo = {
-        static_cast<uint32_t>(mapEntries.size()),
-        mapEntries.data(),
-        specConstantData.size() * sizeof(uint32_t),
-        specConstantData.data(),
-    };
-
-    m_pipeline = m_kernel->create_pipeline(specializationInfo);
+    m_pipeline = m_kernel->create_pipeline(specConstants);
 
     if (m_pipeline == VK_NULL_HANDLE) {
         return CL_OUT_OF_RESOURCES;

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -589,11 +589,6 @@ struct cvk_command_kernel : public cvk_command {
             }
         }
 
-        if (m_pipeline != VK_NULL_HANDLE) {
-            vkDestroyPipeline(m_queue->device()->vulkan_device(), m_pipeline,
-                              nullptr);
-        }
-
         if (m_query_pool != VK_NULL_HANDLE) {
             auto vkdev = m_queue->device()->vulkan_device();
             vkDestroyQueryPool(vkdev, m_query_pool, nullptr);


### PR DESCRIPTION
Introduces a `cvk_entry_point` class which now owns all pipeline state (e.g. descriptor set layouts and information about POD arguments). One instance of this class is shared between all kernel objects created from the same program that target the same kernel function.

Using specialization constants as a key, a `cvk_entry_object` object holds a map of pipelines which can be reused for kernel launches that have the same work-group size and local memory argument sizes. These pipelines are destroyed when the `cvk_entry_point` object is destroyed, which occurs when the parent program object is destroyed.

There isn't a great deal of new code here, it's mostly just refactoring existing code into a new class and changing the lifetime of the Vulkan pipeline structures.