### PR TITLE
Skip fetching deps when checking format in CI

### DIFF
--- a/tests/travis/step-before-script.sh
+++ b/tests/travis/step-before-script.sh
@@ -2,6 +2,10 @@
 
 set -ex
 
+if [ "${JOB_CHECK_FORMAT}" -eq 1 ]; then
+    exit 0
+fi
+
 cd external/clspv
 ./utils/fetch_sources.py --deps llvm
 cd ../..


### PR DESCRIPTION
Should fix CI and also make the format checking job faster.