### PR TITLE
Remove unnecessary compile options

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -862,8 +862,6 @@ cl_build_status cvk_program::compile_source(const cvk_device* device) {
 
     // Prepare options
     std::string options = processed_options;
-    options += " -cluster-pod-kernel-args ";
-
     std::string single_precision_option = "-cl-single-precision-constant";
     if (processed_options.find(single_precision_option) == std::string::npos) {
         options += " " + single_precision_option + " ";
@@ -873,7 +871,6 @@ cl_build_status cvk_program::compile_source(const cvk_device* device) {
     }
     options += " -max-pushconstant-size=" +
                std::to_string(device->vulkan_max_push_constants_size()) + " ";
-    options += " -pod-ubo ";
     options += " -int8 ";
     if (device->supports_ubo_stdlayout()) {
         options += " -std430-ubo-layout ";

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -291,7 +291,7 @@ bool parse_kernel_pushconstant(kernel_argument& arg,
     std::string akind{tokens[toknum++]};
 
     if (akind == "pod_pushconstant") {
-        arg.kind = kernel_argument_kind::pod;
+        arg.kind = kernel_argument_kind::pod_pushconstant;
     } else {
         return false;
     }

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -141,7 +141,7 @@ TEST_F(WithCommandQueue, WorkDim) {
 TEST_F(WithCommandQueue, PodUBO) {
     static const char* program_source =
         "kernel void test(global int* out, int a, int4 b, int c) { *out = a + "
-        "b.x + c; }";
+        "b.y + c; }";
 
     auto kernel = CreateKernel(program_source, " -pod-ubo ", "test");
 
@@ -170,7 +170,7 @@ TEST_F(WithCommandQueue, PodUBO) {
     auto data =
         EnqueueMapBuffer<cl_uint>(buffer, CL_TRUE, CL_MAP_READ, 0, buffer_size);
 
-    EXPECT_EQ(data[0], static_cast<cl_int>(38));
+    EXPECT_EQ(data[0], static_cast<cl_int>(37));
 
     // Unmap the buffer
     EnqueueUnmapMemObject(buffer, data);
@@ -180,7 +180,7 @@ TEST_F(WithCommandQueue, PodUBO) {
 TEST_F(WithCommandQueue, PodPushConstant) {
     static const char* program_source =
         "kernel void test(global int* out, int a, int4 b, int c) { *out = a + "
-        "b.x + c; }";
+        "b.z + c; }";
 
     auto kernel = CreateKernel(program_source, " -pod-pushconstant ", "test");
 
@@ -209,7 +209,7 @@ TEST_F(WithCommandQueue, PodPushConstant) {
     auto data =
         EnqueueMapBuffer<cl_uint>(buffer, CL_TRUE, CL_MAP_READ, 0, buffer_size);
 
-    EXPECT_EQ(data[0], static_cast<cl_int>(40));
+    EXPECT_EQ(data[0], static_cast<cl_int>(42));
 
     // Unmap the buffer
     EnqueueUnmapMemObject(buffer, data);

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -132,6 +132,10 @@ TEST_F(WithCommandQueue, WorkDim) {
             << "Failure comparison at data[" << i << "]:\n - expected " << i + 1
             << "\n - got: " << data[i];
     }
+
+    // Unmap the buffer
+    EnqueueUnmapMemObject(buffer, data);
+    Finish();
 }
 
 TEST_F(WithCommandQueue, PodUBO) {
@@ -159,11 +163,18 @@ TEST_F(WithCommandQueue, PodUBO) {
     size_t lws = 1;
     EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, &lws);
 
+    // Complete execution
+    Finish();
+
     // Map the buffer
     auto data =
         EnqueueMapBuffer<cl_uint>(buffer, CL_TRUE, CL_MAP_READ, 0, buffer_size);
 
     EXPECT_EQ(data[0], static_cast<cl_int>(38));
+
+    // Unmap the buffer
+    EnqueueUnmapMemObject(buffer, data);
+    Finish();
 }
 
 TEST_F(WithCommandQueue, PodPushConstant) {
@@ -191,9 +202,16 @@ TEST_F(WithCommandQueue, PodPushConstant) {
     size_t lws = 1;
     EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, &lws);
 
+    // Complete execution
+    Finish();
+
     // Map the buffer
     auto data =
         EnqueueMapBuffer<cl_uint>(buffer, CL_TRUE, CL_MAP_READ, 0, buffer_size);
 
     EXPECT_EQ(data[0], static_cast<cl_int>(40));
+
+    // Unmap the buffer
+    EnqueueUnmapMemObject(buffer, data);
+    Finish();
 }

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -132,8 +132,68 @@ TEST_F(WithCommandQueue, WorkDim) {
             << "Failure comparison at data[" << i << "]:\n - expected " << i + 1
             << "\n - got: " << data[i];
     }
+}
 
-    // Unmap the buffer
-    EnqueueUnmapMemObject(buffer, data);
-    Finish();
+TEST_F(WithCommandQueue, PodUBO) {
+    static const char* program_source =
+        "kernel void test(global int* out, int a, int4 b, int c) { *out = a + "
+        "b.x + c; }";
+
+    auto kernel = CreateKernel(program_source, " -pod-ubo ", "test");
+
+    // Output buffer
+    size_t buffer_size = sizeof(cl_uint);
+    auto buffer = CreateBuffer(CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR,
+                               buffer_size, nullptr);
+    SetKernelArg(kernel, 0, buffer);
+
+    // Pod args
+    cl_int a = 42;
+    cl_int b[4] = {-1, -2, -3, -4};
+    cl_int c = -3;
+    SetKernelArg(kernel, 1, &a);
+    SetKernelArg(kernel, 2, 4 * sizeof(cl_int), b);
+    SetKernelArg(kernel, 3, &c);
+
+    size_t gws = 1;
+    size_t lws = 1;
+    EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, &lws);
+
+    // Map the buffer
+    auto data =
+        EnqueueMapBuffer<cl_uint>(buffer, CL_TRUE, CL_MAP_READ, 0, buffer_size);
+
+    EXPECT_EQ(data[0], static_cast<cl_int>(38));
+}
+
+TEST_F(WithCommandQueue, PodPushConstant) {
+    static const char* program_source =
+        "kernel void test(global int* out, int a, int4 b, int c) { *out = a + "
+        "b.x + c; }";
+
+    auto kernel = CreateKernel(program_source, " -pod-pushconstant ", "test");
+
+    // Output buffer
+    size_t buffer_size = sizeof(cl_uint);
+    auto buffer = CreateBuffer(CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR,
+                               buffer_size, nullptr);
+    SetKernelArg(kernel, 0, buffer);
+
+    // Pod args
+    cl_int a = 42;
+    cl_int b[4] = {1, 2, 3, 4};
+    cl_int c = -3;
+    SetKernelArg(kernel, 1, &a);
+    SetKernelArg(kernel, 2, 4 * sizeof(cl_int), b);
+    SetKernelArg(kernel, 3, &c);
+
+    size_t gws = 1;
+    size_t lws = 1;
+    EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, &lws);
+
+    // Map the buffer
+    auto data =
+        EnqueueMapBuffer<cl_uint>(buffer, CL_TRUE, CL_MAP_READ, 0, buffer_size);
+
+    EXPECT_EQ(data[0], static_cast<cl_int>(40));
 }


### PR DESCRIPTION
* Remove unnecessary options
  * -work-dim is on by default
  * -cluster-pod-kernel-args is on by default
  * -pod-ubo removal allows clspv to choose implementation
* Added some tests to confirm both ubo and push constant pod args work
* Update clspv