### PR TITLE
Improve global state destruction

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -278,22 +278,8 @@ clvk_global_state::~clvk_global_state() {
     term_logging();
 }
 
-static clvk_global_state* gGlobalState;
-static std::once_flag gInitOnceFlag;
-
-static void destroy_global_state() { delete gGlobalState; }
-
-static void init_global_state() {
-    gGlobalState = new clvk_global_state();
-#ifndef WIN32
-    if (atexit(destroy_global_state) != 0) {
-        cvk_fatal(
-            "Could not register global state destructor using atexit()\n");
-    }
-#endif
-}
 
 clvk_global_state* get_or_init_global_state() {
-    std::call_once(gInitOnceFlag, init_global_state);
-    return gGlobalState;
+    static clvk_global_state state;
+    return &state;
 }


### PR DESCRIPTION
Simplify the order of objects destruction by relying on C++'s rule for
ctor/dtor execution order. Using std::atexit is not necessary and
increases code complexity.

To work properly, an OpenCL application must ensure all of its static
objects that rely on the OpenCL API in their destructors (e.g.
cl::CommandQueue) are destroyed before CLVK runtime is. Due to how
std::exit works, the application must ensure the CLVK runtime is
initialised before the completion of the constructor of such static
objects.

This can be done in several ways, such as calling:

    clGetPlatformIDs(0, nullptr, nullptr); // returns CL_INVALID_VALUE

before constructing such static objects, or, at the very least, before
the end of their constructors.

Additionally, one should remember this part of the OpenCL API
Specification (Appendix A):

> The behavior of OpenCL API functions called from global constructors
> or destructors is therefore implementation-defined.
