### PR TITLE
Use build status to avoid concurrent builds

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1083,6 +1083,7 @@ void cvk_program::do_build() {
                                 desc.addressing_mode, desc.filter_mode);
         if (sampler == nullptr) {
             complete_operation(device, CL_BUILD_ERROR);
+            return;
         }
         m_literal_samplers.emplace_back(sampler);
     }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1116,7 +1116,14 @@ bool cvk_program::build(build_operation operation, cl_uint num_devices,
                         const cl_program* input_programs,
                         const char** header_include_names,
                         cvk_program_callback cb, void* data) {
-    if (!m_lock.try_lock()) {
+    std::lock_guard<std::mutex> lock(m_lock);
+
+    // Check if there is already a build in progress
+    // TODO: Allow concurrent builds targeting different devices
+    if (std::count_if(m_dev_status.begin(), m_dev_status.end(),
+                      [](auto& status) {
+                          return status.second == CL_BUILD_IN_PROGRESS;
+                      })) {
         return false;
     }
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -387,7 +387,6 @@ struct cvk_program : public _cl_program, api_object {
 
     void complete_operation(cvk_device* device, cl_build_status status) {
         m_dev_status[device] = status;
-        m_lock.unlock();
         if (m_operation_callback != nullptr) {
             m_operation_callback(this, m_operation_callback_data);
         }


### PR DESCRIPTION
This is a much simpler fix than we previously discussed in #162. Instead of using the mutex to signal when the build has completed, just rely on the fact that we already have this information in the build status. The mutex is now just used to avoid concurrent calls to clBuildProgram.

The check is slightly conservative; this doesn't allow the same program to be built for two different devices concurrently (which would be handled by the larger refactor into a cvk_program_build that we briefly discussed). I think this is fine for now however, given that the rest of the program build logic assumes single device anyway.