### PR TITLE
Skip extra validation when stripping reflection

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -486,7 +486,9 @@ bool spir_binary::strip_reflection(std::vector<uint32_t>* stripped) {
     spvtools::Optimizer opt(m_target_env);
     opt.SetMessageConsumer(consumer);
     opt.RegisterPass(spvtools::CreateStripReflectInfoPass());
-    if (!opt.Run(m_code.data(), m_code.size(), stripped)) {
+    spvtools::OptimizerOptions options;
+    options.set_run_validator(false);
+    if (!opt.Run(m_code.data(), m_code.size(), stripped, options)) {
         return false;
     }
     return true;


### PR DESCRIPTION
We've already run SPIR-V validation manually just before this, so we
don't need to do it again.