### PR TITLE
Work around LLVM CMake issue and update CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,10 @@ set(SPIRV-Headers_SOURCE_DIR ${SPIRV_HEADERS_SOURCE_DIR})
 add_subdirectory(${SPIRV_TOOLS_SOURCE_DIR} EXCLUDE_FROM_ALL)
 
 # clspv
+# FIXME remove the defintion of LLVM_TARGETS_TO_BUILD when LLVM supports an
+# empty list again
+set(LLVM_TARGETS_TO_BUILD AArch64 CACHE STRING
+    "Semicolon-separated list of targets to build, or \"all\".")
 set(CLSPV_SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/clspv
     CACHE STRING "Clspv source directory")
 add_subdirectory(${CLSPV_SOURCE_DIR} ${PROJECT_BINARY_DIR}/external/clspv

--- a/tests/azure/pipeline-precommit.yml
+++ b/tests/azure/pipeline-precommit.yml
@@ -31,14 +31,14 @@ stages:
   - template: job-precommit.yml
     parameters:
       namePrefix: Windows_2016_MSVC_2017_online_clspv
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
       os: windows
       cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=1'
       buildType: Release
   - template: job-precommit.yml
     parameters:
       namePrefix: Windows_2016_MSVC_2017_offline_clspv
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
       os: windows
       cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=0'
       buildType: Release

--- a/tests/azure/pipeline-precommit.yml
+++ b/tests/azure/pipeline-precommit.yml
@@ -30,14 +30,14 @@ stages:
   jobs:
   - template: job-precommit.yml
     parameters:
-      namePrefix: Windows_2016_MSVC_2017_online_clspv
+      namePrefix: Windows_2019_MSVC_2019_online_clspv
       vmImage: windows-2019
       os: windows
       cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=1'
       buildType: Release
   - template: job-precommit.yml
     parameters:
-      namePrefix: Windows_2016_MSVC_2017_offline_clspv
+      namePrefix: Windows_2019_MSVC_2019_offline_clspv
       vmImage: windows-2019
       os: windows
       cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=0'

--- a/tests/azure/steps-build.yml
+++ b/tests/azure/steps-build.yml
@@ -35,7 +35,6 @@ steps:
                   -DCLVK_CCACHE_BUILD=${{ parameters.useCCache }}
                   -DCLVK_VULKAN_IMPLEMENTATION=${{ parameters.vulkanImplementation }}
                   -DCLVK_VULKAN_LOADER_DIR=${{ parameters.vulkanLoaderDir }}
-                  -DLLVM_TARGETS_TO_BUILD=ARM
                   -DSPIRV_WERROR=OFF
                   ${{ parameters.cmakeFlags }} ..'
   - ${{ if eq(parameters.os, 'windows') }}:

--- a/tests/azure/steps-build.yml
+++ b/tests/azure/steps-build.yml
@@ -35,6 +35,7 @@ steps:
                   -DCLVK_CCACHE_BUILD=${{ parameters.useCCache }}
                   -DCLVK_VULKAN_IMPLEMENTATION=${{ parameters.vulkanImplementation }}
                   -DCLVK_VULKAN_LOADER_DIR=${{ parameters.vulkanLoaderDir }}
+                  -DLLVM_TARGETS_TO_BUILD=ARM
                   -DSPIRV_WERROR=OFF
                   ${{ parameters.cmakeFlags }} ..'
   - ${{ if eq(parameters.os, 'windows') }}:

--- a/tests/azure/steps-fetch-sources.yml
+++ b/tests/azure/steps-fetch-sources.yml
@@ -5,7 +5,7 @@ parameters:
     default: python
   - name: 'loaderRevision'
     type: string
-    default: v1.2.137
+    default: v1.2.166
 
 steps:
   - script: git submodule update --depth 1 --init


### PR DESCRIPTION
Building with LLVM_TARGETS_TO_BUILD set to an empty string is broken again:

CMake Error at external/clspv/third_party/llvm/llvm/cmake/modules/LLVM-Config.cmake:31 (list):
  list sub-command REMOVE_ITEM requires two or more arguments

until this is resolved upstream, set it to contain at least one target.

Also update the Vulkan Loader version and move to Windows 2019 in the CI.

Signed-off-by: Kévin Petit <kpet@free.fr>