### PR TITLE
cmake changes to ease in chromeos infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,12 @@ set_target_properties(clspv PROPERTIES RUNTIME_OUTPUT_DIRECTORY
 if (CLVK_COMPILER_AVAILABLE)
   set(LLVM_DIR
       ${CMAKE_BINARY_DIR}/external/clspv/third_party/llvm/lib/cmake/llvm)
-  set(LLVM_SPIRV_SOURCE ${PROJECT_SOURCE_DIR}/external/SPIRV-LLVM-Translator)
+  set(LLVM_SPIRV_SOURCE ${PROJECT_SOURCE_DIR}/external/SPIRV-LLVM-Translator CACHE STRING
+      "Path to SPIRV-LLVM-Translator directory")
   set(LLVM_SPIRV_BUILD_EXTERNAL YES)
-  add_subdirectory(${LLVM_SPIRV_SOURCE} EXCLUDE_FROM_ALL)
+  add_subdirectory(${LLVM_SPIRV_SOURCE}
+                   ${CMAKE_CURRENT_BINARY_DIR}/external/SPIRV-LLVM-Translator
+                   EXCLUDE_FROM_ALL)
 
   if (CLVK_CLSPV_ONLINE_COMPILER)
     # Include LLVM dependencies for SPIRV-LLVM

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ supported:
 It is possible to disable the build of the tests by passing
 `-DCLVK_BUILD_TESTS=OFF`.
 
+It is also possible to disable only the build of the tests linking with the
+static OpenCL library by passing `-DCLVK_BUILD_STATIC_TESTS=OFF`.
+
 ### OpenCL conformance tests
 
 Passing `-DCLVK_BUILD_CONFORMANCE_TESTS=ON` will instruct CMake to build the
@@ -106,6 +109,31 @@ in the same process via the Clspv C++ API.
 
 You can build clvk using an external Clspv source tree by setting
 `-DCLSPV_SOURCE_DIR=/path/to/clspv/source/`.
+
+### SPIRV components
+
+All needed SPIRV components are added to `clvk` using git submodules.
+It is possible to disable the build of those component or to reuse already
+existing sources:
+
+#### SPIRV-Headers
+
+`SPIRV_HEADERS_SOURCE_DIR` can be overriden to use another `SPIRV-Headers`
+repository.
+
+#### SPIRV-Tools
+
+`SPIRV_TOOLS_SOURCE_DIR` can be overriden to use another `SPIRV-Tools`
+repository.
+You can also disable the build of `SPIRV-Tools` by setting
+`-DCLVK_BUILD_SPIRV_TOOLS=OFF`.
+
+#### SPIRV-LLVM-Translator
+
+`LLVM_SPIRV_SOURCE` can be overriden to use another `SPIRV-LLVM-Translator`
+repository.
+Note that it is not used if the compiler support is disabled (enabled by
+default).
 
 ## Building for Android
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cmake_minimum_required(VERSION 3.9)
+project(clvk_test)
+
+set(CLVK_PROJECT_SOURCE_DIR ${PROJECT_SOURCE_DIR}/..)
+
+set(CLVK_BUILD_STATIC_TESTS ON CACHE BOOL
+    "Set to OFF to disable the build of tests with static OpenCL library")
+
 macro(add_gtest_executable name)
   add_executable(${name} ${ARGN})
   # Use the gtest copy that comes with clspv's version of LLVM
@@ -19,10 +27,27 @@ macro(add_gtest_executable name)
   include_directories(${LLVM_SOURCE_DIR}/include)
   include_directories(${LLVM_SOURCE_DIR}/utils/unittest/googletest/include/)
 
-  target_link_libraries(${name} OpenCL gtest gtest_main LLVMSupport)
+  target_link_libraries(${name} OpenCL gtest gtest_main)
+  if (BUILD_SHARED_LIBS)
+    target_link_libraries(${name} LLVMSupport)
+  endif()
 
   set_target_properties(${name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
     ${CMAKE_BINARY_DIR})
+endmacro()
+
+macro(add_simple_executable name source libraries)
+  add_executable(${name} ${source})
+  target_link_libraries(${name} ${libraries})
+  set_target_properties(${name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+    ${CMAKE_BINARY_DIR})
+endmacro()
+
+macro(add_simple_static_and_dyn_executable name source)
+  add_simple_executable(${name} ${source} OpenCL)
+  if (CLVK_BUILD_STATIC_TESTS)
+    add_simple_executable("${name}_static" ${source} OpenCL-static)
+  endif()
 endmacro()
 
 if (CLVK_COMPILER_AVAILABLE)

--- a/tests/conformance/CMakeLists.txt
+++ b/tests/conformance/CMakeLists.txt
@@ -15,9 +15,9 @@
 set(CLConf_OUT_DIR dummy)
 set(CLConform_LIBRARIES -lOpenCL)
 set(CL_LIBCLCXX_DIR dummy)
-set(CL_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/external/OpenCL-Headers)
-set(CL_LIB_DIR ${PROJECT_SOURCE_DIR}/external/OpenCL-ICD-Loader/build)
+set(CL_INCLUDE_DIR ${CLVK_PROJECT_SOURCE_DIR}/external/OpenCL-Headers)
+set(CL_LIB_DIR ${CLVK_PROJECT_SOURCE_DIR}/external/OpenCL-ICD-Loader/build)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/conformance)
-add_subdirectory(${PROJECT_SOURCE_DIR}/external/OpenCL-CTS
+add_subdirectory(${CLVK_PROJECT_SOURCE_DIR}/external/OpenCL-CTS
                  ${CMAKE_BINARY_DIR}/conformance)

--- a/tests/sha1/CMakeLists.txt
+++ b/tests/sha1/CMakeLists.txt
@@ -15,8 +15,8 @@
 
 add_gtest_executable(sha1_tests
     main.cpp
-    ${PROJECT_SOURCE_DIR}/src/sha1.cpp
+    ${CLVK_PROJECT_SOURCE_DIR}/src/sha1.cpp
 )
 
-include_directories(${PROJECT_SOURCE_DIR}/src)
+include_directories(${CLVK_PROJECT_SOURCE_DIR}/src)
 

--- a/tests/simple-from-binary/CMakeLists.txt
+++ b/tests/simple-from-binary/CMakeLists.txt
@@ -12,17 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(BINARY_NAME simple_test_from_binary)
-set(BINARY_NAME_STATIC simple_test_from_binary_static)
-
-add_executable(${BINARY_NAME} simple.cpp)
-add_executable(${BINARY_NAME_STATIC} simple.cpp)
-
-target_link_libraries(${BINARY_NAME} OpenCL)
-target_link_libraries(${BINARY_NAME_STATIC} OpenCL-static)
-
-set_target_properties(${BINARY_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-    ${CMAKE_BINARY_DIR})
-set_target_properties(${BINARY_NAME_STATIC} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-    ${CMAKE_BINARY_DIR})
-
+add_simple_static_and_dyn_executable(simple_test_from_binary simple.cpp)

--- a/tests/simple-from-il-binary/CMakeLists.txt
+++ b/tests/simple-from-il-binary/CMakeLists.txt
@@ -12,17 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(BINARY_NAME simple_test_from_il_binary)
-set(BINARY_NAME_STATIC simple_test_from_il_binary_static)
-
-add_executable(${BINARY_NAME} simple.cpp)
-add_executable(${BINARY_NAME_STATIC} simple.cpp)
-
-target_link_libraries(${BINARY_NAME} OpenCL)
-target_link_libraries(${BINARY_NAME_STATIC} OpenCL-static)
-
-set_target_properties(${BINARY_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-    ${CMAKE_BINARY_DIR})
-set_target_properties(${BINARY_NAME_STATIC} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-    ${CMAKE_BINARY_DIR})
-
+add_simple_static_and_dyn_executable(simple_test_from_il_binary simple.cpp)

--- a/tests/simple/CMakeLists.txt
+++ b/tests/simple/CMakeLists.txt
@@ -12,17 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(BINARY_NAME simple_test)
-set(BINARY_NAME_STATIC simple_test_static)
-
-add_executable(${BINARY_NAME} simple.cpp)
-add_executable(${BINARY_NAME_STATIC} simple.cpp)
-
-target_link_libraries(${BINARY_NAME} OpenCL)
-target_link_libraries(${BINARY_NAME_STATIC} OpenCL-static)
-
-set_target_properties(${BINARY_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-    ${CMAKE_BINARY_DIR})
-set_target_properties(${BINARY_NAME_STATIC} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-    ${CMAKE_BINARY_DIR})
-
+add_simple_static_and_dyn_executable(simple_test simple.cpp)


### PR DESCRIPTION
- SPIRV-LLVM-Translator path can be overriden
- tests/CMakeLists.txt can be used on its own
- Static tests can be disabled with CLVK_BUILD_STATIC_TESTS
- LLVMSupport is added only when BUILD_SHARED_LIBS=ON