### PR TITLE
Add test that loads program from IL Binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,11 @@ endif()
 # empty list again
 set(LLVM_TARGETS_TO_BUILD AArch64 CACHE STRING
     "Semicolon-separated list of targets to build, or \"all\".")
+if (CLVK_COMPILER_AVAILABLE AND NOT CLVK_CLSPV_ONLINE_COMPILER)
+  # clang used to test simple_test_from_il_binary in CI
+  set(LLVM_ENABLE_PROJECTS clang CACHE STRING
+      "Control which projects are enabled.")
+endif()
 set(CLSPV_SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/clspv
     CACHE STRING "Clspv source directory")
 add_subdirectory(${CLSPV_SOURCE_DIR} ${PROJECT_BINARY_DIR}/external/clspv

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,11 @@ if (CLVK_COMPILER_AVAILABLE)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/api)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sha1)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/simple)
+
+if (NOT CLVK_CLSPV_ONLINE_COMPILER)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/simple-from-il-binary)
+endif()
+
 endif()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/simple-from-binary)
 

--- a/tests/azure/job-precommit.yml
+++ b/tests/azure/job-precommit.yml
@@ -47,6 +47,8 @@ jobs:
       buildType: ${{ parameters.buildType }}
       artifactName: ${{ parameters.artifactName }}
       vulkanImplementation: swiftshader
+      compilerAvailable: ${{ parameters.compilerAvailable }}
+      onlineCompiler: ${{ parameters.onlineCompiler }}
   - template: steps-run-tests.yml
     parameters:
       os: ${{ parameters.os }}

--- a/tests/azure/job-precommit.yml
+++ b/tests/azure/job-precommit.yml
@@ -16,6 +16,8 @@ parameters:
   - name: compilerAvailable
     type: boolean
     default: true
+  - name: onlineCompiler
+    type: boolean
 
 jobs:
 - job: ${{ parameters.namePrefix }}_${{ parameters.buildType }}
@@ -49,4 +51,5 @@ jobs:
     parameters:
       os: ${{ parameters.os }}
       compilerAvailable: ${{ parameters.compilerAvailable }}
+      onlineCompiler: ${{ parameters.onlineCompiler }}
 

--- a/tests/azure/pipeline-precommit.yml
+++ b/tests/azure/pipeline-precommit.yml
@@ -36,6 +36,7 @@ stages:
       cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=1'
       buildType: Release
       artifactName: Windows_Builtin_Compiler
+      onlineCompiler: true
   - template: job-precommit.yml
     parameters:
       namePrefix: Windows_2019_MSVC_2019_offline_clspv
@@ -44,6 +45,7 @@ stages:
       cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=0'
       buildType: Release
       artifactName: Windows_Separate_Compiler
+      onlineCompiler: false
   - template: job-precommit.yml
     parameters:
       namePrefix: Ubuntu_18_04_online_clspv
@@ -52,6 +54,7 @@ stages:
       cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=1'
       buildType: Release
       artifactName: Linux_Builtin_Compiler
+      onlineCompiler: true
   - template: job-precommit.yml
     parameters:
       namePrefix: Ubuntu_18_04_offline_clspv
@@ -60,6 +63,7 @@ stages:
       cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=0'
       buildType: Release
       artifactName: Linux_Separate_Compiler
+      onlineCompiler: false
   - template: job-precommit.yml
     parameters:
       namePrefix: macOS_X_Catalina_10_15_online_clspv
@@ -68,6 +72,7 @@ stages:
       cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=1'
       buildType: Release
       artifactName: macOS_Builtin_Compiler
+      onlineCompiler: true
   - template: job-precommit.yml
     parameters:
       namePrefix: macOS_X_Catalina_10_15_offline_clspv
@@ -76,6 +81,7 @@ stages:
       cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=0'
       buildType: Debug
       artifactName: macOS_Separate_Compiler_Debug
+      onlineCompiler: false
   - template: job-precommit.yml
     parameters:
       namePrefix: Ubuntu_18_04_nocompiler
