### PR TITLE
Batch kernel dispatches in the same command buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,6 @@ variables. Here's a quick guide:
 
 * `CLVK_SKIP_SPIRV_CAPABILITY_CHECK` to avoid checking whether the Vulkan device
   supports all of the SPIR-V capabilities declared by each SPIR-V module.
+
+* `CLVK_MAX_BATCH_SIZE` to control the maximum number of commands that can be
+  recorded in a single command buffer.

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1030,10 +1030,8 @@ cl_int cvk_enqueue_marker_with_wait_list(cvk_command_queue* command_queue,
 
     auto cmd = new cvk_command_dep(command_queue, CL_COMMAND_MARKER);
 
-    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
                                              event_wait_list, event);
-
-    return CL_SUCCESS;
 }
 
 cl_int CLVK_API_CALL clEnqueueMarkerWithWaitList(
@@ -1071,10 +1069,8 @@ cl_int cvk_enqueue_barrier_with_wait_list(cvk_command_queue* command_queue,
 
     auto cmd = new cvk_command_dep(command_queue, CL_COMMAND_BARRIER);
 
-    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
                                              event_wait_list, event);
-
-    return CL_SUCCESS;
 }
 
 cl_int CLVK_API_CALL clEnqueueBarrierWithWaitList(
@@ -1557,10 +1553,8 @@ cl_int CLVK_API_CALL clEnqueueMigrateMemObjects(
     auto cmd =
         new cvk_command_dep(command_queue, CL_COMMAND_MIGRATE_MEM_OBJECTS);
 
-    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
                                              event_wait_list, event);
-
-    return CL_SUCCESS;
 }
 
 cl_int CLVK_API_CALL clGetMemObjectInfo(cl_mem mem, cl_mem_info param_name,
@@ -2858,10 +2852,8 @@ cl_int CLVK_API_CALL clEnqueueFillBuffer(
                                            static_cast<cvk_buffer*>(buffer),
                                            offset, size, pattern, pattern_size);
 
-    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
                                              event_wait_list, event);
-
-    return CL_SUCCESS;
 }
 
 cl_int CLVK_API_CALL clEnqueueCopyBuffer(cl_command_queue cq, cl_mem srcbuf,
@@ -2900,10 +2892,8 @@ cl_int CLVK_API_CALL clEnqueueCopyBuffer(cl_command_queue cq, cl_mem srcbuf,
         static_cast<cvk_buffer*>(src_buffer),
         static_cast<cvk_buffer*>(dst_buffer), src_offset, dst_offset, size);
 
-    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
                                              event_wait_list, event);
-
-    return CL_SUCCESS;
 }
 
 cl_int CLVK_API_CALL clEnqueueCopyBufferRect(
@@ -2984,10 +2974,8 @@ cl_int CLVK_API_CALL clEnqueueCopyBufferRect(
     auto cmd = new cvk_command_copy_buffer_rect(
         command_queue, srcbuf, dstbuf, src_origin, dst_origin, region,
         src_row_pitch, src_slice_pitch, dst_row_pitch, dst_slice_pitch);
-    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
                                              event_wait_list, event);
-
-    return CL_SUCCESS;
 }
 
 void* CLVK_API_CALL clEnqueueMapBuffer(cl_command_queue cq, cl_mem buf,
@@ -3128,10 +3116,8 @@ cl_int CLVK_API_CALL clEnqueueUnmapMemObject(cl_command_queue cq, cl_mem mem,
         cmd = new cvk_command_unmap_buffer(command_queue, buffer, mapped_ptr);
     }
 
-    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
                                              event_wait_list, event);
