### PR TITLE
Parse reflection info after linking programs

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -896,9 +896,10 @@ cl_build_status cvk_program::link() {
 
     m_binary.use(std::move(linked_opt));
 
-    // Merge descriptor maps
-    for (cl_uint i = 0; i < m_num_input_programs; i++) {
-        m_binary.insert_descriptor_map(m_input_programs[i]->m_binary);
+    // Load descriptor map
+    if (!m_binary.load_descriptor_map()) {
+      cvk_error("Could not load descriptor map for SPIR-V binary.");
+      return CL_BUILD_ERROR;
     }
 
     cvk_debug_fn("linked binary has %zu kernels",
@@ -961,12 +962,13 @@ void cvk_program::do_build() {
         if (!m_binary.loaded_from_binary()) {
             status = compile_source(device);
         }
-        prepare_push_constant_range();
         break;
     case build_operation::link:
         status = link();
         break;
     }
+
+    prepare_push_constant_range();
 
     if ((m_operation == build_operation::compile) ||
         (status != CL_BUILD_SUCCESS)) {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -516,13 +516,6 @@ bool spir_binary::load_descriptor_map() {
     return true;
 }
 
-void spir_binary::insert_descriptor_map(const spir_binary& other) {
-    for (auto& args : other.kernels_arguments()) {
-        m_dmaps[args.first] = args.second;
-    }
-    m_dmaps_text += other.m_dmaps_text;
-}
-
 bool spir_binary::get_capabilities(
     std::vector<spv::Capability>& capabilities) const {
     // Callback for receiving parsed instructions.

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -898,8 +898,8 @@ cl_build_status cvk_program::link() {
 
     // Load descriptor map
     if (!m_binary.load_descriptor_map()) {
-      cvk_error("Could not load descriptor map for SPIR-V binary.");
-      return CL_BUILD_ERROR;
+        cvk_error("Could not load descriptor map for SPIR-V binary.");
+        return CL_BUILD_ERROR;
     }
 
     cvk_debug_fn("linked binary has %zu kernels",

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -119,7 +119,6 @@ public:
     CHECK_RETURN bool load_spir(const char* fname);
     CHECK_RETURN bool load_spir(std::istream& istream, uint32_t size);
     CHECK_RETURN bool load_descriptor_map();
-    void insert_descriptor_map(const spir_binary& other);
     CHECK_RETURN bool save_spir(const char* fname) const;
     CHECK_RETURN bool load(std::istream& istream);
     CHECK_RETURN bool save(std::ostream& ostream) const;
@@ -201,7 +200,6 @@ private:
     std::unordered_map<spec_constant, uint32_t> m_spec_constants;
     kernels_arguments_map m_dmaps;
     kernels_reqd_work_group_size_map m_reqd_work_group_sizes;
-    std::string m_dmaps_text;
     bool m_loaded_from_binary;
     spv_target_env m_target_env;
 };

--- a/tests/api/compiler.cpp
+++ b/tests/api/compiler.cpp
@@ -82,7 +82,7 @@ TEST_F(WithCommandQueue, CompileAndLinkWithPushConstants) {
 
 // Test that literal sampler information is propagated correctly when linking.
 TEST_F(WithCommandQueue, CompileAndLinkWithLiteralSamplers) {
-    // Read just past the end of a 1D image width two different samplers.
+    // Read just past the end of a 1D image with two different samplers.
     static const char* source = R"(
         static constant sampler_t sampler_clamp = CLK_ADDRESS_CLAMP_TO_EDGE |
                                                   CLK_NORMALIZED_COORDS_TRUE |

--- a/tests/api/compiler.cpp
+++ b/tests/api/compiler.cpp
@@ -54,7 +54,7 @@ TEST_F(WithCommandQueue, CompileAndLinkWithPushConstants) {
     CompileProgram(program, "-cl-std=CL2.0");
 
     cl_program program_list = program;
-    holder<cl_program> linked_program = LinkProgram(1, &program_list);
+    auto linked_program = LinkProgram(1, &program_list);
 
     auto gws_output = CreateBuffer(CL_MEM_READ_WRITE, sizeof(cl_uint));
     auto lws_output = CreateBuffer(CL_MEM_READ_WRITE, sizeof(cl_uint));
@@ -103,7 +103,7 @@ TEST_F(WithCommandQueue, CompileAndLinkWithLiteralSamplers) {
     CompileProgram(program);
 
     cl_program program_list = program;
-    holder<cl_program> linked_program = LinkProgram(1, &program_list);
+    auto linked_program = LinkProgram(1, &program_list);
 
     // Create a 1D input image.
     size_t IMAGE_WIDTH = 4;

--- a/tests/api/compiler.cpp
+++ b/tests/api/compiler.cpp
@@ -72,11 +72,11 @@ TEST_F(WithCommandQueue, CompileAndLinkWithPushConstants) {
 
     // Check results.
     cl_uint result = -1;
-    EnqueueReadBuffer(gws_output, CL_TRUE, 0, sizeof(cl_uint), &result);
+    EnqueueReadBuffer(gws_output, CL_BLOCKING, 0, sizeof(cl_uint), &result);
     EXPECT_EQ(result, gws[0]);
-    EnqueueReadBuffer(lws_output, CL_TRUE, 0, sizeof(cl_uint), &result);
+    EnqueueReadBuffer(lws_output, CL_BLOCKING, 0, sizeof(cl_uint), &result);
     EXPECT_EQ(result, lws[0]);
-    EnqueueReadBuffer(dim_output, CL_TRUE, 0, sizeof(cl_uint), &result);
+    EnqueueReadBuffer(dim_output, CL_BLOCKING, 0, sizeof(cl_uint), &result);
     EXPECT_EQ(result, 1);
 }
 
@@ -150,8 +150,8 @@ TEST_F(WithCommandQueue, CompileAndLinkWithLiteralSamplers) {
 
     // Check results.
     cl_uint result = -1;
-    EnqueueReadBuffer(clamp_output, CL_TRUE, 0, sizeof(cl_uint), &result);
+    EnqueueReadBuffer(clamp_output, CL_BLOCKING, 0, sizeof(cl_uint), &result);
     EXPECT_EQ(result, value_end);
-    EnqueueReadBuffer(repeat_output, CL_TRUE, 0, sizeof(cl_uint), &result);
+    EnqueueReadBuffer(repeat_output, CL_BLOCKING, 0, sizeof(cl_uint), &result);
     EXPECT_EQ(result, value_start);
 }

--- a/tests/api/compiler.cpp
+++ b/tests/api/compiler.cpp
@@ -79,3 +79,79 @@ TEST_F(WithCommandQueue, CompileAndLinkWithPushConstants) {
     EnqueueReadBuffer(dim_output, CL_TRUE, 0, sizeof(cl_uint), &result);
     EXPECT_EQ(result, 1);
 }
+
+// Test that literal sampler information is propagated correctly when linking.
+TEST_F(WithCommandQueue, CompileAndLinkWithLiteralSamplers) {
+    // Read just past the end of a 1D image width two different samplers.
+    static const char* source = R"(
+        static constant sampler_t sampler_clamp = CLK_ADDRESS_CLAMP_TO_EDGE |
+                                                  CLK_NORMALIZED_COORDS_TRUE |
+                                                  CLK_FILTER_NEAREST;
+        static constant sampler_t sampler_repeat = CLK_ADDRESS_REPEAT |
+                                                   CLK_NORMALIZED_COORDS_TRUE |
+                                                   CLK_FILTER_NEAREST;
+        kernel void test(read_only image1d_t input,
+                         global uint *output_clamp,
+                         global uint *output_repeat) {
+          *output_clamp = read_imageui(input, sampler_clamp, 1.f).x;
+          *output_repeat = read_imageui(input, sampler_repeat, 1.f).x;
+        }
+    )";
+
+    auto program = CreateProgram(source);
+
+    CompileProgram(program);
+
+    cl_program program_list = program;
+    holder<cl_program> linked_program = LinkProgram(1, &program_list);
+
+    // Create a 1D input image.
+    size_t IMAGE_WIDTH = 4;
+    cl_image_format format = {CL_R, CL_UNSIGNED_INT8};
+    cl_image_desc desc = {
+        CL_MEM_OBJECT_IMAGE1D, // image_type
+        IMAGE_WIDTH,           // image_width
+        1,                     // image_height
+        1,                     // image_depth
+        1,                     // image_array_size
+        0,                     // image_row_pitch
+        0,                     // image_slice_pitch
+        0,                     // num_mip_levels
+        0,                     // num_samples
+        nullptr,               // buffer
+    };
+    auto input = CreateImage(CL_MEM_READ_ONLY, &format, &desc);
+
+    // Set the input image values.
+    cl_uchar value_start = 7;
+    cl_uchar value_end = 42;
+    size_t origin[3] = {0, 0, 0};
+    size_t region[3] = {IMAGE_WIDTH, 1, 1};
+    size_t row_pitch = IMAGE_WIDTH;
+    auto data = EnqueueMapImage<cl_uchar>(input, CL_BLOCKING,
+                                          CL_MAP_WRITE_INVALIDATE_REGION,
+                                          origin, region, &row_pitch, nullptr);
+    memset(data, 0xFF, IMAGE_WIDTH);
+    data[0] = value_start;
+    data[IMAGE_WIDTH - 1] = value_end;
+    EnqueueUnmapMemObject(input, data);
+
+    auto clamp_output = CreateBuffer(CL_MEM_READ_WRITE, sizeof(cl_uint));
+    auto repeat_output = CreateBuffer(CL_MEM_READ_WRITE, sizeof(cl_uint));
+
+    auto kernel = CreateKernel(linked_program, "test");
+    SetKernelArg(kernel, 0, input);
+    SetKernelArg(kernel, 1, clamp_output);
+    SetKernelArg(kernel, 2, repeat_output);
+    size_t gws[3] = {32, 1, 1};
+    size_t lws[3] = {8, 1, 1};
+    EnqueueNDRangeKernel(kernel, 1, nullptr, gws, lws);
+    Finish();
+
+    // Check results.
+    cl_uint result = -1;
+    EnqueueReadBuffer(clamp_output, CL_TRUE, 0, sizeof(cl_uint), &result);
+    EXPECT_EQ(result, value_end);
+    EnqueueReadBuffer(repeat_output, CL_TRUE, 0, sizeof(cl_uint), &result);
+    EXPECT_EQ(result, value_start);
+}

--- a/tests/api/images.cpp
+++ b/tests/api/images.cpp
@@ -91,7 +91,7 @@ TEST_F(WithCommandQueue, DISABLED_TALVOS(BasicImageMapUnmap)) {
         0,                     // num_samples
         nullptr,               // buffer
     };
-    auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc, nullptr);
+    auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc);
 
     // Map it
     size_t origin[3] = {0, 0, 0};
@@ -185,7 +185,7 @@ TEST_F(WithCommandQueue, ImageReadMappingCantChangeImage) {
         0,                     // num_samples
         nullptr,               // buffer
     };
-    auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc, nullptr);
+    auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc);
 
     // Init with pattern
     size_t origin[3] = {0, 0, 0};
@@ -257,7 +257,7 @@ TEST_F(WithCommandQueue,
         0,                     // num_samples
         nullptr,               // buffer
     };
-    auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc, nullptr);
+    auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc);
 
     // Init content
     size_t origin[3] = {0, 0, 0};

--- a/tests/api/simple_image.cpp
+++ b/tests/api/simple_image.cpp
@@ -56,7 +56,7 @@ TEST_F(WithCommandQueue, DISABLED_TALVOS_SWIFTSHADER(SimpleImage)) {
         0,                     // num_samples
         nullptr,               // buffer
     };
-    auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc, nullptr);
+    auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc);
 
     // Create the sampler
     auto sampler = CreateSampler(CL_FALSE, CL_ADDRESS_CLAMP, CL_FILTER_NEAREST);

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -347,7 +347,7 @@ protected:
     holder<cl_mem> CreateImage(cl_mem_flags flags,
                                const cl_image_format* image_format,
                                const cl_image_desc* image_desc,
-                               void* host_ptr) {
+                               void* host_ptr = nullptr) {
         cl_int err;
         auto mem = clCreateImage(m_context, flags, image_format, image_desc,
                                  host_ptr, &err);

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -230,6 +230,34 @@ protected:
         return program;
     }
 
+    void CompileProgram(cl_program program, const char* options = nullptr) {
+        cl_int err = clCompileProgram(program, 1, &gDevice, options, 0, nullptr,
+                                      nullptr, nullptr, nullptr);
+        EXPECT_CL_SUCCESS(err);
+
+        if (err != CL_SUCCESS) {
+            std::string build_log = GetProgramBuildLog(program);
+            printf("Build log:\n%s\n", build_log.c_str());
+        }
+    }
+
+    holder<cl_program> LinkProgram(cl_uint num_input_programs,
+                                   cl_program* input_programs,
+                                   const char* options = nullptr) {
+        cl_int err;
+        auto program =
+            clLinkProgram(m_context, 1, &gDevice, options, num_input_programs,
+                          input_programs, nullptr, nullptr, &err);
+        EXPECT_CL_SUCCESS(err);
+
+        if (err != CL_SUCCESS) {
+            std::string build_log = GetProgramBuildLog(program);
+            printf("Build log:\n%s\n", build_log.c_str());
+        }
+
+        return program;
+    }
+
     std::string GetProgramBuildLog(cl_program program) {
         size_t log_size;
         cl_int err = clGetProgramBuildInfo(
@@ -299,7 +327,7 @@ protected:
     }
 
     holder<cl_mem> CreateBuffer(cl_mem_flags flags, size_t size,
-                                void* host_ptr) {
+                                void* host_ptr = nullptr) {
         cl_int err;
         auto mem = clCreateBuffer(m_context, flags, size, host_ptr, &err);
         EXPECT_CL_SUCCESS(err);
@@ -510,6 +538,22 @@ protected:
 
     void EnqueueUnmapMemObject(cl_mem memobj, void* mapped_ptr) {
         EnqueueUnmapMemObject(memobj, mapped_ptr, 0, nullptr, nullptr);
+    }
+
+    void EnqueueReadBuffer(cl_mem buffer, cl_bool blocking_read, size_t offset,
+                           size_t size, void* ptr,
+                           cl_uint num_events_in_wait_list,
+                           const cl_event* event_wait_list, cl_event* event) {
+        auto err = clEnqueueReadBuffer(m_queue, buffer, blocking_read, offset,
+                                       size, ptr, num_events_in_wait_list,
+                                       event_wait_list, event);
+        ASSERT_CL_SUCCESS(err);
+    }
+
+    void EnqueueReadBuffer(cl_mem buffer, cl_bool blocking_read, size_t offset,
+                           size_t size, void* ptr) {
+        EnqueueReadBuffer(buffer, blocking_read, offset, size, ptr, 0, nullptr,
+                          nullptr);
     }
 
     void EnqueueWriteBuffer(cl_mem buffer, cl_bool blocking_write,


### PR DESCRIPTION
Otherwise push constants, spec constants, and required work-group size information will not be present in the linked binary.

This fixes some CTS regressions introduced by #283. The Clspv update is needed for a recent bugfix that affects the test case added in this PR.