### PR TITLE
Add CLVK_SKIP_SPIRV_CAPABILITY_CHECK option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,5 @@ variables. Here's a quick guide:
   that support `VK_EXT_calibrated_timestamps`
   (see [#110](https://github.com/kpet/clvk/issues/110)).
 
+* `CLVK_SKIP_SPIRV_CAPABILITY_CHECK` to avoid checking whether the Vulkan device
+  supports all of the SPIR-V capabilities declared by each SPIR-V module.

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1149,8 +1149,14 @@ void cvk_program::do_build() {
     }
 
     // Check capabilities against the device.
+    char* skip_capability_check_env =
+        getenv("CLVK_SKIP_SPIRV_CAPABILITY_CHECK");
+    bool skip_capability_check = false;
+    if (skip_capability_check_env &&
+        strcmp(skip_capability_check_env, "1") == 0)
+        skip_capability_check = true;
     if ((m_binary_type == CL_PROGRAM_BINARY_TYPE_EXECUTABLE) &&
-        !check_capabilities(device)) {
+        !skip_capability_check && !check_capabilities(device)) {
         cvk_error("Missing support for required SPIR-V capabilities.");
         complete_operation(device, CL_BUILD_ERROR);
         return;


### PR DESCRIPTION
This is a useful option for developers. Sometimes I want to force clvk to run a shader that uses an unsupported capability, because I know the functionality I need is actually implemented (there might be other parts of the capability that I don't need that are not supported, hence why the device doesn't advertise the capability).