### PR TITLE
Support work dimensions as a spec constant

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -455,6 +455,8 @@ bool spir_binary::parse_specconstant(const std::vector<std::string>& tokens,
         constant = spec_constant::workgroup_size_y;
     } else if (name == "workgroup_size_z") {
         constant = spec_constant::workgroup_size_z;
+    } else if (name == "work_dim") {
+        constant = spec_constant::work_dim;
     } else {
         return false;
     }
@@ -640,6 +642,9 @@ bool spir_binary::load_descriptor_map(
                 break;
             case clspv::SpecConstant::kWorkgroupSizeZ:
                 constant = spec_constant::workgroup_size_z;
+                break;
+            case clspv::SpecConstant::kWorkDim:
+                constant = spec_constant::work_dim;
                 break;
             default:
                 cvk_error(
@@ -878,7 +883,7 @@ cl_build_status cvk_program::compile_source(const cvk_device* device) {
     if (device->supports_ubo_stdlayout()) {
         options += " -std430-ubo-layout ";
     }
-    options += " -work-dim -global-offset ";
+    options += " -global-offset ";
     options += " " + gCLSPVOptions + " ";
 
 #ifdef CLSPV_ONLINE_COMPILER

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -418,9 +418,7 @@ bool spir_binary::parse_pushconstant(const std::vector<std::string>& tokens,
     auto& name = tokens[toknum++];
     pushconstant pc;
 
-    if (name == "dimensions") {
-        pc = pushconstant::dimensions;
-    } else if (name == "global_offset") {
+    if (name == "global_offset") {
         pc = pushconstant::global_offset;
     } else if (name == "enqueued_local_size") {
         pc = pushconstant::enqueued_local_size;
@@ -596,9 +594,6 @@ bool spir_binary::load_descriptor_map(
             pushconstant pc;
             pushconstant_desc pcd;
             switch (entry.push_constant_data.pc) {
-            case clspv::PushConstant::Dimensions:
-                pc = pushconstant::dimensions;
-                break;
             case clspv::PushConstant::GlobalOffset:
                 pc = pushconstant::global_offset;
                 break;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -79,7 +79,6 @@ struct sampler_desc {
 
 enum class pushconstant
 {
-    dimensions,
     global_offset,
     enqueued_local_size,
 };

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -94,6 +94,7 @@ enum class spec_constant
     workgroup_size_x,
     workgroup_size_y,
     workgroup_size_z,
+    work_dim,
 };
 
 class spir_binary {

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -477,13 +477,6 @@ cl_int cvk_command_kernel::build() {
             m_descriptor_sets.data(), 0, 0);
     }
 
-    if (auto pc = program->push_constant(pushconstant::dimensions)) {
-        CVK_ASSERT(pc->size == 4);
-        vkCmdPushConstants(m_command_buffer, m_kernel->pipeline_layout(),
-                           VK_SHADER_STAGE_COMPUTE_BIT, pc->offset, pc->size,
-                           &m_dimensions);
-    }
-
     if (auto pc = program->push_constant(pushconstant::global_offset)) {
         CVK_ASSERT(pc->size == 12);
         vkCmdPushConstants(m_command_buffer, m_kernel->pipeline_layout(),

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -445,6 +445,13 @@ cl_int cvk_command_kernel::build() {
          m_argument_values->specialization_constants()) {
         specConstants[spec_value.first] = spec_value.second;
     }
+    // Clspv allocates a spec constant for work dimensions if get_work_dim() is
+    // used.
+    where = constants.find(spec_constant::work_dim);
+    if (where != constants.end()) {
+        uint32_t dim_id = where->second;
+        specConstants[dim_id] = m_dimensions;
+    }
 
     m_pipeline = m_kernel->create_pipeline(specConstants);
 


### PR DESCRIPTION
* Clspv default for -work-dim is true so stop passing that option
* Parse work dim spec constant in descriptor map
* Populate work dim spec constant value if necessary
* Add test for work dims