### PR TITLE
Fix refcounted_holder move constructor

### DIFF
--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -75,8 +75,10 @@ template <typename T> struct refcounted_holder {
         }
     }
 
-    refcounted_holder(const refcounted_holder&& other) noexcept
-        : m_refcounted(other.m_refcounted) {}
+    refcounted_holder(refcounted_holder&& other) noexcept
+        : m_refcounted(other.m_refcounted) {
+        other.m_refcounted = nullptr;
+    }
 
     ~refcounted_holder() {
         if (m_refcounted != nullptr) {


### PR DESCRIPTION
The move constructor should invalidate the source holder's object reference to avoid decrementing the reference count when the source holder is destroyed.

This was showing up as a heap corruption for programs that contain multiple literal samplers. When the second literal sampler was [added to the `m_literal_samplers` vector](https://github.com/kpet/clvk/blob/04f1fca4a2748fb599e65ccfe38ad999115d0c26/src/program.cpp#L973), the implementation of `emplace_back` was resizing the vector and copying the elements over using the move constructor, and then the old elements were destroyed, triggering the destructor and decrementing the reference count.