### PR TITLE
Support cl_arm_non_uniform_work_group_size

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -369,6 +369,7 @@ void cvk_device::build_extension_ils_list() {
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_il_program"),
 #endif
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_spirv_no_integer_wrap_decoration"),
+        MAKE_NAME_VERSION(1, 0, 0, "cl_arm_non_uniform_work_group_size"),
     };
 
     if (m_properties.apiVersion >= VK_MAKE_VERSION(1, 1, 0)) {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -664,9 +664,6 @@ cl_build_status cvk_program::compile_source(const cvk_device* device) {
         // FIXME The 1.2 conformance tests shouldn't pass this option.
         //       It doesn't exist after OpenCL 1.0.
         {"-cl-strict-aliasing", ""},
-        // Some applications pass this even when using uniform NDRanges
-        // Swallow the flag to enable these use cases
-        {"-cl-arm-non-uniform-work-group-size", ""},
         // clspv require entrypoint inlining for OpenCL 2.0
         {"-cl-std=CL2.0", "-cl-std=CL2.0 -inline-entry-points"},
     };


### PR DESCRIPTION
Update clspv to be able to use the corresponding option.