### PR TITLE
Support global offset as a spec constant

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -463,6 +463,12 @@ bool spir_binary::parse_specconstant(const std::vector<std::string>& tokens,
         constant = spec_constant::workgroup_size_z;
     } else if (name == "work_dim") {
         constant = spec_constant::work_dim;
+    } else if (name == "global_offset_x") {
+        constant = spec_constant::global_offset_x;
+    } else if (name == "global_offset_y") {
+        constant = spec_constant::global_offset_y;
+    } else if (name == "global_offset_z") {
+        constant = spec_constant::global_offset_z;
     } else {
         return false;
     }
@@ -648,6 +654,15 @@ bool spir_binary::load_descriptor_map(
                 break;
             case clspv::SpecConstant::kWorkDim:
                 constant = spec_constant::work_dim;
+                break;
+            case clspv::SpecConstant::kGlobalOffsetX:
+                constant = spec_constant::global_offset_x;
+                break;
+            case clspv::SpecConstant::kGlobalOffsetY:
+                constant = spec_constant::global_offset_y;
+                break;
+            case clspv::SpecConstant::kGlobalOffsetZ:
+                constant = spec_constant::global_offset_z;
                 break;
             default:
                 cvk_error(

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -98,6 +98,9 @@ enum class spec_constant
     workgroup_size_y,
     workgroup_size_z,
     work_dim,
+    global_offset_x,
+    global_offset_y,
+    global_offset_z,
 };
 
 class spir_binary {

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -477,6 +477,23 @@ cl_int cvk_command_kernel::dispatch_uniform_region(const cvk_ndrange& region) {
         specConstants[dim_id] = m_dimensions;
     }
 
+    // Clspv can allocate spec constants for global offset.
+    where = constants.find(spec_constant::global_offset_x);
+    if (where != constants.end()) {
+      uint32_t offset_id = where->second;
+      specConstants[offset_id] = m_global_offsets[0];
+    }
+    where = constants.find(spec_constant::global_offset_y);
+    if (where != constants.end()) {
+      uint32_t offset_id = where->second;
+      specConstants[offset_id] = m_global_offsets[1];
+    }
+    where = constants.find(spec_constant::global_offset_z);
+    if (where != constants.end()) {
+      uint32_t offset_id = where->second;
+      specConstants[offset_id] = m_global_offsets[2];
+    }
+
     m_pipeline = m_kernel->create_pipeline(specConstants);
 
     if (m_pipeline == VK_NULL_HANDLE) {

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -480,18 +480,18 @@ cl_int cvk_command_kernel::dispatch_uniform_region(const cvk_ndrange& region) {
     // Clspv can allocate spec constants for global offset.
     where = constants.find(spec_constant::global_offset_x);
     if (where != constants.end()) {
-      uint32_t offset_id = where->second;
-      specConstants[offset_id] = m_global_offsets[0];
+        uint32_t offset_id = where->second;
+        specConstants[offset_id] = m_global_offsets[0];
     }
     where = constants.find(spec_constant::global_offset_y);
     if (where != constants.end()) {
-      uint32_t offset_id = where->second;
-      specConstants[offset_id] = m_global_offsets[1];
+        uint32_t offset_id = where->second;
+        specConstants[offset_id] = m_global_offsets[1];
     }
     where = constants.find(spec_constant::global_offset_z);
     if (where != constants.end()) {
-      uint32_t offset_id = where->second;
-      specConstants[offset_id] = m_global_offsets[2];
+        uint32_t offset_id = where->second;
+        specConstants[offset_id] = m_global_offsets[2];
     }
 
     m_pipeline = m_kernel->create_pipeline(specConstants);

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -233,9 +233,9 @@ kernel void test(global int* out) {
                                buffer_size, nullptr);
     SetKernelArg(kernel, 0, buffer);
 
-    size_t gws[3] = {1,1,1};
-    size_t lws[3] = {1,1,1};
-    size_t offset[3] = {123,234,345};
+    size_t gws[3] = {1, 1, 1};
+    size_t lws[3] = {1, 1, 1};
+    size_t offset[3] = {123, 234, 345};
     EnqueueNDRangeKernel(kernel, 3, offset, gws, lws);
 
     // Complete execution
@@ -272,9 +272,9 @@ kernel void test(global int* out) {
                                buffer_size, nullptr);
     SetKernelArg(kernel, 0, buffer);
 
-    size_t gws[3] = {1,1,1};
-    size_t lws[3] = {1,1,1};
-    size_t offset[3] = {101,202,303};
+    size_t gws[3] = {1, 1, 1};
+    size_t lws[3] = {1, 1, 1};
+    size_t offset[3] = {101, 202, 303};
     EnqueueNDRangeKernel(kernel, 3, offset, gws, lws);
 
     // Complete execution


### PR DESCRIPTION
* Parse global offset spec constants
* Provide values for global offset spec constants in kernel enqueue
* add tests for both spec constant and push constant

Clspv generates global offset as a spec constant unless `-global-offset-push-constant` is specified or the language is CL2.0 or CL C++. The latter because of all the other global data that is needed for non-uniform nd ranges.