### PR TITLE
Infrastructure to support pod push constants

### DIFF
--- a/src/device.hpp
+++ b/src/device.hpp
@@ -226,6 +226,10 @@ struct cvk_device : public _cl_device_id {
 
     VkDevice vulkan_device() const { return m_dev; }
 
+    uint32_t vulkan_max_push_constants_size() const {
+        return m_properties.limits.maxPushConstantsSize;
+    }
+
 private:
     std::string version_desc() const {
         std::string ret = "CLVK on Vulkan v";

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -21,6 +21,11 @@ std::unique_ptr<cvk_buffer> cvk_kernel::allocate_pod_buffer() {
     return m_entry_point->allocate_pod_buffer();
 }
 
+std::unique_ptr<std::vector<uint8_t>>
+cvk_kernel::allocate_pod_pushconstant_buffer() {
+    return m_entry_point->allocate_pod_pushconstant_buffer();
+}
+
 cl_ulong cvk_kernel::local_mem_size() const {
     cl_ulong ret = 0; // FIXME take the compile-time allocations into account
 
@@ -91,7 +96,7 @@ bool cvk_kernel::setup_descriptor_sets(
     }
 
     // Setup descriptors for POD arguments
-    if (has_pod_arguments()) {
+    if (has_pod_buffer_arguments()) {
 
         // Update desciptors
         VkDescriptorBufferInfo bufferInfo = {arg_values->pod_vulkan_buffer(),
@@ -205,6 +210,7 @@ bool cvk_kernel::setup_descriptor_sets(
         }
         case kernel_argument_kind::pod: // skip POD arguments
         case kernel_argument_kind::pod_ubo:
+        case kernel_argument_kind::pod_pushconstant:
             break;
         case kernel_argument_kind::local: // nothing to do?
             break;

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -143,11 +143,8 @@ struct cvk_kernel_argument_values {
 
             m_pod_buffer = std::move(buffer);
         } else if (m_kernel->has_pod_arguments()) {
+            // TODO(#101): host out-of-memory errors are currently unhandled.
             auto buffer = m_kernel->allocate_pod_pushconstant_buffer();
-            if (buffer == nullptr) {
-                return false;
-            }
-
             m_pod_pushconstant_buffer = std::move(buffer);
         }
 

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -22,7 +22,6 @@
 #include "program.hpp"
 
 struct cvk_kernel_argument_values;
-struct cvk_command_buffer;
 
 struct cvk_kernel : public _cl_kernel, api_object {
 

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -213,7 +213,10 @@ struct cvk_kernel_argument_values {
 
     VkBuffer pod_vulkan_buffer() const { return m_pod_buffer->vulkan_buffer(); }
 
-    std::vector<uint8_t>& pod_pushconstant_buffer() const {
+    const std::vector<uint8_t>& pod_pushconstant_buffer() const {
+        return *m_pod_pushconstant_buffer;
+    }
+    std::vector<uint8_t>& pod_pushconstant_buffer() {
         return *m_pod_pushconstant_buffer;
     }
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1155,8 +1155,8 @@ cvk_entry_point::cvk_entry_point(VkDevice dev, cvk_program* program,
     : m_device(dev), m_context(program->context()), m_program(program),
       m_name(name), m_pod_descriptor_type(VK_DESCRIPTOR_TYPE_MAX_ENUM),
       m_pod_buffer_size(0u), m_has_pod_arguments(false),
-      m_descriptor_pool(VK_NULL_HANDLE), m_pipeline_layout(VK_NULL_HANDLE),
-      m_pipeline_cache(VK_NULL_HANDLE) {}
+      m_has_pod_buffer_arguments(false), m_descriptor_pool(VK_NULL_HANDLE),
+      m_pipeline_layout(VK_NULL_HANDLE), m_pipeline_cache(VK_NULL_HANDLE) {}
 
 cvk_entry_point* cvk_program::get_entry_point(std::string& name,
                                               cl_int* errcode_ret) {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1248,6 +1248,7 @@ bool cvk_entry_point::build_descriptor_sets_layout_bindings_for_arguments(
             } else {
                 continue;
             }
+            break;
         case kernel_argument_kind::pod_pushconstant:
             continue;
         }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -275,7 +275,8 @@ bool parse_arg(kernel_argument& arg, const std::vector<std::string>& tokens,
     return true;
 }
 
-bool parse_kernel_pushconstant(kernel_argument& arg, const std::vector<std::string>& tokens,
+bool parse_kernel_pushconstant(kernel_argument& arg,
+                               const std::vector<std::string>& tokens,
                                int toknum) {
     if (tokens[toknum++] != "offset") {
       return false;
@@ -296,7 +297,7 @@ bool parse_kernel_pushconstant(kernel_argument& arg, const std::vector<std::stri
     }
 
     if (tokens[toknum++] != "argSize") {
-      return false;
+        return false;
     }
 
     arg.size = atoi(tokens[toknum++].c_str());

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -810,15 +810,14 @@ cl_build_status cvk_program::compile_source(const cvk_device* device) {
     if (!devices_support_images()) {
         options += " -images=0 ";
     }
-    options += " -pod-pushconstant ";
     options += " -max-pushconstant-size=" +
                std::to_string(device->vulkan_max_push_constants_size()) + " ";
-    //options += " -pod-ubo ";
+    options += " -pod-ubo ";
     options += " -int8 ";
     if (device->supports_ubo_stdlayout()) {
         options += " -std430-ubo-layout ";
     }
-    //options += " -work-dim -global-offset ";
+    options += " -work-dim -global-offset ";
     options += " " + gCLSPVOptions + " ";
 
 #ifdef CLSPV_ONLINE_COMPILER

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -219,6 +219,8 @@ public:
 
     std::unique_ptr<cvk_buffer> allocate_pod_buffer();
 
+    std::unique_ptr<std::vector<uint8_t>> allocate_pod_pushconstant_buffer();
+
     const std::vector<kernel_argument>& args() const { return m_args; }
 
     bool has_pod_arguments() const { return m_has_pod_arguments; }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -67,7 +67,6 @@ struct kernel_argument {
         return (kind == kernel_argument_kind::pod) ||
                (kind == kernel_argument_kind::pod_ubo);
     }
-
 };
 
 struct sampler_desc {

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -39,6 +39,7 @@ enum class kernel_argument_kind
     buffer_ubo,
     pod,
     pod_ubo,
+    pod_pushconstant,
     ro_image,
     wo_image,
     sampler,
@@ -58,8 +59,15 @@ struct kernel_argument {
 
     bool is_pod() const {
         return (kind == kernel_argument_kind::pod) ||
+               (kind == kernel_argument_kind::pod_ubo) ||
+               (kind == kernel_argument_kind::pod_pushconstant);
+    }
+
+    bool is_pod_buffer() const {
+        return (kind == kernel_argument_kind::pod) ||
                (kind == kernel_argument_kind::pod_ubo);
     }
+
 };
 
 struct sampler_desc {
@@ -215,6 +223,8 @@ public:
 
     bool has_pod_arguments() const { return m_has_pod_arguments; }
 
+    bool has_pod_buffer_arguments() const { return m_has_pod_buffer_arguments; }
+
     uint32_t num_resources() const { return m_num_resources; }
 
     VkPipelineLayout pipeline_layout() const { return m_pipeline_layout; }
@@ -233,6 +243,7 @@ private:
     VkDescriptorType m_pod_descriptor_type;
     uint32_t m_pod_buffer_size;
     bool m_has_pod_arguments;
+    bool m_has_pod_buffer_arguments;
     std::vector<kernel_argument> m_args;
     uint32_t m_num_resources;
     VkDescriptorPool m_descriptor_pool;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -399,7 +399,8 @@ cl_int cvk_command_kernel::build() {
                            &m_global_offsets);
     }
 
-    if (m_kernel->has_pod_arguments() && !m_kernel->has_pod_buffer_arguments()) {
+    if (m_kernel->has_pod_arguments() &&
+        !m_kernel->has_pod_buffer_arguments()) {
         for (auto& arg : m_kernel->arguments()) {
             if (arg.kind == kernel_argument_kind::pod_pushconstant) {
                 CVK_ASSERT(arg.offset + arg.size <=


### PR DESCRIPTION
* Adds a new pod buffer in host memory for pushconstant pod args
  * treated similarly to the pod buffer, but is not a VkBuffer
* adding updated descriptor map parsing

There are two commits. The first commit includes hacks to the compile to force the use of pod push constants (how I tested this). The second commit removes those options so that the new functionality is unused (as per https://github.com/google/clspv/issues/529). 

I only added infrastructure this time to reduce the size of the PR and because not all the clspv functionality is in place to do a complete switch yet. I'd appreciate feedback on whether you think this is a good direction.