### PR TITLE
Introduce primitive batching of kernel commands

### DIFF
--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -192,9 +192,13 @@ bool is_command_batchable(cvk_command* cmd) {
     bool unresolved_other_queue_dependencies = false;
 
     for (auto ev : cmd->dependencies()) {
-        if (ev->is_user_event() && !ev->completed()) {
-            unresolved_user_event_dependencies = true;
-            break;
+        if (ev->is_user_event()) {
+            if (!ev->completed()) {
+                unresolved_user_event_dependencies = true;
+                break;
+            } else {
+                continue;
+            }
         }
 
         if ((ev->queue() != cmd->queue()) && !ev->completed()) {

--- a/src/vkutils.hpp
+++ b/src/vkutils.hpp
@@ -53,6 +53,30 @@ struct cvk_vulkan_queue_wrapper {
         return ret;
     }
 
+    CHECK_RETURN VkResult submit(const std::vector<VkCommandBuffer>& cmdbufs) {
+        std::lock_guard<std::mutex> lock(m_lock);
+
+        VkSubmitInfo submitInfo = {
+            VK_STRUCTURE_TYPE_SUBMIT_INFO,
+            nullptr,
+            0,                                     // waitSemaphoreCOunt
+            nullptr,                               // pWaitSemaphores
+            nullptr,                               // pWaitDstStageMask
+            static_cast<uint32_t>(cmdbufs.size()), // commandBufferCount
+            cmdbufs.data(),
+            0,       // signalSemaphoreCount
+            nullptr, // pSignalSemaphores
+        };
+
+        auto ret = vkQueueSubmit(m_queue, 1, &submitInfo, VK_NULL_HANDLE);
+        if (ret != VK_SUCCESS) {
+            cvk_error_fn("could not submit work to queue: %s",
+                         vulkan_error_string(ret));
+        }
+
+        return ret;
+    }
+
     CHECK_RETURN VkResult wait_idle() {
         std::lock_guard<std::mutex> lock(m_lock);
 


### PR DESCRIPTION
The command buffers of contiguous kernel commands with resolved external
dependencies are submitted together.

Contributes to #167

Signed-off-by: Kévin Petit <kpet@free.fr>