### PR TITLE
Add support for pipeline cache serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,7 @@ variables. Here's a quick guide:
 
    * 0: disabled (default)
    * 1: enabled
+
+* `CLVK_CACHE_DIR` specifies a directory used for caching compiled program data
+  between applications runs. The user is responsible for ensuring that this
+  directory is not used concurrently by more than one application.

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -528,15 +528,16 @@ get_pipeline_cache_filename(VkPhysicalDeviceProperties properties) {
     }
 
     // The pipeline cache file path is:
-    // ${CLVK_CACHE_DIR}/<UUID>.clvk-pipeline-cache.bin
+    // ${CLVK_CACHE_DIR}/clvk-pipeline-cache.<UUID>.bin
     std::stringstream uuid_ss;
     for (int i = 0; i < VK_UUID_SIZE; i++) {
         uuid_ss << std::hex << (int)properties.pipelineCacheUUID[i];
     }
     std::string cache_path = cache_dir;
     cache_path += "/";
+    cache_path += "clvk-pipeline-cache.";
     cache_path += uuid_ss.str();
-    cache_path += ".clvk-pipeline-cache.bin";
+    cache_path += ".bin";
     return cache_path;
 }
 

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -520,7 +520,8 @@ bool cvk_device::init_time_management(VkInstance instance) {
 
 // Returns the pipeline cache file path for a given Vulkan implementation.
 // If pipeline cache serialization is not enabled, an empty string is returned.
-std::string get_pipeline_cache_filename(VkPhysicalDeviceProperties properties) {
+static std::string
+get_pipeline_cache_filename(VkPhysicalDeviceProperties properties) {
     const char* cache_dir = getenv("CLVK_CACHE_DIR");
     if (cache_dir == nullptr) {
         return "";

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -596,14 +596,14 @@ void cvk_device::save_pipeline_cache() {
     size_t size;
     res = vkGetPipelineCacheData(m_dev, m_pipeline_cache, &size, nullptr);
     if (res != VK_SUCCESS) {
-        cvk_warn("Failed to retrieve pipeline cache size");
+        cvk_error("Failed to retrieve pipeline cache size");
         return;
     }
     std::vector<char> cache_data(size);
     res = vkGetPipelineCacheData(m_dev, m_pipeline_cache, &size,
                                  cache_data.data());
     if (res != VK_SUCCESS) {
-        cvk_warn("failed to retrieve pipeline cache data");
+        cvk_error("Failed to retrieve pipeline cache data");
         return;
     }
 

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fstream>
+#include <sstream>
+
 #include "device.hpp"
 #include "init.hpp"
 #include "log.hpp"
@@ -515,6 +518,110 @@ bool cvk_device::init_time_management(VkInstance instance) {
     return true;
 }
 
+// Returns the pipeline cache file path for a given Vulkan implementation.
+// If pipeline cache serialization is not enabled, an empty string is returned.
+std::string get_pipeline_cache_filename(VkPhysicalDeviceProperties properties) {
+    const char* cache_dir = getenv("CLVK_CACHE_DIR");
+    if (cache_dir == nullptr) {
+        return "";
+    }
+
+    // The pipeline cache file path is:
+    // ${CLVK_CACHE_DIR}/<UUID>.clvk-pipeline-cache.bin
+    std::stringstream uuid_ss;
+    for (int i = 0; i < VK_UUID_SIZE; i++) {
+        uuid_ss << std::hex << (int)properties.pipelineCacheUUID[i];
+    }
+    std::string cache_path = cache_dir;
+    cache_path += "/";
+    cache_path += uuid_ss.str();
+    cache_path += ".clvk-pipeline-cache.bin";
+    return cache_path;
+}
+
+bool cvk_device::init_pipeline_cache() {
+    std::vector<char> cache_data;
+
+    // Load initial pipeline cache data from file if this is enabled
+    std::string cache_path = get_pipeline_cache_filename(m_properties);
+    if (!cache_path.empty()) {
+        std::ifstream cache_file(cache_path, std::ios::in | std::ios::binary);
+        if (cache_file.is_open()) {
+            // Get the size of the pipeline cache file
+            cache_file.seekg(0, std::ios::end);
+            uint32_t size = cache_file.tellg();
+            cache_file.seekg(0, std::ios::beg);
+
+            // Load the pipeline cache data into memory
+            cache_data.resize(size);
+            cache_file.read(cache_data.data(), size);
+            if (!cache_file.good()) {
+                cvk_warn("Failed to read pipeline cache data");
+                cache_data.clear();
+            }
+        } else {
+            cvk_warn("Failed to open pipeline cache file: %s",
+                     cache_path.c_str());
+        }
+    }
+
+    // Create pipeline cache
+    VkPipelineCacheCreateInfo pipelineCacheCreateInfo = {
+        VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
+        nullptr,           // pNext
+        0,                 // flags
+        cache_data.size(), // initialDataSize
+        cache_data.data(), // pInitialData
+    };
+
+    VkResult res = vkCreatePipelineCache(m_dev, &pipelineCacheCreateInfo,
+                                         nullptr, &m_pipeline_cache);
+    if (res != VK_SUCCESS) {
+        cvk_error("Could not create pipeline cache.");
+        return false;
+    }
+
+    return true;
+}
+
+void cvk_device::save_pipeline_cache() {
+    VkResult res;
+
+    std::string cache_path = get_pipeline_cache_filename(m_properties);
+    if (cache_path.empty()) {
+        return;
+    }
+
+    // Retrieve the pipeline cache data from the Vulkan implementation
+    size_t size;
+    res = vkGetPipelineCacheData(m_dev, m_pipeline_cache, &size, nullptr);
+    if (res != VK_SUCCESS) {
+        cvk_warn("Failed to retrieve pipeline cache size");
+        return;
+    }
+    std::vector<char> cache_data(size);
+    res = vkGetPipelineCacheData(m_dev, m_pipeline_cache, &size,
+                                 cache_data.data());
+    if (res != VK_SUCCESS) {
+        cvk_warn("failed to retrieve pipeline cache data");
+        return;
+    }
+
+    cvk_info("Writing %lu bytes of pipeline cache data to file", size);
+
+    // Write the pipeline cache data to file
+    std::ofstream cache_file(cache_path, std::ios::out | std::ios::binary);
+    if (!cache_file.is_open()) {
+        cvk_error("Failed to open pipeline cache file for writing: %s",
+                  cache_path.c_str());
+        return;
+    }
+    cache_file.write(cache_data.data(), size);
+    if (!cache_file.good()) {
+        cvk_error("Failed to write pipeline cache data");
+    }
+}
+
 void cvk_device::log_limits_and_memory_information() {
     // Print relevant device limits
     const VkPhysicalDeviceLimits& limits = vulkan_limits();
@@ -577,6 +684,10 @@ bool cvk_device::init(VkInstance instance) {
     }
 
     if (!create_vulkan_queues_and_device(num_queues, queue_family)) {
+        return false;
+    }
+
+    if (!init_pipeline_cache()) {
         return false;
     }
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1105,7 +1105,7 @@ cvk_entry_point::cvk_entry_point(VkDevice dev, cvk_program* program,
       m_name(name), m_pod_descriptor_type(VK_DESCRIPTOR_TYPE_MAX_ENUM),
       m_pod_buffer_size(0u), m_has_pod_arguments(false),
       m_has_pod_buffer_arguments(false), m_descriptor_pool(VK_NULL_HANDLE),
-      m_pipeline_layout(VK_NULL_HANDLE), m_pipeline_cache(VK_NULL_HANDLE) {}
+      m_pipeline_layout(VK_NULL_HANDLE) {}
 
 cvk_entry_point* cvk_program::get_entry_point(std::string& name,
                                               cl_int* errcode_ret) {
@@ -1390,22 +1390,6 @@ cl_int cvk_entry_point::init() {
         }
     }
 
-    // Create pipeline cache
-    VkPipelineCacheCreateInfo pipelineCacheCreateInfo = {
-        VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
-        nullptr, // pNext
-        0,       // flags
-        0,       // initialDataSize
-        nullptr, // pInitialData
-    };
-
-    res = vkCreatePipelineCache(m_device, &pipelineCacheCreateInfo, nullptr,
-                                &m_pipeline_cache);
-    if (res != VK_SUCCESS) {
-        cvk_error("Could not create pipeline cache.");
-        return CL_OUT_OF_RESOURCES;
-    }
-
     return CL_SUCCESS;
 }
 
@@ -1457,8 +1441,9 @@ cvk_entry_point::create_pipeline(const cvk_spec_constant_map& spec_constants) {
     };
 
     VkPipeline pipeline;
-    VkResult res = vkCreateComputePipelines(m_device, m_pipeline_cache, 1,
-                                            &createInfo, nullptr, &pipeline);
+    VkResult res = vkCreateComputePipelines(
+        m_device, m_context->device()->pipeline_cache(), 1, &createInfo,
+        nullptr, &pipeline);
 
     if (res != VK_SUCCESS) {
         cvk_error_fn("Could not create compute pipeline: %s",

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -214,9 +214,6 @@ public:
                      m_name.c_str());
             vkDestroyPipeline(m_device, pipeline.second, nullptr);
         }
-        if (m_pipeline_cache != VK_NULL_HANDLE) {
-            vkDestroyPipelineCache(m_device, m_pipeline_cache, nullptr);
-        }
         if (m_descriptor_pool != VK_NULL_HANDLE) {
             vkDestroyDescriptorPool(m_device, m_descriptor_pool, nullptr);
         }
@@ -278,7 +275,6 @@ private:
     VkDescriptorPool m_descriptor_pool;
     std::vector<VkDescriptorSetLayout> m_descriptor_set_layouts;
     VkPipelineLayout m_pipeline_layout;
-    VkPipelineCache m_pipeline_cache;
 
     std::mutex m_pipeline_cache_lock;
     std::mutex m_descriptor_pool_lock;


### PR DESCRIPTION
If the user sets the `CLVK_CACHE_DIR` environment variable to a non-empty value, clvk will write Vulkan pipeline data to a per-device file in that directory during teardown. On the next run, clvk will load pipeline cache data from this directory and use it to seed the initial pipeline cache.

This also changes the Vulkan pipeline cache to be device-scope, rather than program scope. We could keep using per-program pipeline caches if we serialized them all separately (during program teardown), but we'd need to hash the SPIR-V to uniquely identify them. I didn't want to go this route just yet since it would probably add an additional dependency for the hash function (unless we rolled our own...).

This provides significant performance improvements (1.5-1.8X) for part of a workload that I'm looking at on both Adreno and Mali GPUs. 

I left the environment variable name generic as we may also want to cache the Clspv output at some point as well to improve OpenCL-C compilation speed. The particular workload I'm looking manually caches program binaries and uses `clCreateProgramFromBinary`, which is why the Vulkan pipeline creation cost is showing up as an issue.

We haven't talked about any of this before so I'm happy to discuss here or elsewhere before review if you want to.