@@ -85,6 +91,7 @@ stages:
       buildType: Release
       artifactName: Linux_NoCompiler
       compilerAvailable: false
+      onlineCompiler: false
   - template: job-precommit.yml
     parameters:
       namePrefix: Android_AArch64_online_clspv
@@ -93,3 +100,4 @@ stages:
       cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=1 -DCMAKE_TOOLCHAIN_FILE=$(Build.SourcesDirectory)/ndk/android-ndk-r22/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a'
       buildType: Release
       artifactName: Android_Builtin_Compiler
+      onlineCompiler: true

--- a/tests/azure/steps-build.yml
+++ b/tests/azure/steps-build.yml
@@ -27,6 +27,10 @@ parameters:
       default: true
     - name: artifactName
       type: string
+    - name: compilerAvailable
+      type: boolean
+    - name: onlineCompiler
+      type: boolean
 
 steps:
   - script: mkdir build
@@ -66,6 +70,11 @@ steps:
         which ccache && ccache --show-stats || echo "ccache not available"
         make -C build -j3 clspv
       displayName: make
+    - script: |
+        which ccache && ccache --show-stats || echo "ccache not available"
+        make -C build -j3 clang
+      displayName: make clang
+      condition: and(${{ parameters.compilerAvailable }}, not(${{ parameters.onlineCompiler }}))
   - script: cmake --install ./build
     displayName: install
   - publish: ./build/install

--- a/tests/azure/steps-run-tests.yml
+++ b/tests/azure/steps-run-tests.yml
@@ -10,6 +10,8 @@ parameters:
     type: string
   - name: compilerAvailable
     type: boolean
+  - name: onlineCompiler
+    type: boolean
 
 steps:
   - download: swiftshader
@@ -43,7 +45,8 @@ steps:
         export CLVK_LOG=3
         ./build/simple_test_from_il_binary
         ./build/simple_test_from_il_binary_static
-      displayName: Offline IR compilation simple tests
+      displayName: Offline IL compilation simple tests
+      condition: and(${{ parameters.compilerAvailable }}, not(${{ parameters.onlineCompiler }}))
   - ${{ if eq(parameters.os, 'windows') }}:
     - script: |
         cp build/src/Release/OpenCL.dll build/Release

--- a/tests/azure/steps-run-tests.yml
+++ b/tests/azure/steps-run-tests.yml
@@ -37,7 +37,7 @@ steps:
       displayName: Offline compilation simple tests
     - script: |
         set -ex
-        clang -c -target spir -O0 -emit-llvm -o simple-cl.bc ./tests/simple-from-il-binary/simple.cl
+        clang  -Xclang -finclude-default-header -c -target spir -O0 -emit-llvm -o simple-cl.bc ./tests/simple-from-il-binary/simple.cl
         ./build/llvm-spirv simple-cl.bc -o simple-cl.spv
         export VK_ICD_FILENAMES=${{ parameters.icd_json_unix }}
         export CLVK_LOG=3

--- a/tests/azure/steps-run-tests.yml
+++ b/tests/azure/steps-run-tests.yml
@@ -39,7 +39,7 @@ steps:
       displayName: Offline compilation simple tests
     - script: |
         set -ex
-        clang  -Xclang -finclude-default-header -c -target spir -O0 -emit-llvm -o simple-cl.bc ./tests/simple-from-il-binary/simple.cl
+        ./build/external/clspv/third_party/llvm/bin/clang  -Xclang -finclude-default-header -c -target spir -O0 -emit-llvm -o simple-cl.bc ./tests/simple-from-il-binary/simple.cl
         ./build/llvm-spirv simple-cl.bc -o simple-cl.spv
         export VK_ICD_FILENAMES=${{ parameters.icd_json_unix }}
         export CLVK_LOG=3

