### PR TITLE
Create command pool with RESET_COMMAND_BUFFER_BIT

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -43,9 +43,8 @@ void cvk_device::init_properties(VkInstance instance) {
     m_driver_properties.pNext = nullptr;
     if (m_properties.apiVersion < VK_MAKE_VERSION(1, 1, 0)) {
         // Use the extension on Vulkan 1.0 platforms
-        auto func = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
-            vkGetInstanceProcAddr(instance,
-                                  "vkGetPhysicalDeviceProperties2KHR"));
+        auto func =
+            GET_INSTANCE_PROC(instance, vkGetPhysicalDeviceProperties2KHR);
         if (!func) {
             cvk_fatal(
                 "Failed to get pointer to vkGetPhysicalDeviceProperties2KHR()");

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -78,9 +78,7 @@ void cvk_device::init_driver_behaviors(VkInstance instance) {
     // List driver behaviors
     cvk_info("Driver behaviors:");
 #define PRINT_BEHAVIOR(name)                                                   \
-    cvk_info("  %s = %s", #name,                                               \
-             (m_driver_behaviors & use_reset_command_buffer_bit) ? "true"      \
-                                                                 : "false")
+    cvk_info("  %s = %s", #name, (m_driver_behaviors & name) ? "true" : "false")
     PRINT_BEHAVIOR(use_reset_command_buffer_bit);
 #undef PRINT_BEHAVIOR
 }

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -315,8 +315,13 @@ struct cvk_device : public _cl_device_id {
         }
     }
 
-    bool use_reset_command_buffer_bit() const {
-        return m_use_reset_command_buffer_bit;
+    // Driver-specific behaviors.
+    enum cvk_driver_behavior
+    {
+        use_reset_command_buffer_bit = 0x00000001,
+    };
+    bool is_driver_behavior_enabled(cvk_driver_behavior behavior) const {
+        return m_driver_behaviors & behavior;
     }
 
 private:
@@ -354,9 +359,6 @@ private:
     VkPhysicalDevice8BitStorageFeaturesKHR m_features_8bit_storage{};
     VkPhysicalDevice16BitStorageFeaturesKHR m_features_16bit_storage{};
 
-    // Driver-specific behaviors.
-    bool m_use_reset_command_buffer_bit = false;
-
     VkDevice m_dev;
     std::vector<const char*> m_vulkan_device_extensions;
 
@@ -367,6 +369,8 @@ private:
     std::vector<cl_name_version_khr> m_extensions;
     std::string m_ils_string;
     std::vector<cl_name_version_khr> m_ils;
+
+    uint32_t m_driver_behaviors;
 
     bool m_has_timer_support;
 };

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -41,7 +41,10 @@ struct cvk_platform;
 struct cvk_device : public _cl_device_id {
 
     cvk_device(cvk_platform* platform, VkPhysicalDevice pd)
-        : m_platform(platform), m_pdev(pd), m_has_timer_support(false) {}
+        : m_platform(platform), m_pdev(pd), m_has_timer_support(false) {
+        vkGetPhysicalDeviceProperties(m_pdev, &m_properties);
+        vkGetPhysicalDeviceMemoryProperties(m_pdev, &m_mem_properties);
+    }
 
     static cvk_device* create(cvk_platform* platform, VkInstance instance,
                               VkPhysicalDevice pdev);
@@ -326,7 +329,7 @@ private:
 
     CHECK_RETURN bool init_queues(uint32_t* num_queues, uint32_t* queue_family);
     CHECK_RETURN bool init_extensions();
-    void init_properties(VkInstance instance);
+    void init_driver_behaviors(VkInstance instance);
     void init_features(VkInstance instance);
     void build_extension_ils_list();
     CHECK_RETURN bool create_vulkan_queues_and_device(uint32_t num_queues,

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -41,10 +41,7 @@ struct cvk_platform;
 struct cvk_device : public _cl_device_id {
 
     cvk_device(cvk_platform* platform, VkPhysicalDevice pd)
-        : m_platform(platform), m_pdev(pd), m_has_timer_support(false) {
-        vkGetPhysicalDeviceProperties(m_pdev, &m_properties);
-        vkGetPhysicalDeviceMemoryProperties(m_pdev, &m_mem_properties);
-    }
+        : m_platform(platform), m_pdev(pd), m_has_timer_support(false) {}
 
     static cvk_device* create(cvk_platform* platform, VkInstance instance,
                               VkPhysicalDevice pdev);
@@ -315,6 +312,10 @@ struct cvk_device : public _cl_device_id {
         }
     }
 
+    bool use_reset_command_buffer_bit() const {
+        return m_use_reset_command_buffer_bit;
+    }
+
 private:
     std::string version_desc() const {
         std::string ret = "CLVK on Vulkan v";
@@ -325,6 +326,7 @@ private:
 
     CHECK_RETURN bool init_queues(uint32_t* num_queues, uint32_t* queue_family);
     CHECK_RETURN bool init_extensions();
+    void init_properties(VkInstance instance);
     void init_features(VkInstance instance);
     void build_extension_ils_list();
     CHECK_RETURN bool create_vulkan_queues_and_device(uint32_t num_queues,
@@ -338,6 +340,7 @@ private:
     cvk_vulkan_extension_functions m_vkfns{};
     VkPhysicalDevice m_pdev;
     VkPhysicalDeviceProperties m_properties;
+    VkPhysicalDeviceDriverPropertiesKHR m_driver_properties;
     VkPhysicalDeviceMemoryProperties m_mem_properties;
     // Vulkan features
     VkPhysicalDeviceFeatures2 m_features{};
@@ -347,6 +350,9 @@ private:
         m_features_ubo_stdlayout{};
     VkPhysicalDevice8BitStorageFeaturesKHR m_features_8bit_storage{};
     VkPhysicalDevice16BitStorageFeaturesKHR m_features_16bit_storage{};
+
+    // Driver-specific behaviors.
+    bool m_use_reset_command_buffer_bit = false;
 
     VkDevice m_dev;
     std::vector<const char*> m_vulkan_device_extensions;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -27,7 +27,7 @@ cvk_command_queue::cvk_command_queue(cvk_context* ctx, cvk_device* device,
                                      cl_command_queue_properties properties)
     : api_object(ctx), m_device(device), m_properties(properties),
       m_executor(nullptr), m_vulkan_queue(device->vulkan_queue_allocate()),
-      m_command_pool(device->vulkan_device(), m_vulkan_queue.queue_family()) {
+      m_command_pool(device, m_vulkan_queue.queue_family()) {
 
     m_groups.push_back(std::make_unique<cvk_command_group>());
 
@@ -306,13 +306,13 @@ VkResult cvk_command_pool::allocate_command_buffer(VkCommandBuffer* cmdbuf) {
         1 // commandBufferCount
     };
 
-    return vkAllocateCommandBuffers(m_device, &commandBufferAllocateInfo,
-                                    cmdbuf);
+    return vkAllocateCommandBuffers(m_device->vulkan_device(),
+                                    &commandBufferAllocateInfo, cmdbuf);
 }
 
 void cvk_command_pool::free_command_buffer(VkCommandBuffer buf) {
     std::lock_guard<std::mutex> lock(m_lock);
-    vkFreeCommandBuffers(m_device, m_command_pool, 1, &buf);
+    vkFreeCommandBuffers(m_device->vulkan_device(), m_command_pool, 1, &buf);
 }
 
 bool cvk_command_buffer::begin() {

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -196,7 +196,8 @@ struct cvk_command_pool {
 
     CHECK_RETURN VkResult init() {
         VkCommandPoolCreateFlags flags = 0;
-        if (m_device->use_reset_command_buffer_bit()) {
+        if (m_device->is_driver_behavior_enabled(
+                cvk_device::use_reset_command_buffer_bit)) {
             flags |= VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
         }
 

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -197,7 +197,7 @@ struct cvk_command_pool {
         // Create command pool
         VkCommandPoolCreateInfo createInfo = {
             VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO, nullptr,
-            0, // flags
+            VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT, // flags
             m_queue_family};
 
         return vkCreateCommandPool(m_device, &createInfo, nullptr,


### PR DESCRIPTION
Avoids creeping memory growth (and subsequent crashes) with some drivers, and gives performance wins in some cases.

For example, the Arm Mali developer guide [says](https://developer.arm.com/documentation/101897/0200/cpu-overheads/command-pools-for-vulkan?lang=en):

> Command pools do not automatically recycle memory from deleted command buffers unless created with the RESET_COMMAND_BUFFER_BIT flag. Pools without this flag do not recycle their memory until the application resets the pool.

It later recommends *against* using `RESET_COMMAND_BUFFER_BIT` (due to potential increase in CPU overheads), but the alternative is using `vkResetCommandPool`, which is more difficult to fit into clvk right now. I didn't see any significant performance drops when using `RESET_COMMAND_BUFFER_BIT` in my own benchmarking, and there were several significant performance gains.