### PR TITLE
add support for CL_MEM_OBJECT_IMAGE1D_BUFFER

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1837,7 +1837,7 @@ cl_int CLVK_API_CALL clGetMemObjectInfo(cl_mem mem, cl_mem_info param_name,
         break;
     case CL_MEM_ASSOCIATED_MEMOBJECT:
         if (memobj->is_image_type()) {
-            auto img = static_cast<cvk_image*>(mem);
+            auto img = static_cast<cvk_image*>(memobj);
             val_memobj = img->buffer();
         } else {
             val_memobj = memobj->parent();

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1836,7 +1836,12 @@ cl_int CLVK_API_CALL clGetMemObjectInfo(cl_mem mem, cl_mem_info param_name,
         ret_size = sizeof(val_uint);
         break;
     case CL_MEM_ASSOCIATED_MEMOBJECT:
-        val_memobj = memobj->parent();
+        if (memobj->is_image_type()) {
+            auto img = static_cast<cvk_image*>(mem);
+            val_memobj = img->buffer();
+        } else {
+            val_memobj = memobj->parent();
+        }
         copy_ptr = &val_memobj;
         ret_size = sizeof(val_memobj);
         break;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -792,6 +792,7 @@ bool cvk_device::supports_capability(spv::Capability capability) const {
     case spv::CapabilitySampled1D:
     case spv::CapabilityImage1D:
     case spv::CapabilityImageQuery:
+    case spv::CapabilityImageBuffer:
         return true;
     // Optional capabilities:
     case spv::CapabilityFloat16:

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -14,7 +14,6 @@
 
 #include <cmath>
 
-#include "CL/cl.h"
 #include "memory.hpp"
 
 bool cvk_mem::map() {

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -128,6 +128,14 @@ struct cvk_mem : public _cl_mem, api_object<object_magic::memory_object> {
         return m_properties;
     }
 
+    cvk_memory_allocation* memory() const {
+        if (m_parent == nullptr) {
+            return m_memory.get();
+        } else {
+            return m_parent->memory();
+        }
+    }
+
     static bool is_image_type(cl_mem_object_type type) {
         return ((type == CL_MEM_OBJECT_IMAGE1D) ||
                 (type == CL_MEM_OBJECT_IMAGE1D_ARRAY) ||
@@ -415,6 +423,9 @@ struct cvk_image : public cvk_mem {
         }
         if (m_image_view != VK_NULL_HANDLE) {
             vkDestroyImageView(vkdev, m_image_view, nullptr);
+        }
+        if (buffer() != nullptr) {
+            buffer()->release();
         }
     }
 


### PR DESCRIPTION
cl_image use the vkMemory from the cl_buffer.
it only works if the device host visible memory is also device local
memory so that the memory can be bind by vulkan to the vkImage.