--- a/tests/azure/steps-run-tests.yml
+++ b/tests/azure/steps-run-tests.yml
@@ -35,6 +35,15 @@ steps:
         ./build/simple_test_from_binary
         ./build/simple_test_from_binary_static
       displayName: Offline compilation simple tests
+    - script: |
+        set -ex
+        clang -c -target spir -O0 -emit-llvm -o simple-cl.bc ./tests/simple-from-il-binary/simple.cl
+        ./build/llvm-spirv simple-cl.bc -o simple-cl.spv
+        export VK_ICD_FILENAMES=${{ parameters.icd_json_unix }}
+        export CLVK_LOG=3
+        ./build/simple_test_from_il_binary
+        ./build/simple_test_from_il_binary_static
+      displayName: Offline IR compilation simple tests
   - ${{ if eq(parameters.os, 'windows') }}:
     - script: |
         cp build/src/Release/OpenCL.dll build/Release

--- a/tests/simple-from-il-binary/CMakeLists.txt
+++ b/tests/simple-from-il-binary/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2022 The clvk authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(BINARY_NAME simple_test_from_il_binary)
+set(BINARY_NAME_STATIC simple_test_from_il_binary_static)
+
+add_executable(${BINARY_NAME} simple.cpp)
+add_executable(${BINARY_NAME_STATIC} simple.cpp)
+
+target_link_libraries(${BINARY_NAME} OpenCL)
+target_link_libraries(${BINARY_NAME_STATIC} OpenCL-static)
+
+set_target_properties(${BINARY_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+    ${CMAKE_BINARY_DIR})
+set_target_properties(${BINARY_NAME_STATIC} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+    ${CMAKE_BINARY_DIR})
+

--- a/tests/simple-from-il-binary/simple.cl
+++ b/tests/simple-from-il-binary/simple.cl
@@ -1,0 +1,5 @@
+kernel void test_simple(global uint* out)
+{
+    size_t gid = get_global_id(0);
+    out[gid] = gid;
+}

--- a/tests/simple-from-il-binary/simple.cpp
+++ b/tests/simple-from-il-binary/simple.cpp
@@ -64,18 +64,13 @@ int main(int argc, char* argv[]) {
                           &extensions_length);
     CHECK_CL_ERRCODE(err);
 
-    char* extensions = (char*)calloc(extensions_length + 1, sizeof(char));
-    err =
-        clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS,
-                        sizeof(char) * extensions_length, extensions, nullptr);
+    std::vector<char> extensions(extensions_length);
+    err = clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, extensions_length,
+                          extensions.data(), nullptr);
     CHECK_CL_ERRCODE(err);
 
