### PR TITLE
Add workaround for NVIDIA driver bug

### DIFF
--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -655,6 +655,10 @@ cl_int cvk_command_kernel::build() {
                                      VK_ACCESS_MEMORY_READ_BIT |
                                          VK_ACCESS_MEMORY_WRITE_BIT};
 
+    // Workaround for a bug on some NVIDIA devices.
+    // This should already be covered by VK_ACCESS_MEMORY_READ_BIT.
+    memoryBarrier.dstAccessMask |= VK_ACCESS_SHADER_READ_BIT;
+
     vkCmdPipelineBarrier(
         m_command_buffer,
         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, // srcStageMask


### PR DESCRIPTION
Since this should be a no-op on devices that don't have this bug I figured it's OK to do this unconditionally - let me know if you disagree. I'll try to make a minimal reproducer to send to NVIDIA and add to Vulkan CTS in the meantime.