### PR TITLE
Reuse descriptor sets between kernel launches

### DIFF
--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -103,7 +103,13 @@ struct cvk_kernel_argument_values {
           m_kernel_resources(other.m_kernel_resources),
           m_local_args_size(other.m_local_args_size) {}
 
-    ~cvk_kernel_argument_values() {}
+    ~cvk_kernel_argument_values() {
+        for (auto ds : m_descriptor_sets) {
+            if (ds != VK_NULL_HANDLE) {
+                m_entry_point->free_descriptor_set(ds);
+            }
+        }
+    }
 
     static std::shared_ptr<cvk_kernel_argument_values>
     create(cvk_entry_point* entry_point) {

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -22,66 +22,25 @@
 #include "program.hpp"
 
 struct cvk_kernel_argument_values;
-struct cvk_kernel_descriptors;
-
-struct cvk_kernel_descriptors : refcounted {
-    cvk_kernel_descriptors(cvk_entry_point* entry_point)
-        : m_entry_point(entry_point), m_descriptor_sets{VK_NULL_HANDLE} {}
-
-    virtual ~cvk_kernel_descriptors() {
-        for (auto ds : m_descriptor_sets) {
-            if (ds != VK_NULL_HANDLE) {
-                m_entry_point->free_descriptor_set(ds);
-            }
-        }
-    }
-
-    CHECK_RETURN bool init() {
-        return m_entry_point->allocate_descriptor_sets(descriptor_sets());
-    }
-
-    VkDescriptorSet* descriptor_sets() { return m_descriptor_sets.data(); }
-
-    bool create_pod_buffer(const std::vector<uint8_t>& pod_data) {
-        CVK_ASSERT(pod_data.size() >= m_entry_point->pod_buffer_size());
-
-        // Create buffer and copy POD data to it
-        m_pod_buffer = m_entry_point->allocate_pod_buffer();
-        if (m_pod_buffer == nullptr) {
-            return false;
-        }
-        return m_pod_buffer->copy_from(pod_data.data(), 0,
-                                       m_entry_point->pod_buffer_size());
-    }
-
-    VkBuffer pod_vulkan_buffer() const { return m_pod_buffer->vulkan_buffer(); }
-
-private:
-    cvk_entry_point* m_entry_point;
-    std::array<VkDescriptorSet, spir_binary::MAX_DESCRIPTOR_SETS>
-        m_descriptor_sets;
-    std::unique_ptr<cvk_buffer> m_pod_buffer;
-};
-using cvk_kernel_descriptors_holder = refcounted_holder<cvk_kernel_descriptors>;
 
 struct cvk_kernel : public _cl_kernel, api_object {
 
     cvk_kernel(cvk_program* program, const char* name)
         : api_object(program->context()), m_program(program),
-          m_entry_point(nullptr), m_name(name), m_pod_arg(nullptr) {
+          m_entry_point(nullptr), m_name(name) {
         m_program->retain();
     }
 
     CHECK_RETURN cl_int init();
 
     virtual ~cvk_kernel() {
-        m_kernel_descriptors->release();
+        m_argument_values.reset();
         m_program->release();
     }
 
-    CHECK_RETURN bool setup_descriptor_sets(
-        cvk_kernel_descriptors_holder& kernel_descriptors,
-        std::unique_ptr<cvk_kernel_argument_values>& arg_values);
+    std::shared_ptr<cvk_kernel_argument_values> argument_values() const {
+        return m_argument_values;
+    }
 
     CHECK_RETURN cl_int set_arg(cl_uint index, size_t size, const void* value);
     CHECK_RETURN VkPipeline
@@ -114,18 +73,14 @@ struct cvk_kernel : public _cl_kernel, api_object {
     cl_ulong local_mem_size() const;
 
 private:
-    std::unique_ptr<cvk_buffer> allocate_pod_buffer();
-    std::unique_ptr<std::vector<uint8_t>> allocate_pod_host_buffer() const;
     friend cvk_kernel_argument_values;
 
     std::mutex m_lock;
     cvk_program* m_program;
     cvk_entry_point* m_entry_point;
     std::string m_name;
-    const kernel_argument* m_pod_arg;
     std::vector<kernel_argument> m_args;
-    std::unique_ptr<cvk_kernel_argument_values> m_argument_values;
-    cvk_kernel_descriptors_holder m_kernel_descriptors;
+    std::shared_ptr<cvk_kernel_argument_values> m_argument_values;
 };
 
 static inline cvk_kernel* icd_downcast(cl_kernel kernel) {
@@ -136,22 +91,23 @@ using cvk_kernel_holder = refcounted_holder<cvk_kernel>;
 
 struct cvk_kernel_argument_values {
 
-    cvk_kernel_argument_values(cvk_kernel* kernel, uint32_t num_resources)
-        : m_kernel(kernel), m_owns_resources(false),
-          m_kernel_resources(num_resources),
-          m_local_args_size(m_kernel->num_args(), 0) {}
+    cvk_kernel_argument_values(cvk_entry_point* entry_point)
+        : m_entry_point(entry_point), m_is_enqueued(false),
+          m_args(m_entry_point->args()), m_pod_arg(nullptr),
+          m_kernel_resources(m_entry_point->num_resources()),
+          m_local_args_size(m_entry_point->args().size(), 0) {}
 
     cvk_kernel_argument_values(const cvk_kernel_argument_values& other)
-        : m_kernel(other.m_kernel), m_owns_resources(false),
+        : m_entry_point(other.m_entry_point), m_is_enqueued(false),
+          m_args(m_entry_point->args()), m_pod_arg(nullptr),
           m_kernel_resources(other.m_kernel_resources),
           m_local_args_size(other.m_local_args_size) {}
 
-    ~cvk_kernel_argument_values() { release_resources(); }
+    ~cvk_kernel_argument_values() {}
 
-    static std::unique_ptr<cvk_kernel_argument_values>
-    create(cvk_kernel* kernel, uint32_t num_resources) {
-        auto val =
-            std::make_unique<cvk_kernel_argument_values>(kernel, num_resources);
+    static std::shared_ptr<cvk_kernel_argument_values>
+    create(cvk_entry_point* entry_point) {
+        auto val = std::make_shared<cvk_kernel_argument_values>(entry_point);
 
         if (!val->init()) {
             return nullptr;
@@ -160,9 +116,9 @@ struct cvk_kernel_argument_values {
         return val;
     }
 
-    static std::unique_ptr<cvk_kernel_argument_values>
+    static std::shared_ptr<cvk_kernel_argument_values>
     create(const cvk_kernel_argument_values& other) {
-        auto val = std::make_unique<cvk_kernel_argument_values>(other);
+        auto val = std::make_shared<cvk_kernel_argument_values>(other);
 
         if (!val->init()) {
             return nullptr;
@@ -176,9 +132,23 @@ struct cvk_kernel_argument_values {
     }
 
     bool init() {
-        if (m_kernel->has_pod_arguments()) {
+        // Init POD arguments
+        if (m_entry_point->has_pod_arguments()) {
+            // Find out POD binding
+            for (auto& arg : m_args) {
+                if (arg.is_pod()) {
+                    m_pod_arg = &arg;
+                    break;
+                }
+            }
+
+            if (m_pod_arg == nullptr) {
+                return CL_INVALID_PROGRAM;
+            }
+
             // TODO(#101): host out-of-memory errors are currently unhandled.
-            auto buffer = m_kernel->allocate_pod_host_buffer();
+            auto buffer = std::make_unique<std::vector<uint8_t>>(
+                m_entry_point->pod_buffer_size());
             m_pod_data = std::move(buffer);
         }
 
@@ -186,7 +156,7 @@ struct cvk_kernel_argument_values {
     }
 
     bool init_copy(const cvk_kernel_argument_values& other) {
-        if (m_kernel->has_pod_arguments()) {
+        if (m_entry_point->has_pod_arguments()) {
             memcpy(&pod_data()[0], &other.pod_data()[0], pod_data().size());
             return true;
         } else {
@@ -229,6 +199,8 @@ struct cvk_kernel_argument_values {
         return m_kernel_resources[arg.binding];
     }
 
+    bool is_enqueued() const { return m_is_enqueued; }
+
     const std::vector<uint8_t>& pod_data() const { return *m_pod_data; }
     std::vector<uint8_t>& pod_data() { return *m_pod_data; }
 
@@ -239,32 +211,50 @@ struct cvk_kernel_argument_values {
         return m_specialization_constants;
     }
 
+    CHECK_RETURN bool setup_descriptor_sets();
+
+    VkDescriptorSet* descriptor_sets() { return m_descriptor_sets.data(); }
+
     // Take ownership of resources and retain them.
     void retain_resources() {
-        if (!m_owns_resources) {
-            m_owns_resources = true;
-            for (auto& resource : m_kernel_resources) {
-                if (resource)
-                    resource->retain();
-            }
+        for (auto& resource : m_kernel_resources) {
+            if (resource)
+                resource->retain();
         }
     }
 
     // Release all resources owned resources.
     void release_resources() {
-        if (m_owns_resources) {
-            for (auto& resource : m_kernel_resources) {
-                if (resource)
-                    resource->release();
-            }
+        for (auto& resource : m_kernel_resources) {
+            if (resource)
+                resource->release();
         }
     }
 
 private:
-    cvk_kernel* m_kernel;
+    bool create_pod_buffer() {
+        CVK_ASSERT(m_pod_data->size() >= m_entry_point->pod_buffer_size());
+
+        // Create POD buffer and copy data to it
+        m_pod_buffer = m_entry_point->allocate_pod_buffer();
+        if (m_pod_buffer == nullptr) {
+            return false;
+        }
+        return m_pod_buffer->copy_from(m_pod_data->data(), 0,
+                                       m_entry_point->pod_buffer_size());
+    }
+
+    std::mutex m_lock;
+    cvk_entry_point* m_entry_point;
     std::unique_ptr<std::vector<uint8_t>> m_pod_data;
-    bool m_owns_resources;
+    bool m_is_enqueued;
+    const std::vector<kernel_argument>& m_args;
+    const kernel_argument* m_pod_arg;
     std::vector<refcounted*> m_kernel_resources;
     std::vector<size_t> m_local_args_size;
     std::unordered_map<uint32_t, uint32_t> m_specialization_constants;
+
+    std::unique_ptr<cvk_buffer> m_pod_buffer;
+    std::array<VkDescriptorSet, spir_binary::MAX_DESCRIPTOR_SETS>
+        m_descriptor_sets;
 };

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -95,13 +95,15 @@ struct cvk_kernel_argument_values {
         : m_entry_point(entry_point), m_is_enqueued(false),
           m_args(m_entry_point->args()), m_pod_arg(nullptr),
           m_kernel_resources(m_entry_point->num_resources()),
-          m_local_args_size(m_entry_point->args().size(), 0) {}
+          m_local_args_size(m_entry_point->args().size(), 0),
+          m_descriptor_sets{VK_NULL_HANDLE} {}
 
     cvk_kernel_argument_values(const cvk_kernel_argument_values& other)
         : m_entry_point(other.m_entry_point), m_is_enqueued(false),
           m_args(m_entry_point->args()), m_pod_arg(nullptr),
           m_kernel_resources(other.m_kernel_resources),
-          m_local_args_size(other.m_local_args_size) {}
+          m_local_args_size(other.m_local_args_size), m_descriptor_sets{
+                                                          VK_NULL_HANDLE} {}
 
     ~cvk_kernel_argument_values() {
         for (auto ds : m_descriptor_sets) {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1701,8 +1701,3 @@ std::unique_ptr<cvk_buffer> cvk_entry_point::allocate_pod_buffer() {
 
     return buffer;
 }
-
-std::unique_ptr<std::vector<uint8_t>>
-cvk_entry_point::allocate_pod_host_buffer() const {
-    return std::make_unique<std::vector<uint8_t>>(m_pod_buffer_size);
-}

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1513,6 +1513,7 @@ cl_int cvk_entry_point::init() {
         }
 
         m_pod_buffer_size = max_offset + max_offset_arg_size;
+        m_pod_buffer_size = round_up(m_pod_buffer_size, 4);
     }
 
     // Don't pass the range at pipeline layout creation time if no push
@@ -1702,7 +1703,6 @@ std::unique_ptr<cvk_buffer> cvk_entry_point::allocate_pod_buffer() {
 }
 
 std::unique_ptr<std::vector<uint8_t>>
-cvk_entry_point::allocate_pod_pushconstant_buffer() {
-    auto size = round_up(m_pod_buffer_size, 4);
-    return std::make_unique<std::vector<uint8_t>>(size);
+cvk_entry_point::allocate_pod_host_buffer() const {
+    return std::make_unique<std::vector<uint8_t>>(m_pod_buffer_size);
 }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -241,8 +241,6 @@ public:
 
     std::unique_ptr<cvk_buffer> allocate_pod_buffer();
 
-    std::unique_ptr<std::vector<uint8_t>> allocate_pod_host_buffer() const;
-
     const std::vector<kernel_argument>& args() const { return m_args; }
 
     bool has_pod_arguments() const { return m_has_pod_arguments; }
@@ -258,6 +256,8 @@ public:
     VkDescriptorType pod_descriptor_type() const {
         return m_pod_descriptor_type;
     }
+
+    cvk_program* program() const { return m_program; }
 
 private:
     const uint32_t MAX_INSTANCES = 16 * 1024; // FIXME find a better definition

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -241,13 +241,15 @@ public:
 
     std::unique_ptr<cvk_buffer> allocate_pod_buffer();
 
-    std::unique_ptr<std::vector<uint8_t>> allocate_pod_pushconstant_buffer();
+    std::unique_ptr<std::vector<uint8_t>> allocate_pod_host_buffer() const;
 
     const std::vector<kernel_argument>& args() const { return m_args; }
 
     bool has_pod_arguments() const { return m_has_pod_arguments; }
 
     bool has_pod_buffer_arguments() const { return m_has_pod_buffer_arguments; }
+
+    uint32_t pod_buffer_size() const { return m_pod_buffer_size; }
 
     uint32_t num_resources() const { return m_num_resources; }
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -645,9 +645,11 @@ cl_int cvk_command_kernel::build(cvk_command_buffer& command_buffer) {
     // TODO CL_INVALID_KERNEL_ARGS if the kernel argument values have not been
     // specified.
 
+    m_argument_values = m_kernel->argument_values();
+    m_argument_values->retain_resources();
+
     // Setup descriptors
-    if (!m_kernel->setup_descriptor_sets(m_kernel_descriptors,
-                                         m_argument_values)) {
+    if (!m_argument_values->setup_descriptor_sets()) {
         return CL_OUT_OF_RESOURCES;
     }
 
@@ -686,7 +688,7 @@ cl_int cvk_command_kernel::build(cvk_command_buffer& command_buffer) {
         vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
                                 m_kernel->pipeline_layout(), 0,
                                 m_kernel->num_set_layouts(),
-                                m_kernel_descriptors->descriptor_sets(), 0, 0);
+                                m_argument_values->descriptor_sets(), 0, 0);
     }
 
     update_global_push_constants(command_buffer);

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -605,13 +605,16 @@ struct cvk_command_kernel : public cvk_command {
                        const std::array<uint32_t, 3>& lws)
         : cvk_command(CL_COMMAND_NDRANGE_KERNEL, q), m_kernel(kernel),
           m_dimensions(dims), m_global_offsets(global_offsets), m_gws(gws),
-          m_lws(lws), m_kernel_descriptors(nullptr), m_pipeline(VK_NULL_HANDLE),
-          m_query_pool(VK_NULL_HANDLE), m_argument_values(nullptr) {}
+          m_lws(lws), m_pipeline(VK_NULL_HANDLE), m_query_pool(VK_NULL_HANDLE),
+          m_argument_values(nullptr) {}
 
     ~cvk_command_kernel() {
         if (m_query_pool != VK_NULL_HANDLE) {
             auto vkdev = m_queue->device()->vulkan_device();
             vkDestroyQueryPool(vkdev, m_query_pool, nullptr);
+        }
+        if (m_argument_values) {
+            m_argument_values->release_resources();
         }
     }
 
@@ -642,10 +645,9 @@ private:
     std::array<uint32_t, 3> m_global_offsets;
     std::array<uint32_t, 3> m_gws;
     std::array<uint32_t, 3> m_lws;
-    cvk_kernel_descriptors_holder m_kernel_descriptors;
     VkPipeline m_pipeline;
     VkQueryPool m_query_pool;
-    std::unique_ptr<cvk_kernel_argument_values> m_argument_values;
+    std::shared_ptr<cvk_kernel_argument_values> m_argument_values;
 
     std::unique_ptr<cvk_command_buffer> m_command_buffer;
 

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -605,17 +605,10 @@ struct cvk_command_kernel : public cvk_command {
                        const std::array<uint32_t, 3>& lws)
         : cvk_command(CL_COMMAND_NDRANGE_KERNEL, q), m_kernel(kernel),
           m_dimensions(dims), m_global_offsets(global_offsets), m_gws(gws),
-          m_lws(lws), m_descriptor_sets{VK_NULL_HANDLE},
-          m_pipeline(VK_NULL_HANDLE), m_query_pool(VK_NULL_HANDLE),
-          m_argument_values(nullptr) {}
+          m_lws(lws), m_kernel_descriptors(nullptr), m_pipeline(VK_NULL_HANDLE),
+          m_query_pool(VK_NULL_HANDLE), m_argument_values(nullptr) {}
 
     ~cvk_command_kernel() {
-        for (auto ds : m_descriptor_sets) {
-            if (ds != VK_NULL_HANDLE) {
-                m_kernel->free_descriptor_set(ds);
-            }
-        }
-
         if (m_query_pool != VK_NULL_HANDLE) {
             auto vkdev = m_queue->device()->vulkan_device();
             vkDestroyQueryPool(vkdev, m_query_pool, nullptr);
@@ -649,8 +642,7 @@ private:
     std::array<uint32_t, 3> m_global_offsets;
     std::array<uint32_t, 3> m_gws;
     std::array<uint32_t, 3> m_lws;
-    std::array<VkDescriptorSet, spir_binary::MAX_DESCRIPTOR_SETS>
-        m_descriptor_sets;
+    cvk_kernel_descriptors_holder m_kernel_descriptors;
     VkPipeline m_pipeline;
     VkQueryPool m_query_pool;
     std::unique_ptr<cvk_kernel_argument_values> m_argument_values;


### PR DESCRIPTION
Summary:

* Make descriptor sets and POD buffer part of the `cvk_kernel_kernel_argument_values` structure

* Reuse existing `cvk_kernel_argument_values` instance when enqueueing
  kernel with same args multiple times

* Create new `cvk_kernel_argument_values` instance when setting argument
  for a kernel object that has already been enqueued

* Handle shared ownership of `cvk_kernel_argument_values` via `std::shared_ptr`

Notes:

This ended up being more intrusive than I originally imagined it would be. Some of the changes around how `cvk_kernel_argument_values` ownership and resource retention is handled are not directly related to descriptor set reuse, but I think are a little cleaner than the previous implementation (feel free to disagree!). If this is going too far, the second commit here can be removed, and we can have descriptor set reuse via a second dedicated structure (`cvk_kernel_descriptors`) instead via the first commit on its own.