-    if (extensions[extensions_length] != '\0') {
-        fprintf(stderr, "CL_DEVICE_EXTENSIONS is not null-terminated\n");
-        return EXIT_FAILURE;
-    }
-
-    if (strstr(extensions, "cl_khr_il_program") == nullptr) {
+    if (std::string(extensions.data()).find("cl_khr_il_program") ==
+        std::string::npos) {
         fprintf(stderr,
                 "cl_khr_il_program extension is not supported by device\n");
         return EXIT_FAILURE;
@@ -111,15 +106,15 @@ int main(int argc, char* argv[]) {
 
     // Create program
     size_t program_size = size;
-    const unsigned char* program_code =
-        reinterpret_cast<const unsigned char*>(code.data());
+    auto program_code = reinterpret_cast<const unsigned char*>(code.data());
 
     clCreateProgramWithILKHR_fn clCreateProgramWithILKHR = NULL;
     clCreateProgramWithILKHR =
         (clCreateProgramWithILKHR_fn)clGetExtensionFunctionAddressForPlatform(
             platform, "clCreateProgramWithILKHR");
     if (clCreateProgramWithILKHR == NULL) {
-        fprintf(stderr, "Failed to find extension clCreateProgramWithILKHR\n");
+        fprintf(stderr,
+                "Failed to find extension function clCreateProgramWithILKHR\n");
         return EXIT_FAILURE;
     }
     auto program =

--- a/tests/simple-from-il-binary/simple.cpp
+++ b/tests/simple-from-il-binary/simple.cpp
@@ -1,0 +1,177 @@
+// Copyright 2022 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <vector>
+
+#define CL_TARGET_OPENCL_VERSION 120
+#include "CL/cl.h"
+#include "CL/cl_ext.h"
+
+#define BUFFER_SIZE 1024
+
+#define CHECK_CL_ERRCODE(err)                                                  \
+    do {                                                                       \
+        if (err != CL_SUCCESS) {                                               \
+            fprintf(stderr, "%s:%d error after CL call: %d\n", __FILE__,       \
+                    __LINE__, err);                                            \
+            return EXIT_FAILURE;                                               \
+        }                                                                      \
+    } while (0)
+
+int main(int argc, char* argv[]) {
+    cl_platform_id platform;
+    cl_device_id device;
+    cl_int err;
+
+    // Get the first GPU device of the first platform
+    err = clGetPlatformIDs(1, &platform, nullptr);
+    CHECK_CL_ERRCODE(err);
+
+    char platform_name[128];
+    err = clGetPlatformInfo(platform, CL_PLATFORM_NAME, sizeof(platform_name),
+                            platform_name, nullptr);
+    CHECK_CL_ERRCODE(err);
+
+    printf("Platform: %s\n", platform_name);
+
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, nullptr);
+    CHECK_CL_ERRCODE(err);
+
+    char device_name[128];
+    err = clGetDeviceInfo(device, CL_DEVICE_NAME, sizeof(device_name),
+                          device_name, nullptr);
+    CHECK_CL_ERRCODE(err);
+
+    printf("Device: %s\n", device_name);
+
+    auto context = clCreateContext(nullptr, 1, &device, nullptr, nullptr, &err);
+    CHECK_CL_ERRCODE(err);
+
+    // Load program from file
+    std::ifstream ifile;
+    const char* fname = "simple-cl.spv";
+    ifile.open(fname, std::ios::in | std::ios::binary);
+
+    if (!ifile.is_open()) {
+        fprintf(stderr, "Failed to open file %s\n", fname);
+        return EXIT_FAILURE;
+    }
+
+    ifile.seekg(0, std::ios::end);
+    uint32_t size = ifile.tellg();
+    ifile.seekg(0, std::ios::beg);
+
+    const uint32_t SPIR_WORD_SIZE = 4;
+    std::vector<char> code;
+    code.assign(size, 0);
+
+    ifile.read(reinterpret_cast<char*>(code.data()), size);
+    if (!ifile.good()) {
+        fprintf(stderr, "Failed to read SPIR-V module from %s\n", fname);
+        return EXIT_FAILURE;
+    }
+    printf("Loaded SPIR-V data from %s, size = %u\n", fname, size);
+
+    // Create program
+    size_t program_size = size;
+    const unsigned char* program_code =
+        reinterpret_cast<const unsigned char*>(code.data());
+
+    clCreateProgramWithILKHR_fn clCreateProgramWithILKHR = NULL;
+    clCreateProgramWithILKHR =
+        (clCreateProgramWithILKHR_fn)clGetExtensionFunctionAddressForPlatform(
+            platform, "clCreateProgramWithILKHR");
+    if (clCreateProgramWithILKHR == NULL) {
+        fprintf(stderr, "Failed to find extension clCreateProgramWithILKHR\n");
+        return EXIT_FAILURE;
+    }
+    auto program =
+        clCreateProgramWithILKHR(context, program_code, program_size, &err);
+    CHECK_CL_ERRCODE(err);
+
+    // Build program
+    err = clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr);
+    CHECK_CL_ERRCODE(err);
+
+    // Create kernel
+    auto kernel = clCreateKernel(program, "test_simple", &err);
+    CHECK_CL_ERRCODE(err);
+
+    // Create command queue
+    auto queue = clCreateCommandQueue(context, device, 0, &err);
+    CHECK_CL_ERRCODE(err);
+
+    // Create buffer
+    auto buffer =
+        clCreateBuffer(context, CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR,
+                       BUFFER_SIZE, nullptr, &err);
+    CHECK_CL_ERRCODE(err);
+
+    // Set kernel arguments
+    err = clSetKernelArg(kernel, 0, sizeof(cl_mem), &buffer);
+    CHECK_CL_ERRCODE(err);
+
+    size_t gws = BUFFER_SIZE / sizeof(cl_int);
+    size_t lws = 2;
+
+    err = clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &gws, &lws, 0,
+                                 nullptr, nullptr);
+    CHECK_CL_ERRCODE(err);
+
+    // Complete execution
+    err = clFinish(queue);
+    CHECK_CL_ERRCODE(err);
+
+    // Map the buffer
+    auto ptr = clEnqueueMapBuffer(queue, buffer, CL_TRUE, CL_MAP_READ, 0,
+                                  BUFFER_SIZE, 0, nullptr, nullptr, &err);
+    CHECK_CL_ERRCODE(err);
+
+    // Check the expected result
+    bool success = true;
+    auto buffer_data = static_cast<cl_uint*>(ptr);
+    for (cl_uint i = 0; i < BUFFER_SIZE / sizeof(cl_uint); ++i) {
+        if (buffer_data[i] != static_cast<cl_uint>(i)) {
+            printf("Failed comparison at buffer_data[%u]: expected %u but got "
+                   "%u\n",
+                   i, i, buffer_data[i]);
+            success = false;
+        }
+    }
+
+    // Unmap the buffer
+    err = clEnqueueUnmapMemObject(queue, buffer, ptr, 0, nullptr, nullptr);
+    CHECK_CL_ERRCODE(err);
+    err = clFinish(queue);
+    CHECK_CL_ERRCODE(err);
+
+    // Cleanup
+    clReleaseMemObject(buffer);
+    clReleaseCommandQueue(queue);
+    clReleaseKernel(kernel);
+    clReleaseProgram(program);
+    clReleaseContext(context);
+
+    // Report status
+    if (success) {
+        printf("Buffer content verified, test passed.\n");
+        return EXIT_SUCCESS;
+    } else {
+        printf("Test failed.\n");
+        return EXIT_FAILURE;
+    }
+}

