### PR TITLE
Add timing.hpp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,11 @@ if(WIN32)
 		NOMINMAX)
 endif()
 
+option(CLVK_ENABLE_TIMING "Enable timing of clvk internals" OFF)
+if (CLVK_ENABLE_TIMING)
+	target_compile_definitions(OpenCL-objects PRIVATE CVK_ENABLE_TIMING)
+endif()
+
 function(CLLibrary target type)
   add_library(${target} ${type} $<TARGET_OBJECTS:OpenCL-objects>)
   target_link_libraries(${target} ${OpenCL-dependencies})

--- a/src/timing.hpp
+++ b/src/timing.hpp
@@ -1,0 +1,101 @@
+// Copyright 2020 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+
+#include "log.hpp"
+
+class cvk_timer {
+public:
+    cvk_timer(std::string name) : m_name(name) {}
+
+#ifdef CVK_ENABLE_TIMING
+
+    ~cvk_timer() {
+        double average = m_count ? (m_total_time / 1.0e6) / m_count : 0.0;
+        cvk_warn("%.2f ms -> %s (%d blocks, avg %.3f ms)", m_total_time / 1.0e6,
+                 m_name.c_str(), m_count.load(), average);
+    }
+
+    void add_time(long nanoseconds) {
+        m_total_time += nanoseconds;
+        m_count++;
+    }
+
+#endif
+
+private:
+    std::string m_name;
+#ifdef CVK_ENABLE_TIMING
+    std::atomic<long> m_total_time{0};
+    std::atomic<int> m_count{0};
+#endif
+};
+
+class cvk_unscoped_timer {
+public:
+    cvk_unscoped_timer(cvk_timer& timer) : m_timer(timer) {}
+
+    void start() {
+#ifdef CVK_ENABLE_TIMING
+        m_start_time = std::chrono::steady_clock::now();
+#endif
+    }
+
+    void stop() {
+#ifdef CVK_ENABLE_TIMING
+        auto elapsed = std::chrono::steady_clock::now() - m_start_time;
+        auto nanoseconds =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed);
+        m_timer.add_time(nanoseconds.count());
+#endif
+    }
+
+private:
+    [[maybe_unused]] cvk_timer& m_timer;
+#ifdef CVK_ENABLE_TIMING
+    std::chrono::steady_clock::time_point m_start_time;
+#endif
+};
+
+class cvk_scoped_timer {
+public:
+    cvk_scoped_timer(cvk_timer& timer) : m_timer(timer) {
+#ifdef CVK_ENABLE_TIMING
+        m_timer.start();
+#endif
+    }
+    ~cvk_scoped_timer() {
+#ifdef CVK_ENABLE_TIMING
+        m_timer.stop();
+#endif
+    }
+
+private:
+    cvk_unscoped_timer m_timer;
+};
+
+#define CVK_TIMED_BLOCK(name, description)                                     \
+    static cvk_timer name##timer(description);                                 \
+    cvk_scoped_timer name##timed_scope(name##timer)
+
+#define CVK_TIMED_FUNCTION CVK_TIMED_BLOCK(__func__, __func__)
+
+#define CVK_UNSCOPED_TIMER(name, description)                                  \
+    static cvk_timer name##timer(description);                                 \
+    cvk_unscoped_timer name(name##timer);                                      \
+    name


### PR DESCRIPTION
Approach
----------

A single timer is a static storage duration object with a name/description, accumulates timings over the course of the application run, and prints out the total and average times at exit. Utility macros are provided to easily create scoped timers (e.g. for a function or block) and unscoped timers (manual start/stop).

A new CMake option, `CLVK_ENABLE_TIMING`, is used to turn on internal timing (off by default). This means that timers can be safely left in the codebase for things that frequently need to be profiled, without introducing overheads for builds that run without timing enabled.

Timing output is printed with `cvk_warn` so that it can be used at `CLVK_LOG<=2` (higher levels tend to introduce noise to performance due to excessive logging).

I (very roughly) measured overheads of about 200ns per timed region on an Android device. This is small enough that I haven't seen measurement noise for any of what I've used this for so far. I did try using this to time `refcounted::{retain,release}` and it did move the needle there, but not by a huge amount.

Usage
------

Just `#include "timing.hpp"` in a file that needs timing, and then use the macros as follows:

Time a function:
(uses the function name as the timer description)
```
void cvk_program::do_build() {
  CVK_TIMED_FUNCTION;
  // function body
}
```

Time a block:
```
if (do_work) {
  CVK_TIMED_BLOCK(foo_timer, "doing foo");
  // do foo
}
```

Unscoped timing:
```
CVK_UNSCOPED_TIMER(foo_timer, "doing foo");
for (...) {
   // do stuff

   foo_timer.start();
   // do foo
   foo_timer.stop();

  // do more stuff
}

// Can also start the timer at the same time as definition for convenience:
CVK_UNSCOPED_TIMER(bar_timer, "doing bar").start();
// do bar
bar_timer.stop();
```


Example output
----------------

Timing some API calls and some `cvk_program::do_build()` internals currently produces output like this:
```
[CLVK] 229.69 ms -> clReleaseProgram (1632 blocks, avg 0.141 ms)
[CLVK] 334.05 ms -> clEnqueueNDRangeKernel (4820 blocks, avg 0.069 ms)
[CLVK] 0.28 ms -> clGetKernelWorkGroupInfo (2838 blocks, avg 0.000 ms)
[CLVK] 290.23 ms -> clCreateKernel (1419 blocks, avg 0.205 ms)
[CLVK] 149.62 ms -> stripping reflection info (213 blocks, avg 0.702 ms)
[CLVK] 433.32 ms -> SPIR-V validation (213 blocks, avg 2.034 ms)
[CLVK] 595.00 ms -> do_build (213 blocks, avg 2.793 ms)
[CLVK] 654.32 ms -> clBuildProgram (213 blocks, avg 3.072 ms)
```

Future improvements?
----------------------

Happy to discuss/change the output format, names of macros, or any other aspect of this. No rush to review/land either, since it's easy to keep as a local patch.

It'd be nice to sort the output or at least group timers by compilation unit (e.g. all OpenCL APIs together), but I haven't come up with a nice way to do this yet (and it isn't that important really). Even better would be track timing hierarchies so that we can do inclusive/exclusive times (e.g. `do_build` includes some of the other stuff in the above output), but this might make things too heavyweight (and again isn't that important).
