### PR TITLE
Initialize memory allocation pointer

### DIFF
--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -21,7 +21,8 @@
 struct cvk_memory_allocation {
 
     cvk_memory_allocation(VkDevice dev, VkDeviceSize size, uint32_t type_index)
-        : m_device(dev), m_size(size), m_memory_type_index(type_index) {}
+        : m_device(dev), m_size(size), m_memory(VK_NULL_HANDLE),
+          m_memory_type_index(type_index) {}
 
     ~cvk_memory_allocation() {
         if (m_memory != VK_NULL_HANDLE) {


### PR DESCRIPTION
Prevents invalid calls to vkFreeMemory upon destruction for memory
allocations that failed.

This was causing tests in allocations CTS suite to crash on some platforms.