### PR TITLE
Fix the clvk-side Windows build errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,7 +92,7 @@ else()
     DEFAULT_LLVMSPIRV_BINARY_PATH="$<TARGET_FILE:llvm-spirv>")
 endif()
 
-if(MSVC)
+if(WIN32)
 	target_compile_definitions(OpenCL-objects PRIVATE
 		NOMINMAX)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,8 @@
 if(NOT MSVC)
     add_compile_options(-Wall -W -Wextra)
     add_compile_options(-Wno-ignored-attributes)
+else()
+	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
 if (UNIX AND NOT APPLE)
@@ -88,6 +90,11 @@ else()
     DEFAULT_CLSPV_BINARY_PATH="$<TARGET_FILE:clspv>")
   target_compile_definitions(OpenCL-objects PRIVATE
     DEFAULT_LLVMSPIRV_BINARY_PATH="$<TARGET_FILE:llvm-spirv>")
+endif()
+
+if(MSVC)
+	target_compile_definitions(OpenCL-objects PRIVATE
+		NOMINMAX)
 endif()
 
 function(CLLibrary target type)

--- a/tests/api/simple_ubo.cpp
+++ b/tests/api/simple_ubo.cpp
@@ -30,7 +30,7 @@ TEST_F(WithCommandQueue, SimpleUBO) {
                                " -constant-args-ubo -inline-entry-points ",
                                "test_simple");
 
-    auto num_items = BUFFER_SIZE / sizeof(cl_uint);
+    const auto num_items = BUFFER_SIZE / sizeof(cl_uint);
     cl_int c_data[num_items];
     for (auto i = 0; i != num_items; ++i) {
         c_data[i] = 1;


### PR DESCRIPTION
This _fixes_ the build issues from:  #173 

There are two more issues in OpenCL-Headers, that are addressed separately (although the submodule needs updating then).

Also exporting all symbols through CMake is probably not the best idea and should be handled better..