### PR TITLE
Fix clFinish when called just after clFlush

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -2823,15 +2823,7 @@ cl_int CLVK_API_CALL clFinish(cl_command_queue command_queue) {
         return CL_INVALID_COMMAND_QUEUE;
     }
 
-    cvk_event* event = nullptr;
-    cl_int status = icd_downcast(command_queue)->flush(&event);
-
-    if ((status == CL_SUCCESS) && (event != nullptr)) {
-        event->wait();
-        event->release();
-    }
-
-    return status;
+    return icd_downcast(command_queue)->finish();
 }
 
 /* Enqueued Commands APIs */

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -230,6 +230,8 @@ private:
     std::mutex m_lock;
 };
 
+using cvk_event_holder = refcounted_holder<cvk_event>;
+
 struct cvk_command_queue : public _cl_command_queue, api_object {
 
     cvk_command_queue(cvk_context* ctx, cvk_device* dev,
@@ -256,7 +258,9 @@ struct cvk_command_queue : public _cl_command_queue, api_object {
 
     CHECK_RETURN static cl_int wait_for_events(cl_uint num_events,
                                                const cl_event* event_list);
-    CHECK_RETURN cl_int flush(cvk_event** event = nullptr);
+    CHECK_RETURN cl_int flush_no_lock();
+    CHECK_RETURN cl_int flush();
+    CHECK_RETURN cl_int finish();
     bool profiling_on_device() const {
         return m_device->has_timer_support() ||
                gQueueProfilingUsesTimestampQueries;
@@ -292,6 +296,7 @@ private:
     std::vector<cl_queue_properties> m_properties_array;
 
     cvk_executor_thread* m_executor;
+    cvk_event_holder m_finish_event;
 
     std::mutex m_lock;
     std::deque<std::unique_ptr<cvk_command_group>> m_groups;

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -343,7 +343,6 @@ void finish_after_flush_thread(void* data) {
 
 } // namespace
 
-
 TEST_F(WithCommandQueue, FinishAfterFlush) {
     auto uevent = CreateUserEvent();
 
@@ -363,7 +362,8 @@ TEST_F(WithCommandQueue, FinishAfterFlush) {
     thread_data.finish_returned = 42;
     thread_data.started_running = false;
 
-    auto thread = std::make_unique<std::thread>(finish_after_flush_thread, &thread_data);
+    auto thread =
+        std::make_unique<std::thread>(finish_after_flush_thread, &thread_data);
 
     while (!thread_data.started_running) {
         usleep(500);

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -15,6 +15,7 @@
 #include "testcl.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <thread>
 
 TEST_F(WithCommandQueue, ManyInstancesInFlight) {
@@ -365,11 +366,13 @@ TEST_F(WithCommandQueue, FinishAfterFlush) {
     auto thread =
         std::make_unique<std::thread>(finish_after_flush_thread, &thread_data);
 
+    using namespace std::literals;
+
     while (!thread_data.started_running) {
-        usleep(500);
+        std::this_thread::sleep_for(500us);
     }
 
-    usleep(1000);
+    std::this_thread::sleep_for(1000us);
 
     int res = thread_data.finish_returned;
     if (res != 42) {


### PR DESCRIPTION
Always keep the last event produced as part of sending work to the
executor in the queue. Wait on that event in clFinish.

The test is not bullet-proof (hard to guarantee that the thread
about to call clFinish is blocked without blocking) but in my tests
failed 100% of the time before the fix and passed 100% of the time
after.

Fixes #241

Signed-off-by: Kévin Petit <kpet@free.fr>