### PR TITLE
add test in CI for standalone build and run of clvk tests

### DIFF
--- a/tests/azure/job-precommit.yml
+++ b/tests/azure/job-precommit.yml
@@ -54,4 +54,10 @@ jobs:
       os: ${{ parameters.os }}
       compilerAvailable: ${{ parameters.compilerAvailable }}
       onlineCompiler: ${{ parameters.onlineCompiler }}
+  - template: steps-run-tests-standalone.yml
+    parameters:
+      os: ${{ parameters.os }}
+      compilerAvailable: ${{ parameters.compilerAvailable }}
+      onlineCompiler: ${{ parameters.onlineCompiler }}
+      vulkanImplementation: swiftshader
 

--- a/tests/azure/steps-run-tests-standalone.yml
+++ b/tests/azure/steps-run-tests-standalone.yml
@@ -1,0 +1,126 @@
+
+parameters:
+  - name: icd_json_unix
+    type: string
+    default: "$(Pipeline.Workspace)/swiftshader/swiftshader-$(Agent.OS)/vk_swiftshader_icd.json"
+  - name: icd_json_win
+    type: string
+    default: "$(Pipeline.Workspace)\\swiftshader\\swiftshader-$(Agent.OS)\\vk_swiftshader_icd.json"
+  - name: os
+    type: string
+  - name: compilerAvailable
+    type: boolean
+  - name: onlineCompiler
+    type: boolean
+  - name: 'vulkanImplementation'
+    default: 'loader'
+    type: string
+
+steps:
+  - download: swiftshader
+    artifact: swiftshader-$(Agent.OS)
+  - script: mkdir build_tests
+    displayName: Create tests build directory
+  - task: CMake@1
+    inputs:
+      workingDirectory: build_tests
+      cmakeArgs: '-DCMAKE_BUILD_TYPE=${{ parameters.buildType }}
+                  -DCLVK_VULKAN_IMPLEMENTATION=${{ parameters.vulkanImplementation }}
+                  -DCLVK_COMPILER_AVAILABLE=${{ parameters.compilerAvailable }}
+                  ${{ parameters.cmakeFlags }} ../tests'
+  - ${{ if eq(parameters.os, 'windows') }}:
+    - task: MSBuild@1
+      inputs:
+        solution: 'build_tests/ALL_BUILD.vcxproj'
+        msbuildArchitecture: 'x64'
+        maximumCpuCount: true platform
+        configuration: ${{ parameters.buildType }}
+    - script: |
+        cp build/src/Release/OpenCL.dll build_tests/Release
+        cp $(Pipeline.Workspace)/swiftshader/swiftshader-$(Agent.OS)/* build_tests/Release
+        cp build\Vulkan-Loader\loader\Release\vulkan-1.dll build_tests/Release
+        cd build_tests/Release
+        dir
+      displayName: Prepare running tests
+    - script: |
+        set VK_ICD_FILENAMES=${{ parameters.icd_json_win }}
+        set VK_LOADER_DEBUG=all
+        cd build_tests/Release
+        set CLVK_LOG=3
+        set CLVK_LOG_DEST=stderr
+        echo Starting test
+        simple_test_static.exe
+        echo Done.
+      displayName: Simple test (static)
+    - script: |
+        set VK_ICD_FILENAMES=${{ parameters.icd_json_win }}
+        set VK_LOADER_DEBUG=all
+        cd build_tests/Release
+        set CLVK_LOG=3
+        set CLVK_LOG_DEST=stderr
+        echo Starting test
+        simple_test.exe
+        echo Done.
+      displayName: Simple test
+    - script: |
+        set VK_ICD_FILENAMES=${{ parameters.icd_json_win }}
+        cd build_tests/Release
+        set CLVK_LOG=2
+        set CLVK_LOG_DEST=stderr
+        echo Starting test
+        api_tests.exe
+        echo Done.
+      displayName: API tests
+    - script: |
+        cd build_tests/Release
+        echo Starting test
+        sha1_tests.exe
+        echo Done.
+      displayName: SHA-1 tests
+    - script: |
+        set VK_ICD_FILENAMES=${{ parameters.icd_json_win }}
+        cd build_tests/Release
+        clspv.exe -o simple.spv $(Build.SourcesDirectory)\tests\simple-from-binary\simple.cl
+        set CLVK_LOG=3
+        set CLVK_LOG_DEST=stderr
+        echo Starting tests
+        simple_test_from_binary.exe
+        simple_test_from_binary_static.exe
+        echo Done.
+      displayName: Offline compilation simple tests
+  - ${{ if ne(parameters.os, 'windows') }}:
+    - script: |
+        set -ex
+        make -C build_tests -j3
+      displayName: make
+  - ${{ if or(eq(parameters.os, 'linux'), eq(parameters.os, 'osx')) }}:
+    - script: VK_ICD_FILENAMES=${{ parameters.icd_json_unix }} CLVK_LOG=3 ./build_tests/simple_test_static
+      displayName: Simple test (static)
+      condition: ${{ parameters.compilerAvailable }}
+    - script: VK_ICD_FILENAMES=${{ parameters.icd_json_unix }} CLVK_LOG=3 ./build_tests/simple_test
+      displayName: Simple test
+      condition: ${{ parameters.compilerAvailable }}
+    - script: VK_ICD_FILENAMES=${{ parameters.icd_json_unix }} CLVK_LOG=2 ./build_tests/api_tests
+      displayName: API tests
+      condition: ${{ parameters.compilerAvailable }}
+    - script: ./build_tests/sha1_tests
+      displayName: SHA-1 tests
+      condition: ${{ parameters.compilerAvailable }}
+    - script: |
+        set -ex
+        ./build/clspv -o simple.spv ./tests/simple-from-binary/simple.cl
+        export VK_ICD_FILENAMES=${{ parameters.icd_json_unix }}
+        export CLVK_LOG=3
+        ./build_tests/simple_test_from_binary
+        ./build_tests/simple_test_from_binary_static
+      displayName: Offline compilation simple tests
+    - script: |
+        set -ex
+        ./build/external/clspv/third_party/llvm/bin/clang  -Xclang -finclude-default-header -c -target spir -O0 -emit-llvm -o simple-cl.bc ./tests/simple-from-il-binary/simple.cl
+        ./build/llvm-spirv simple-cl.bc -o simple-cl.spv
+        export VK_ICD_FILENAMES=${{ parameters.icd_json_unix }}
+        export CLVK_LOG=3
+        ./build_tests/simple_test_from_il_binary
+        ./build_tests/simple_test_from_il_binary_static
+      displayName: Offline IL compilation simple tests
+      condition: ${{ parameters.compilerAvailable }}


### PR DESCRIPTION
clvk tests can now be build independently from clvk.
This new CI test tests this usecase.