### PR TITLE
Set global cache size and number of compute units

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -445,7 +445,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         size_ret = sizeof(val_cache_type);
         break;
     case CL_DEVICE_GLOBAL_MEM_CACHE_SIZE:
-        val_ulong = 0; // FIXME
+        val_ulong = device->global_mem_cache_size();
         copy_ptr = &val_ulong;
         size_ret = sizeof(val_ulong);
         break;
@@ -475,7 +475,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         size_ret = sizeof(val_sizet);
         break;
     case CL_DEVICE_MAX_COMPUTE_UNITS:
-        val_uint = 1; // TODO can we do any better here?
+        val_uint = device->num_compute_units();
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -157,6 +157,10 @@ struct cvk_device : public _cl_device_id {
         return std::max(required_by_vulkan_impl, 1024U);
     }
 
+    cl_ulong global_mem_cache_size() const { return m_global_mem_cache_size; }
+
+    cl_uint num_compute_units() const { return m_num_compute_units; }
+
     cl_uint max_samplers() const {
         // There are only 20 different possible samplers in OpenCL 1.2, cap the
         // number of supported samplers to that to help with negative testing of
@@ -346,6 +350,7 @@ private:
 
     CHECK_RETURN bool init_queues(uint32_t* num_queues, uint32_t* queue_family);
     CHECK_RETURN bool init_extensions();
+    void init_properties();
     void init_driver_behaviors(VkInstance instance);
     void init_features(VkInstance instance);
     void build_extension_ils_list();
@@ -383,6 +388,10 @@ private:
     std::vector<cl_name_version> m_ils;
     std::vector<cl_name_version> m_opencl_c_versions;
     std::vector<cl_name_version> m_opencl_c_features;
+
+    // Device properties that do not come from Vulkan
+    cl_ulong m_global_mem_cache_size;
+    cl_ulong m_num_compute_units;
 
     uint32_t m_driver_behaviors;
 


### PR DESCRIPTION
These values are not queryable from Vulkan, so just hardcode the values for some known devices and produce a warning for unknown devices. This should eventually be replaced by a dynamic, portable approach for querying these (and other) device properties, if and when one exists.

Opening this PR with just a couple of properties and devices to get feedback on the high-level approach. It's far from pretty, but it does the job for the MACE benchmarks that I mentioned. I also found it difficult to find definitive sources for these properties, so for now I've just scraped them from the native OpenCL driver and commented as such.

This is a relatively small patch that wouldn't be difficult to maintain as a local change, so I don't mind if you'd rather just wait for the longer term solution to arrive instead of going down this somewhat unpleasant route.