### PR TITLE
Fix clEnqueueWriteImage with offsets

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -4252,16 +4252,17 @@ cl_int cvk_enqueue_image_copy(
     // Create copy command
     auto rpitch = row_pitch;
     if (rpitch == 0) {
-        rpitch = img->width() * img->element_size();
+        rpitch = region[0] * img->element_size();
     }
 
     auto spitch = slice_pitch;
     if (spitch == 0) {
-        spitch = img->height() * rpitch;
+        spitch = region[1] * rpitch;
     }
+    const size_t zero_origin[3] = {0, 0, 0};
     auto cmd_copy = std::make_unique<cvk_command_copy_host_buffer_rect>(
-        queue, command_type, map_buffer, ptr, origin, origin, region, rpitch,
-        spitch, cmd_map->map_buffer_row_pitch(),
+        queue, command_type, map_buffer, ptr, zero_origin, zero_origin, region,
+        rpitch, spitch, cmd_map->map_buffer_row_pitch(),
         cmd_map->map_buffer_slice_pitch(), img->element_size());
 
     // Create unmap command

--- a/tests/api/images.cpp
+++ b/tests/api/images.cpp
@@ -317,13 +317,13 @@ TEST_F(WithCommandQueue, ImageWriteOffset) {
     size_t write_region[3] = {IMAGE_WIDTH / 2, IMAGE_HEIGHT / 2, 1};
 
     cl_uchar fill_value = 0xFF;
-    std::vector<cl_uchar> write_data(IMAGE_WIDTH * IMAGE_HEIGHT, 0);
+    std::vector<cl_uchar> write_data(write_region[0] * write_region[1], 0);
     std::vector<cl_uchar> read_data(IMAGE_WIDTH * IMAGE_HEIGHT, 0);
 
     // Fill the source data.
-    for (int y = 0; y < IMAGE_HEIGHT; y++) {
-        for (int x = 0; x < IMAGE_WIDTH; x++) {
-            write_data[x + y * IMAGE_WIDTH] = x + y * IMAGE_WIDTH;
+    for (int y = 0; y < write_region[1]; y++) {
+        for (int x = 0; x < write_region[0]; x++) {
+            write_data[x + y * write_region[0]] = x + y * write_region[0];
         }
     }
 

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -527,6 +527,61 @@ protected:
         EnqueueWriteBuffer(buffer, blocking_write, offset, size, ptr, 0,
                            nullptr, nullptr);
     }
+
+    void EnqueueReadImage(cl_mem image, cl_bool blocking_read,
+                          const size_t* origin, const size_t* region,
+                          size_t row_pitch, size_t slice_pitch, void* ptr,
+                          cl_uint num_events_in_wait_list,
+                          const cl_event* event_wait_list, cl_event* event) {
+        auto err = clEnqueueReadImage(
+            m_queue, image, blocking_read, origin, region, row_pitch,
+            slice_pitch, ptr, num_events_in_wait_list, event_wait_list, event);
+        ASSERT_CL_SUCCESS(err);
+    }
+
+    void EnqueueReadImage(cl_mem image, cl_bool blocking_read,
+                          const size_t* origin, const size_t* region,
+                          size_t row_pitch, size_t slice_pitch, void* ptr) {
+        EnqueueReadImage(image, blocking_read, origin, region, row_pitch,
+                         slice_pitch, ptr, 0, nullptr, nullptr);
+    }
+
+    void EnqueueWriteImage(cl_mem image, cl_bool blocking_write,
+                           const size_t* origin, const size_t* region,
+                           size_t input_row_pitch, size_t input_slice_pitch,
+                           const void* ptr, cl_uint num_events_in_wait_list,
+                           const cl_event* event_wait_list, cl_event* event) {
+        auto err = clEnqueueWriteImage(
+            m_queue, image, blocking_write, origin, region, input_row_pitch,
+            input_slice_pitch, ptr, num_events_in_wait_list, event_wait_list,
+            event);
+        ASSERT_CL_SUCCESS(err);
+    }
+
+    void EnqueueWriteImage(cl_mem image, cl_bool blocking_write,
+                           const size_t* origin, const size_t* region,
+                           size_t input_row_pitch, size_t input_slice_pitch,
+                           const void* ptr) {
+        EnqueueWriteImage(image, blocking_write, origin, region,
+                          input_row_pitch, input_slice_pitch, ptr, 0, nullptr,
+                          nullptr);
+    }
+
+    void EnqueueFillImage(cl_mem image, const void* fill_color,
+                          const size_t* origin, const size_t* region,
+                          cl_uint num_events_in_wait_list,
+                          const cl_event* event_wait_list, cl_event* event) {
+        auto err =
+            clEnqueueFillImage(m_queue, image, fill_color, origin, region,
+                               num_events_in_wait_list, event_wait_list, event);
+        ASSERT_CL_SUCCESS(err);
+    }
+
+    void EnqueueFillImage(cl_mem image, const void* fill_color,
+                          const size_t* origin, const size_t* region) {
+        EnqueueFillImage(image, fill_color, origin, region, 0, nullptr,
+                         nullptr);
+    }
 };
 
 class WithProfiledCommandQueue : public WithCommandQueue {


### PR DESCRIPTION
Fix clEnqueueWriteImage with offsets

* Do not apply `origin` as an offset when copying from the host
  pointer to the staging buffer.
    
* Use the region size instead of the image size when calculating
  default pitches.
    
Added a test for this.