### PR TITLE
Support IL binaries in online compilation mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,12 +97,20 @@ set_target_properties(clspv PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                       ${CMAKE_BINARY_DIR})
 
 # SPIRV-LLVM-Translator
-if (CLVK_COMPILER_AVAILABLE AND NOT CLVK_CLSPV_ONLINE_COMPILER)
+if (CLVK_COMPILER_AVAILABLE)
   set(LLVM_DIR
       ${CMAKE_BINARY_DIR}/external/clspv/third_party/llvm/lib/cmake/llvm)
   set(LLVM_SPIRV_SOURCE ${PROJECT_SOURCE_DIR}/external/SPIRV-LLVM-Translator)
   set(LLVM_SPIRV_BUILD_EXTERNAL YES)
   add_subdirectory(${LLVM_SPIRV_SOURCE} EXCLUDE_FROM_ALL)
+
+  if (CLVK_CLSPV_ONLINE_COMPILER)
+    # Include LLVM dependencies for SPIRV-LLVM
+    find_package(LLVM ${BASE_LLVM_VERSION} REQUIRED)
+    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+    message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+    include_directories(${LLVM_INCLUDE_DIRS})
+  endif()
 endif()
 
 # Vulkan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ endif()
 # empty list again
 set(LLVM_TARGETS_TO_BUILD AArch64 CACHE STRING
     "Semicolon-separated list of targets to build, or \"all\".")
-if (CLVK_COMPILER_AVAILABLE AND NOT CLVK_CLSPV_ONLINE_COMPILER)
+if (CLVK_COMPILER_AVAILABLE)
   # clang used to test simple_test_from_il_binary in CI
   set(LLVM_ENABLE_PROJECTS clang CACHE STRING
       "Control which projects are enabled.")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,7 +86,10 @@ endif()
 target_include_directories(OpenCL-objects PRIVATE
   "${CLSPV_SOURCE_DIR}/include")
 if (CLVK_CLSPV_ONLINE_COMPILER)
-  set(OpenCL-dependencies ${OpenCL-dependencies} clspv_core)
+  set(OpenCL-dependencies ${OpenCL-dependencies} clspv_core LLVMSPIRVLib)
+  add_dependencies(OpenCL-objects intrinsics_gen)
+  target_include_directories(OpenCL-objects PRIVATE
+    "${LLVM_SPIRV_SOURCE}/include")
 else()
   if (CLVK_COMPILER_AVAILABLE)
     add_dependencies(OpenCL-objects clspv)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,7 +87,6 @@ target_include_directories(OpenCL-objects PRIVATE
   "${CLSPV_SOURCE_DIR}/include")
 if (CLVK_CLSPV_ONLINE_COMPILER)
   set(OpenCL-dependencies ${OpenCL-dependencies} clspv_core LLVMSPIRVLib)
-  add_dependencies(OpenCL-objects intrinsics_gen)
   target_include_directories(OpenCL-objects PRIVATE
     "${LLVM_SPIRV_SOURCE}/include")
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,14 +93,19 @@ if (CLVK_CLSPV_ONLINE_COMPILER)
 else()
   if (CLVK_COMPILER_AVAILABLE)
     add_dependencies(OpenCL-objects clspv)
-    add_dependencies(OpenCL-objects llvm-spirv)
-    set_target_properties(llvm-spirv PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-      ${CMAKE_BINARY_DIR})
     target_compile_definitions(OpenCL-objects PRIVATE
-      DEFAULT_LLVMSPIRV_BINARY_PATH="$<TARGET_FILE:llvm-spirv>")
-    target_compile_definitions(OpenCL-objects PRIVATE
-      DEFAULT_CLSPV_BINARY_PATH="$<TARGET_FILE:clspv>")
+    DEFAULT_CLSPV_BINARY_PATH="$<TARGET_FILE:clspv>")
   endif()
+endif()
+
+# llvm-spirv needed to test simple_test_from_il_binary in CI even when
+# not used in online compilation mode
+if (CLVK_COMPILER_AVAILABLE)
+  add_dependencies(OpenCL-objects llvm-spirv)
+  set_target_properties(llvm-spirv PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+    ${CMAKE_BINARY_DIR})
+  target_compile_definitions(OpenCL-objects PRIVATE
+    DEFAULT_LLVMSPIRV_BINARY_PATH="$<TARGET_FILE:llvm-spirv>")
 endif()
 
 if(WIN32)

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -375,9 +375,7 @@ void cvk_device::build_extension_ils_list() {
         // Add always supported extensions
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_extended_versioning"),
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_create_command_queue"),
-#ifndef CLSPV_ONLINE_COMPILER
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_il_program"),
-#endif
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_spirv_no_integer_wrap_decoration"),
         MAKE_NAME_VERSION(1, 0, 0, "cl_arm_non_uniform_work_group_size"),
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_suggested_local_work_size"),

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -835,7 +835,8 @@ cl_build_status cvk_program::compile_source(const cvk_device* device) {
         static std::mutex llvmspirv_compile_lock;
         llvmspirv_compile_lock.lock();
         if (!llvm::readSpirv(Context, m_il_stream, M, Err)) {
-            cvk_error_fn("Fails to load SPIR-V as LLVM Module: %s", Err);
+            cvk_error_fn("Fails to load SPIR-V as LLVM Module: %s",
+                         Err.c_str());
             return CL_BUILD_ERROR;
         }
         llvmspirv_compile_lock.unlock();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,11 +29,7 @@ if (CLVK_COMPILER_AVAILABLE)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/api)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sha1)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/simple)
-
-if (NOT CLVK_CLSPV_ONLINE_COMPILER)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/simple-from-il-binary)
-endif()
-
 endif()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/simple-from-binary)
 

--- a/tests/azure/steps-build.yml
+++ b/tests/azure/steps-build.yml
@@ -74,7 +74,7 @@ steps:
         which ccache && ccache --show-stats || echo "ccache not available"
         make -C build -j3 clang
       displayName: make clang
-      condition: and(${{ parameters.compilerAvailable }}, not(${{ parameters.onlineCompiler }}))
+      condition: ${{ parameters.compilerAvailable }}
   - script: cmake --install ./build
     displayName: install
   - publish: ./build/install

--- a/tests/azure/steps-build.yml
+++ b/tests/azure/steps-build.yml
@@ -74,7 +74,7 @@ steps:
         which ccache && ccache --show-stats || echo "ccache not available"
         make -C build -j3 clang
       displayName: make clang
-      condition: ${{ parameters.compilerAvailable }}
+      condition: ${{ and(or(eq(parameters.os, 'linux'), eq(parameters.os, 'osx')), parameters.compilerAvailable) }}
   - script: cmake --install ./build
     displayName: install
   - publish: ./build/install

--- a/tests/azure/steps-run-tests.yml
+++ b/tests/azure/steps-run-tests.yml
@@ -46,7 +46,7 @@ steps:
         ./build/simple_test_from_il_binary
         ./build/simple_test_from_il_binary_static
       displayName: Offline IL compilation simple tests
-      condition: and(${{ parameters.compilerAvailable }}, not(${{ parameters.onlineCompiler }}))
+      condition: ${{ parameters.compilerAvailable }}
   - ${{ if eq(parameters.os, 'windows') }}:
     - script: |
         cp build/src/Release/OpenCL.dll build/Release


### PR DESCRIPTION
Adds support for the cl_khr_il_program extension in online
compilation mode by using the readSpirv api from
SPIRV-LLVM-Translator and clspv::Compile.

Closes #45.

@DCastagna @jrprice