--- a/tests/simple-from-il-binary/simple.cpp
+++ b/tests/simple-from-il-binary/simple.cpp
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <string.h>
 #include <vector>
 
 #define CL_TARGET_OPENCL_VERSION 120
@@ -57,6 +58,28 @@ int main(int argc, char* argv[]) {
     CHECK_CL_ERRCODE(err);
 
     printf("Device: %s\n", device_name);
+
+    size_t extensions_length;
+    err = clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, 0, nullptr,
+                          &extensions_length);
+    CHECK_CL_ERRCODE(err);
+
+    char* extensions = (char*)calloc(extensions_length + 1, sizeof(char));
+    err =
+        clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS,
+                        sizeof(char) * extensions_length, extensions, nullptr);
+    CHECK_CL_ERRCODE(err);
+
+    if (extensions[extensions_length] != '\0') {
+        fprintf(stderr, "CL_DEVICE_EXTENSIONS is not null-terminated\n");
+        return EXIT_FAILURE;
+    }
+
+    if (strstr(extensions, "cl_khr_il_program") == nullptr) {
+        fprintf(stderr,
+                "cl_khr_il_program extension is not supported by device\n");
+        return EXIT_FAILURE;
+    }
 
     auto context = clCreateContext(nullptr, 1, &device, nullptr, nullptr, &err);
     CHECK_CL_ERRCODE(err);


### PR DESCRIPTION
Tests using clCreateProgramWithILKHR extension when
CLVK_CLSPV_ONLINE_COMPILER is disabled. Added simple-from-il-binary
test is based off of the existing simple-from-binary test.

Contributes to #45.

@DCastagna @jrprice