### PR TITLE
Destroy existing entry points when rebuilding

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -964,6 +964,9 @@ bool cvk_program::check_capabilities(const cvk_device* device) const {
 void cvk_program::do_build() {
     cl_build_status status = CL_BUILD_SUCCESS;
 
+    // Destroy entry points from previous build
+    m_entry_points.clear();
+
     auto device = m_context->device();
 
     switch (m_operation) {


### PR DESCRIPTION
The new pipeline cache regressed a couple of CTS tests (e.g. compiler options_build_macro) since entry points (and their VkPipeline objects) were persisting after a program was rebuilt with different compiler options.