### PR TITLE
Flush queues when calling clReleaseCommandQueue

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1310,8 +1310,11 @@ cl_int CLVK_API_CALL clReleaseCommandQueue(cl_command_queue command_queue) {
         return CL_INVALID_COMMAND_QUEUE;
     }
 
+    cl_int err = icd_downcast(command_queue)->flush();
+
     icd_downcast(command_queue)->release();
-    return CL_SUCCESS;
+
+    return err;
 }
 
 cl_int CLVK_API_CALL clRetainCommandQueue(cl_command_queue command_queue) {

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -250,9 +250,7 @@ struct cvk_command_queue : public _cl_command_queue, api_object {
 
     CHECK_RETURN static cl_int wait_for_events(cl_uint num_events,
                                                const cl_event* event_list);
-    CHECK_RETURN cl_int flush(cvk_event** event);
-
-    CHECK_RETURN cl_int flush() { return flush(nullptr); }
+    CHECK_RETURN cl_int flush(cvk_event** event = nullptr);
 
     CHECK_RETURN bool allocate_command_buffer(VkCommandBuffer* cmdbuf) {
         return m_command_pool.allocate_command_buffer(cmdbuf) == VK_SUCCESS;


### PR DESCRIPTION
... as required by the OpenCL specification.

Fixes #243

Signed-off-by: Kévin Petit <kpet@free.fr>