### PR TITLE
Add missing icd.hpp include in objects.hpp

### DIFF
--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -30,6 +30,7 @@
 #include <vulkan/vulkan.h>
 
 #include "cl_headers.hpp"
+#include "icd.hpp"
 #include "log.hpp"
 
 enum class object_magic : uint32_t


### PR DESCRIPTION
Without this, `_cl_context` is not a complete type, which causes build failures since it is used as a base class in this file. The `icd.hpp` include was previously happening indirectly via `device.hpp`, but that include was removed in 3961358.