### PR TITLE
Add a simple work-group size selection heuristic

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -3495,51 +3495,7 @@ cl_int CLVK_API_CALL clEnqueueNDRangeKernel(
 
     // Try to pick a sensible work-group size if the user didn't specify one.
     if (local_work_size == nullptr) {
-        lws[0] = lws[1] = lws[2] = 1;
-
-        auto& limits = icd_downcast(command_queue)->device()->vulkan_limits();
-
-        // Cap the total work-group size to the Vulkan device's limit.
-        uint32_t maxSize = limits.maxComputeWorkGroupInvocations;
-
-        // Further cap the total size to 64, as this is expected to be a
-        // reasonable size on many devices.
-        maxSize = std::min(maxSize, UINT32_C(64));
-
-        // TODO: We should also take into account the total number of
-        // work-groups that would be launched, to ensure the device is fully
-        // utilized for smaller global work sizes.
-
-        // Approach: Alternate between increasing the X and Y dimensions until
-        // we hit device limits.
-        bool changed;
-        do {
-            changed = false;
-
-            // Increase the X dimension if we can.
-            // TODO: Allow non power-of-two sizes?
-            // TODO: Allow non-uniform sizes if supported?
-            uint32_t newX = lws[0] * 2;
-            if (gws[0] % newX == 0 &&
-                newX <= limits.maxComputeWorkGroupCount[0] &&
-                newX * lws[1] <= maxSize) {
-                lws[0] = newX;
-                changed = true;
-            }
-
-            // Increase the Y dimension if we can.
-            // TODO: Allow non power-of-two sizes?
-            // TODO: Allow non-uniform sizes if supported?
-            uint32_t newY = lws[1] * 2;
-            if (gws[1] % newY == 0 &&
-                newY <= limits.maxComputeWorkGroupCount[1] &&
-                lws[0] * newY <= maxSize) {
-                lws[1] = newY;
-                changed = true;
-            }
-
-            // TODO: Consider increasing the Z dimension as well?
-        } while (changed);
+        icd_downcast(command_queue)->device()->select_work_group_size(gws, lws);
     }
 
     LOG_API_CALL("goff = {%u,%u,%u}", goff[0], goff[1], goff[2]);

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -304,6 +304,9 @@ struct cvk_device : public _cl_device_id {
 
     bool supports_non_uniform_workgroup() const { return true; }
 
+    void select_work_group_size(const std::array<uint32_t, 3>& global_size,
+                                std::array<uint32_t, 3>& local_size) const;
+
     bool is_vulkan_extension_enabled(const char* ext) const {
         return std::find(m_vulkan_device_extensions.begin(),
                          m_vulkan_device_extensions.end(),


### PR DESCRIPTION
Start at (1,1,1) and alternately double the X and Y dimensions while it is still valid to do so, capped to a total size of 64.

It's pretty crude, but this yields huge gains on a workload that I'm looking at that uses a `NULL` work-group size. I've left TODOs for some of the many potential areas for improvement in the comments.

Contributes to #265.