-
-    return CL_SUCCESS;
 }
 
 cl_int cvk_enqueue_ndrange_kernel(cvk_command_queue* command_queue,
@@ -3251,16 +3237,8 @@ cl_int cvk_enqueue_ndrange_kernel(cvk_command_queue* command_queue,
         new cvk_command_kernel(command_queue, kernel, dims, global_offsets,
                                global_size, workgroup_size);
 
-    cl_int err = cmd->build();
-
-    if (err != CL_SUCCESS) {
-        return err;
-    }
-
-    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
                                              event_wait_list, event);
-
-    return CL_SUCCESS;
 }
 
 cl_int CLVK_API_CALL clEnqueueTask(cl_command_queue command_queue,
@@ -4209,10 +4187,8 @@ clEnqueueCopyImage(cl_command_queue cq, cl_mem src_image, cl_mem dst_image,
         return err;
     }
 
-    command_queue->enqueue_command_with_deps(
+    return command_queue->enqueue_command_with_deps(
         cmd.release(), num_events_in_wait_list, event_wait_list, event);
-
-    return CL_SUCCESS;
 }
 
 cl_int CLVK_API_CALL clEnqueueFillImage(
@@ -4304,9 +4280,8 @@ cl_int CLVK_API_CALL clEnqueueFillImage(
                                        std::move(commands));
 
     // Enqueue combined command
-    command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
+    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
                                              event_wait_list, event);
-    return CL_SUCCESS;
 }
 
 cl_int CLVK_API_CALL clEnqueueCopyImageToBuffer(
@@ -4382,10 +4357,8 @@ cl_int CLVK_API_CALL clEnqueueCopyImageToBuffer(
         return err;
     }
 
-    command_queue->enqueue_command_with_deps(
+    return command_queue->enqueue_command_with_deps(
         cmd.release(), num_events_in_wait_list, event_wait_list, event);
-
-    return CL_SUCCESS;
 }
 
 cl_int CLVK_API_CALL clEnqueueCopyBufferToImage(
@@ -4461,10 +4434,8 @@ cl_int CLVK_API_CALL clEnqueueCopyBufferToImage(
         return err;
     }
 
-    command_queue->enqueue_command_with_deps(
+    return command_queue->enqueue_command_with_deps(
         cmd.release(), num_events_in_wait_list, event_wait_list, event);
-
-    return CL_SUCCESS;
 }
 
 void* cvk_enqueue_map_image(cl_command_queue cq, cl_mem img,

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1030,8 +1030,8 @@ cl_int cvk_enqueue_marker_with_wait_list(cvk_command_queue* command_queue,
 
     auto cmd = new cvk_command_dep(command_queue, CL_COMMAND_MARKER);
 
-    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
-                                             event_wait_list, event);
+    return command_queue->enqueue_command_with_deps(
+        cmd, num_events_in_wait_list, event_wait_list, event);
 }
 
 cl_int CLVK_API_CALL clEnqueueMarkerWithWaitList(
@@ -1069,8 +1069,8 @@ cl_int cvk_enqueue_barrier_with_wait_list(cvk_command_queue* command_queue,
 
     auto cmd = new cvk_command_dep(command_queue, CL_COMMAND_BARRIER);
 
-    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
-                                             event_wait_list, event);
+    return command_queue->enqueue_command_with_deps(
+        cmd, num_events_in_wait_list, event_wait_list, event);
 }
 
 cl_int CLVK_API_CALL clEnqueueBarrierWithWaitList(
@@ -1553,8 +1553,8 @@ cl_int CLVK_API_CALL clEnqueueMigrateMemObjects(
     auto cmd =
         new cvk_command_dep(command_queue, CL_COMMAND_MIGRATE_MEM_OBJECTS);
 
-    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
-                                             event_wait_list, event);
+    return command_queue->enqueue_command_with_deps(
+        cmd, num_events_in_wait_list, event_wait_list, event);
 }
 
 cl_int CLVK_API_CALL clGetMemObjectInfo(cl_mem mem, cl_mem_info param_name,
@@ -2852,8 +2852,8 @@ cl_int CLVK_API_CALL clEnqueueFillBuffer(
                                            static_cast<cvk_buffer*>(buffer),
                                            offset, size, pattern, pattern_size);
 
-    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
-                                             event_wait_list, event);
+    return command_queue->enqueue_command_with_deps(
+        cmd, num_events_in_wait_list, event_wait_list, event);
 }
 
 cl_int CLVK_API_CALL clEnqueueCopyBuffer(cl_command_queue cq, cl_mem srcbuf,
@@ -2892,8 +2892,8 @@ cl_int CLVK_API_CALL clEnqueueCopyBuffer(cl_command_queue cq, cl_mem srcbuf,
         static_cast<cvk_buffer*>(src_buffer),
         static_cast<cvk_buffer*>(dst_buffer), src_offset, dst_offset, size);
 
-    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
-                                             event_wait_list, event);
+    return command_queue->enqueue_command_with_deps(
+        cmd, num_events_in_wait_list, event_wait_list, event);
 }
 
 cl_int CLVK_API_CALL clEnqueueCopyBufferRect(
@@ -2974,8 +2974,8 @@ cl_int CLVK_API_CALL clEnqueueCopyBufferRect(
     auto cmd = new cvk_command_copy_buffer_rect(
         command_queue, srcbuf, dstbuf, src_origin, dst_origin, region,
         src_row_pitch, src_slice_pitch, dst_row_pitch, dst_slice_pitch);
-    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
-                                             event_wait_list, event);
+    return command_queue->enqueue_command_with_deps(
+        cmd, num_events_in_wait_list, event_wait_list, event);
 }
 
 void* CLVK_API_CALL clEnqueueMapBuffer(cl_command_queue cq, cl_mem buf,
@@ -3116,8 +3116,8 @@ cl_int CLVK_API_CALL clEnqueueUnmapMemObject(cl_command_queue cq, cl_mem mem,
         cmd = new cvk_command_unmap_buffer(command_queue, buffer, mapped_ptr);
     }
 
-    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
-                                             event_wait_list, event);
+    return command_queue->enqueue_command_with_deps(
+        cmd, num_events_in_wait_list, event_wait_list, event);
 }
 
 cl_int cvk_enqueue_ndrange_kernel(cvk_command_queue* command_queue,
@@ -3237,8 +3237,8 @@ cl_int cvk_enqueue_ndrange_kernel(cvk_command_queue* command_queue,
         new cvk_command_kernel(command_queue, kernel, dims, global_offsets,
                                global_size, workgroup_size);
 
-    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
-                                             event_wait_list, event);
+    return command_queue->enqueue_command_with_deps(
+        cmd, num_events_in_wait_list, event_wait_list, event);
 }
 
 cl_int CLVK_API_CALL clEnqueueTask(cl_command_queue command_queue,
@@ -4280,8 +4280,8 @@ cl_int CLVK_API_CALL clEnqueueFillImage(
                                        std::move(commands));
 
     // Enqueue combined command
-    return command_queue->enqueue_command_with_deps(cmd, num_events_in_wait_list,
-                                             event_wait_list, event);
+    return command_queue->enqueue_command_with_deps(
+        cmd, num_events_in_wait_list, event_wait_list, event);
 }
 
 cl_int CLVK_API_CALL clEnqueueCopyImageToBuffer(

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -775,6 +775,11 @@ cl_int cvk_command_kernel_group::do_action() {
     for (auto& kcmd : m_kernel_commands) {
         auto ev = kcmd->event();
         if (profiling) {
+            auto ts_group_submit =
+                m_event->get_profiling_info(CL_PROFILING_COMMAND_SUBMIT);
+            ev->set_profiling_info(CL_PROFILING_COMMAND_SUBMIT,
+                                   ts_group_submit);
+
             if (gQueueProfilingUsesTimestampQueries) {
                 auto perr = kcmd->set_profiling_info_from_query_results();
                 // Report the first error if no errors were present

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -126,8 +126,8 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
             m_kernel_group = nullptr;
         }
 
-        // Create a standalone batch for a non-batchable kernel command
         if (is_kernel_command) {
+            // Create a standalone batch for a non-batchable kernel command
             auto group = new cvk_command_kernel_group(this);
             group->set_dependencies(cmd->dependencies());
 
@@ -139,9 +139,9 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
                 return CL_OUT_OF_RESOURCES;
             }
             m_groups.back()->commands.push_back(group);
+        } else {
+            m_groups.back()->commands.push_back(cmd);
         }
-
-        m_groups.back()->commands.push_back(cmd);
     }
 
     cvk_debug_fn("enqueued command %p, event %p", cmd, cmd->event());

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -102,7 +102,6 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
         if (!m_kernel_group) {
             // Create a new kernel batch
             m_kernel_group = new cvk_command_kernel_group(this);
-            m_groups.back()->commands.push_back(m_kernel_group);
         }
 
         // Add kernel to current batch
@@ -193,6 +192,7 @@ cl_int cvk_command_queue::end_current_kernel_group() {
         if (!m_kernel_group->end()) {
             return CL_OUT_OF_RESOURCES;
         }
+        m_groups.back()->commands.push_back(m_kernel_group);
         m_kernel_group = nullptr;
     }
     return CL_SUCCESS;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -26,7 +26,8 @@ static cvk_executor_thread_pool* get_thread_pool() {
 cvk_command_queue::cvk_command_queue(cvk_context* ctx, cvk_device* device,
                                      cl_command_queue_properties properties)
     : api_object(ctx), m_device(device), m_properties(properties),
-      m_executor(nullptr), m_vulkan_queue(device->vulkan_queue_allocate()),
+      m_executor(nullptr), m_kernel_group(nullptr),
+      m_vulkan_queue(device->vulkan_queue_allocate()),
       m_command_pool(device->vulkan_device(), m_vulkan_queue.queue_family()) {
 
     m_groups.push_back(std::make_unique<cvk_command_group>());
@@ -51,11 +52,83 @@ cvk_command_queue::~cvk_command_queue() {
     }
 }
 
-void cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
+namespace {
+
+bool is_command_batchable(cvk_command* cmd) {
+    bool batchable_type = (cmd->type() == CL_COMMAND_NDRANGE_KERNEL) ||
+                          (cmd->type() == CL_COMMAND_TASK);
+    bool unresolved_user_event_dependencies = false;
+    bool unresolved_other_queue_dependencies = false;
+
+    for (auto ev : cmd->dependencies()) {
+        if (ev->is_user_event()) {
+            if (!ev->completed()) {
+                unresolved_user_event_dependencies = true;
+                break;
+            } else {
+                continue;
+            }
+        }
+
+        if ((ev->queue() != cmd->queue()) && !ev->completed()) {
+            unresolved_other_queue_dependencies = true;
+            break;
+        }
+    }
+
+    return batchable_type && !unresolved_user_event_dependencies &&
+           !unresolved_other_queue_dependencies;
+}
+
+} // namespace
+
+cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
 
     std::lock_guard<std::mutex> lock(m_lock);
 
-    m_groups.back()->commands.push_back(cmd);
+    cl_int err;
+
+    bool is_kernel_command = cmd->type() == CL_COMMAND_NDRANGE_KERNEL ||
+                             cmd->type() == CL_COMMAND_TASK;
+    if (is_command_batchable(cmd)) {
+        if (!m_kernel_group) {
+            // Create a new kernel batch
+            m_kernel_group = new cvk_command_kernel_group(this);
+            m_groups.back()->commands.push_back(m_kernel_group);
+        }
+
+        // Add kernel to current batch
+        CVK_ASSERT(is_kernel_command);
+        err = m_kernel_group->add_kernel(static_cast<cvk_command_kernel*>(cmd));
+        if (err != CL_SUCCESS) {
+            return err;
+        }
+    } else {
+        if (m_kernel_group) {
+            // End the current kernel batch
+            if (!m_kernel_group->end()) {
+                return CL_OUT_OF_RESOURCES;
+            }
+            m_kernel_group = nullptr;
+        }
+
+        // Create a standalone batch for a non-batchable kernel command
+        if (is_kernel_command) {
+            auto group = new cvk_command_kernel_group(this);
+            group->set_dependencies(cmd->dependencies());
+
+            err = group->add_kernel(static_cast<cvk_command_kernel*>(cmd));
+            if (err != CL_SUCCESS) {
+                return err;
+            }
+            if (!group->end()) {
+                return CL_OUT_OF_RESOURCES;
+            }
+            m_groups.back()->commands.push_back(group);
+        }
+
+        m_groups.back()->commands.push_back(cmd);
+    }
 
     cvk_debug_fn("enqueued command %p, event %p", cmd, cmd->event());
 
@@ -68,14 +141,15 @@ void cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
         *event = cmd->event();
         cvk_debug_fn("returning event %p", *event);
     }
+
+    return CL_SUCCESS;
 }
 
-void cvk_command_queue::enqueue_command_with_deps(cvk_command* cmd,
-                                                  cl_uint num_dep_events,
-                                                  _cl_event* const* dep_events,
-                                                  _cl_event** event) {
+cl_int cvk_command_queue::enqueue_command_with_deps(
+    cvk_command* cmd, cl_uint num_dep_events, _cl_event* const* dep_events,
+    _cl_event** event) {
     cmd->set_dependencies(num_dep_events, dep_events);
-    enqueue_command(cmd, event);
+    return enqueue_command(cmd, event);
 }
 
 cl_int cvk_command_queue::enqueue_command_with_deps(
@@ -84,9 +158,10 @@ cl_int cvk_command_queue::enqueue_command_with_deps(
     cmd->set_dependencies(num_dep_events, dep_events);
 
     _cl_event* evt;
-    enqueue_command(cmd, &evt);
-
-    cl_int err = CL_SUCCESS;
+    cl_int err = enqueue_command(cmd, &evt);
+    if (err != CL_SUCCESS) {
+        return err;
+    }
 
     if (blocking) {
         err = wait_for_events(1, &evt);
@@ -183,65 +258,6 @@ void cvk_executor_thread::executor() {
     }
 }
 
-namespace {
-
-bool is_command_batchable(cvk_command* cmd) {
-    bool batchable_type = (cmd->type() == CL_COMMAND_NDRANGE_KERNEL) ||
-                          (cmd->type() == CL_COMMAND_TASK);
-    bool unresolved_user_event_dependencies = false;
-    bool unresolved_other_queue_dependencies = false;
-
-    for (auto ev : cmd->dependencies()) {
-        if (ev->is_user_event()) {
-            if (!ev->completed()) {
-                unresolved_user_event_dependencies = true;
-                break;
-            } else {
-                continue;
-            }
-        }
-
-        if ((ev->queue() != cmd->queue()) && !ev->completed()) {
-            unresolved_other_queue_dependencies = true;
-            break;
-        }
-    }
-
-    return batchable_type && !unresolved_user_event_dependencies &&
-           !unresolved_other_queue_dependencies;
-}
-
-static std::unique_ptr<cvk_command_group>
-batch_kernels(std::unique_ptr<cvk_command_group> group) {
-    std::unique_ptr<cvk_command_group> newgroup =
-        std::make_unique<cvk_command_group>();
-    cvk_command_kernel_group* kgroup = nullptr;
-
-    for (auto cmd : group->commands) {
-
-        if (is_command_batchable(cmd)) {
-            if (kgroup == nullptr) {
-                kgroup = new cvk_command_kernel_group(cmd->queue());
-            }
-            kgroup->add_kernel(static_cast<cvk_command_kernel*>(cmd));
-        } else {
-            if (kgroup != nullptr) {
-                newgroup->commands.push_back(kgroup);
-                kgroup = nullptr;
-            }
-            newgroup->commands.push_back(cmd);
-        }
-    }
-
-    if (kgroup != nullptr) {
-        newgroup->commands.push_back(kgroup);
-    }
-
-    return newgroup;
-}
-
-} // namespace
-
 cl_int cvk_command_queue::flush(cvk_event** event) {
 
     cvk_info_fn("queue = %p, event = %p", this, event);
@@ -250,6 +266,15 @@ cl_int cvk_command_queue::flush(cvk_event** event) {
     std::unique_ptr<cvk_command_group> group;
     {
         std::lock_guard<std::mutex> lock(m_lock);
+
+        // End current kernel group
+        if (m_kernel_group) {
+            if (!m_kernel_group->end()) {
+                return CL_OUT_OF_RESOURCES;
+            }
+            m_kernel_group = nullptr;
+        }
+
         if (m_groups.front()->commands.size() == 0) {
             return CL_SUCCESS;
         }
@@ -270,10 +295,6 @@ cl_int cvk_command_queue::flush(cvk_event** event) {
                 CL_PROFILING_COMMAND_SUBMIT);
         }
     }
-
-    // Batch kernels for submission
-    group = batch_kernels(std::move(group));
-    CVK_ASSERT(group->commands.size() > 0);
 
     // Create execution thread if it doesn't exist
     {
@@ -355,26 +376,27 @@ bool cvk_command_buffer::submit_and_wait() {
     return true;
 }
 
-void cvk_command_kernel::update_global_push_constants() {
+void cvk_command_kernel::update_global_push_constants(
+    cvk_command_buffer& command_buffer) {
     auto program = m_kernel->program();
 
     if (auto pc = program->push_constant(pushconstant::global_offset)) {
         CVK_ASSERT(pc->size == 12);
-        vkCmdPushConstants(m_command_buffer, m_kernel->pipeline_layout(),
+        vkCmdPushConstants(command_buffer, m_kernel->pipeline_layout(),
                            VK_SHADER_STAGE_COMPUTE_BIT, pc->offset, pc->size,
                            &m_global_offsets);
     }
 
     if (auto pc = program->push_constant(pushconstant::enqueued_local_size)) {
         CVK_ASSERT(pc->size == 12);
-        vkCmdPushConstants(m_command_buffer, m_kernel->pipeline_layout(),
+        vkCmdPushConstants(command_buffer, m_kernel->pipeline_layout(),
                            VK_SHADER_STAGE_COMPUTE_BIT, pc->offset, pc->size,
                            &m_lws);
     }
 
     if (auto pc = program->push_constant(pushconstant::global_size)) {
         CVK_ASSERT(pc->size == 12);
-        vkCmdPushConstants(m_command_buffer, m_kernel->pipeline_layout(),
+        vkCmdPushConstants(command_buffer, m_kernel->pipeline_layout(),
                            VK_SHADER_STAGE_COMPUTE_BIT, pc->offset, pc->size,
                            &m_gws);
     }
@@ -389,7 +411,7 @@ void cvk_command_kernel::update_global_push_constants() {
                 num_workgroups[i]++;
             }
         }
-        vkCmdPushConstants(m_command_buffer, m_kernel->pipeline_layout(),
+        vkCmdPushConstants(command_buffer, m_kernel->pipeline_layout(),
                            VK_SHADER_STAGE_COMPUTE_BIT, pc->offset, pc->size,
                            &num_workgroups);
     }
@@ -406,7 +428,7 @@ void cvk_command_kernel::update_global_push_constants() {
                 uint32_t size = round_up(arg.size, 4);
                 uint32_t offset = arg.offset & ~0x3U;
                 vkCmdPushConstants(
-                    m_command_buffer, m_kernel->pipeline_layout(),
+                    command_buffer, m_kernel->pipeline_layout(),
                     VK_SHADER_STAGE_COMPUTE_BIT, offset, size,
                     &m_argument_values->pod_pushconstant_buffer()[offset]);
             }
@@ -414,7 +436,8 @@ void cvk_command_kernel::update_global_push_constants() {
     }
 }
 
-cl_int cvk_command_kernel::dispatch_uniform_region(const cvk_ndrange& region) {
+cl_int cvk_command_kernel::dispatch_uniform_region(
+    const cvk_ndrange& region, cvk_command_buffer& command_buffer) {
 
     // Calculate number of workgroups for region
     std::array<uint32_t, 3> num_workgroups;
@@ -505,7 +528,7 @@ cl_int cvk_command_kernel::dispatch_uniform_region(const cvk_ndrange& region) {
         return CL_OUT_OF_RESOURCES;
     }
 
-    vkCmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+    vkCmdBindPipeline(command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
                       m_pipeline);
 
     if (auto pc = program->push_constant(pushconstant::region_offset)) {
@@ -515,7 +538,7 @@ cl_int cvk_command_kernel::dispatch_uniform_region(const cvk_ndrange& region) {
             m_global_offsets[1] + region.offset[1],
             m_global_offsets[2] + region.offset[2],
         };
-        vkCmdPushConstants(m_command_buffer, m_kernel->pipeline_layout(),
+        vkCmdPushConstants(command_buffer, m_kernel->pipeline_layout(),
                            VK_SHADER_STAGE_COMPUTE_BIT, pc->offset, pc->size,
                            &region_offsets);
     }
@@ -527,18 +550,19 @@ cl_int cvk_command_kernel::dispatch_uniform_region(const cvk_ndrange& region) {
             region.offset[1] / m_lws[1],
             region.offset[2] / m_lws[2],
         };
-        vkCmdPushConstants(m_command_buffer, m_kernel->pipeline_layout(),
+        vkCmdPushConstants(command_buffer, m_kernel->pipeline_layout(),
                            VK_SHADER_STAGE_COMPUTE_BIT, pc->offset, pc->size,
                            &region_group_offsets);
     }
 
-    vkCmdDispatch(m_command_buffer, num_workgroups[0], num_workgroups[1],
+    vkCmdDispatch(command_buffer, num_workgroups[0], num_workgroups[1],
                   num_workgroups[2]);
 
     return CL_SUCCESS;
 }
 
-cl_int cvk_command_kernel::build_and_dispatch_regions() {
+cl_int cvk_command_kernel::build_and_dispatch_regions(
+    cvk_command_buffer& command_buffer) {
 
     // Split non-uniform NDRange into uniform regions
     cvk_ndrange regions[8];
@@ -576,7 +600,7 @@ cl_int cvk_command_kernel::build_and_dispatch_regions() {
                   regions[i].lws[0], regions[i].lws[1], regions[i].lws[2],
                   regions[i].offset[0], regions[i].offset[1],
                   regions[i].offset[2]);
-        auto err = dispatch_uniform_region(regions[i]);
+        auto err = dispatch_uniform_region(regions[i], command_buffer);
         if (err != CL_SUCCESS) {
             return err;
         }
@@ -585,7 +609,7 @@ cl_int cvk_command_kernel::build_and_dispatch_regions() {
     return CL_SUCCESS;
 }
 
-cl_int cvk_command_kernel::build() {
+cl_int cvk_command_kernel::build(cvk_command_buffer& command_buffer) {
 
     // TODO check against the size specified at compile time, if any
     // TODO CL_INVALID_KERNEL_ARGS if the kernel argument values have not been
@@ -618,32 +642,27 @@ cl_int cvk_command_kernel::build() {
         }
     }
 
-    // Start recording commands
-    if (!m_command_buffer.begin()) {
-        return CL_OUT_OF_RESOURCES;
-    }
-
     // Sample timestamp if profiling
     if (profiling && !is_profiled_by_executor()) {
-        vkCmdResetQueryPool(m_command_buffer, m_query_pool, 0,
+        vkCmdResetQueryPool(command_buffer, m_query_pool, 0,
                             NUM_POOL_QUERIES_PER_KERNEL);
-        vkCmdWriteTimestamp(m_command_buffer,
+        vkCmdWriteTimestamp(command_buffer,
                             VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, m_query_pool,
                             POOL_QUERY_KERNEL_START);
     }
 
     // Bind descriptors and update push constants
     if (m_kernel->num_set_layouts() > 0) {
-        vkCmdBindDescriptorSets(
-            m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-            m_kernel->pipeline_layout(), 0, m_kernel->num_set_layouts(),
-            m_descriptor_sets.data(), 0, 0);
+        vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                m_kernel->pipeline_layout(), 0,
+                                m_kernel->num_set_layouts(),
+                                m_descriptor_sets.data(), 0, 0);
     }
 
-    update_global_push_constants();
+    update_global_push_constants(command_buffer);
 
     // Dispatch work
-    auto err = build_and_dispatch_regions();
+    auto err = build_and_dispatch_regions(command_buffer);
     if (err != CL_SUCCESS) {
         return err;
     }
@@ -660,7 +679,7 @@ cl_int cvk_command_kernel::build() {
     memoryBarrier.dstAccessMask |= VK_ACCESS_SHADER_READ_BIT;
 
     vkCmdPipelineBarrier(
-        m_command_buffer,
+        command_buffer,
         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, // srcStageMask
         VK_PIPELINE_STAGE_HOST_BIT | VK_PIPELINE_STAGE_TRANSFER_BIT |
             VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, // dstStageMask
@@ -674,14 +693,9 @@ cl_int cvk_command_kernel::build() {
 
     // Sample timestamp if profiling
     if (profiling && !is_profiled_by_executor()) {
-        vkCmdWriteTimestamp(m_command_buffer,
+        vkCmdWriteTimestamp(command_buffer,
                             VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, m_query_pool,
                             POOL_QUERY_KERNEL_END);
-    }
-
-    // End command recording
-    if (!m_command_buffer.end()) {
-        return CL_OUT_OF_RESOURCES;
     }
 
     return CL_SUCCESS;
@@ -712,31 +726,11 @@ cl_int cvk_command_kernel::set_profiling_info_from_query_results() {
 }
 
 cl_int cvk_command_kernel::do_action() {
-    if (!m_command_buffer.submit_and_wait()) {
-        return CL_OUT_OF_RESOURCES;
-    }
-
-    bool profiling = m_queue->has_property(CL_QUEUE_PROFILING_ENABLE);
-
-    cl_int err = CL_COMPLETE;
-
-    if (profiling && !is_profiled_by_executor()) {
-        err = set_profiling_info_from_query_results();
-    }
-
-    return err;
+    cvk_error("kernel command executed outside of a batch");
+    return CL_INVALID_OPERATION;
 }
 
 cl_int cvk_command_kernel_group::submit_and_wait() {
-    std::vector<VkCommandBuffer> buffers;
-    for (auto& kcmd : m_kernel_commands) {
-        auto& cmd_buf = kcmd->command_buffer();
-        VkCommandBuffer vkbuf = cmd_buf;
-        buffers.push_back(vkbuf);
-    }
-
-    auto& queue = m_queue->vulkan_queue();
-
     bool profiling = m_queue->has_property(CL_QUEUE_PROFILING_ENABLE);
 
     if (profiling && !gQueueProfilingUsesTimestampQueries) {
@@ -744,15 +738,7 @@ cl_int cvk_command_kernel_group::submit_and_wait() {
             CL_PROFILING_COMMAND_START);
     }
 
-    VkResult res = queue.submit(buffers);
-
-    if (res != VK_SUCCESS) {
-        return CL_OUT_OF_RESOURCES;
-    }
-
-    res = queue.wait_idle();
-
-    if (res != VK_SUCCESS) {
+    if (!m_command_buffer->submit_and_wait()) {
         return CL_OUT_OF_RESOURCES;
     }
 
@@ -765,6 +751,8 @@ cl_int cvk_command_kernel_group::submit_and_wait() {
 }
 
 cl_int cvk_command_kernel_group::do_action() {
+
+    cvk_info("executing batch of %lu kernels", m_kernel_commands.size());
 
     cl_int status = submit_and_wait();
 
@@ -947,8 +935,8 @@ cl_int cvk_command_copy_buffer::do_action() {
 }
 
 namespace {
-template<typename T>
-void memset_multi(void *dst, void *pattern_ptr, size_t size) {
+template <typename T>
+void memset_multi(void* dst, void* pattern_ptr, size_t size) {
     T pattern = *static_cast<T*>(pattern_ptr);
     auto end = pointer_offset(dst, size);
     while (dst < end) {
@@ -956,7 +944,7 @@ void memset_multi(void *dst, void *pattern_ptr, size_t size) {
         dst = pointer_offset(dst, sizeof(pattern));
     }
 }
-}
+} // namespace
 
 cl_int cvk_command_fill_buffer::do_action() {
     memobj_map_holder map_holder{m_buffer};

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -267,6 +267,7 @@ struct cvk_command_queue : public _cl_command_queue, api_object {
 
 private:
     CHECK_RETURN cl_int enqueue_command(cvk_command* cmd, _cl_event** event);
+    CHECK_RETURN cl_int end_current_kernel_group();
     void executor();
 
     cvk_device* m_device;

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -276,6 +276,8 @@ private:
 
     std::mutex m_lock;
     std::deque<std::unique_ptr<cvk_command_group>> m_groups;
+
+    cl_uint m_max_batch_size;
     cvk_command_kernel_group* m_kernel_group;
 
     cvk_vulkan_queue_wrapper& m_vulkan_queue;
@@ -670,6 +672,8 @@ struct cvk_command_kernel_group : public cvk_command {
     }
 
     CHECK_RETURN bool end() { return m_command_buffer->end(); }
+
+    cl_uint batch_size() { return m_kernel_commands.size(); }
 
     bool is_profiled_by_executor() const override { return false; }
 

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -628,6 +628,7 @@ struct cvk_command_kernel : public cvk_command {
 
     CHECK_RETURN cl_int set_profiling_info_from_query_results();
 
+    CHECK_RETURN cl_int build();
     CHECK_RETURN cl_int build(cvk_command_buffer& command_buffer);
     virtual cl_int do_action() override;
 
@@ -653,6 +654,8 @@ private:
     VkPipeline m_pipeline;
     VkQueryPool m_query_pool;
     std::unique_ptr<cvk_kernel_argument_values> m_argument_values;
+
+    std::unique_ptr<cvk_command_buffer> m_command_buffer;
 
     static const int NUM_POOL_QUERIES_PER_KERNEL = 2;
     static const int POOL_QUERY_KERNEL_START = 0;


### PR DESCRIPTION
Summary:
* `cvk_command_queue` maintains a `cvk_command_kernel_group`
  - Add new commands to it as long as they are batchable
  - End the group when a non-batchable command is enqueued
* `cvk_command_kernel_group` has a `cvk_command_buffer`
  - Used for all of its kernel commands
* `cvk_command_kernel::build()` now takes a `cvk_command_buffer` parameter
  - Called by `cvk_command_kernel_group::add_kernel()`
* Non-batchable kernel commands are in their own `cvk_command_kernel_group`
  - Avoids splitting batchable/non-batchable logic in `cvk_command_kernel`
* Added `CLVK_MAX_BATCH_SIZE` environment variable
  - Some apps might need to limit this to avoid device timeout
  - Defaults to 10000

Having `cvk_command_kernel::do_action()` be a never-called method is a little awkward. The simplest alternative is to have two different codepaths for batched/non-batched kernels (i.e. two different `::build()` methods, one that receives a command buffer and another that creates one), but this also felt a little unpleasant to me.

This is mostly either a performance win or neutral. However, this does give some performance regressions for certain benchmarks on certain devices. This seems to be related to push constant updates for POD args. I'm still investigating and will try and address in a follow-up soon (though I also don't mind if you want to hold off on this PR until it's resolved).