### PR TITLE
Fix use of vkGetPhysicalDeviceFeatures2 for Vulkan 1.0

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -68,11 +68,6 @@ VkBool32 VKAPI_CALL debugCallback(VkDebugReportFlagsEXT flags,
 static void init_vulkan() {
     VkResult res;
 
-    // Get version information
-    uint32_t version;
-    res = vkEnumerateInstanceVersion(&version);
-    CVK_VK_CHECK_FATAL(res, "Could not query supported instance version");
-
     // Print layer info
     uint32_t numLayerProperties;
     res = vkEnumerateInstanceLayerProperties(&numLayerProperties, nullptr);
@@ -106,11 +101,6 @@ static void init_vulkan() {
 
     std::vector<const char*> enabledExtensions;
 
-    if (version < VK_MAKE_VERSION(1, 1, 0)) {
-        enabledExtensions.push_back(
-            VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-    };
-
     for (size_t i = 0; i < numExtensionProperties; i++) {
         cvk_info("Found extension %s, spec version %u",
                  extensionProperties[i].extensionName,
@@ -120,6 +110,11 @@ static void init_vulkan() {
                     VK_EXT_DEBUG_REPORT_EXTENSION_NAME)) {
             enabledExtensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
             gDebugReportEnabled = true;
+        } else if (
+            !strcmp(extensionProperties[i].extensionName,
+                    VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
+            enabledExtensions.push_back(
+                VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         }
     }
 

--- a/src/init.hpp
+++ b/src/init.hpp
@@ -18,6 +18,7 @@
 
 #include <string>
 
+extern VkInstance gVkInstance;
 extern cvk_platform* gPlatform;
 
 extern std::string gCLSPVPath;


### PR DESCRIPTION
The Vulkan loader may report a newer API version than the underlying Vulkan device, so we cannot rely on the version reported by `vkGetInstanceVersion` to determine whether or not to enable the extension. Instead, enable the extension if it is present, check the device's API version at the point we use the function, and get the KHR suffixed variant via `vkGetInstanceProcAddr` if we are on Vulkan 1.0.

This change allows clvk to work over MoltenVK. I have not tested any other Vulkan 1.0 devices, but my other Vulkan 1.1 devices still work.