### PR TITLE
Split region that are bigger than vklimits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/src)
 
 # Tests
 option(CLVK_BUILD_TESTS "Build tests" ON)
+option(CLVK_UNIT_TESTING "Build unit tests that require vulkan properties to be overriden" OFF)
 if (CLVK_BUILD_TESTS)
 add_subdirectory(${PROJECT_SOURCE_DIR}/tests)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,9 +50,14 @@ add_library(OpenCL-objects OBJECT
   program.cpp
   queue.cpp
   sha1.cpp
+  unit.cpp
   utils.cpp
   exports.map
 )
+
+if (CLVK_UNIT_TESTING)
+   target_compile_definitions(OpenCL-objects PUBLIC CLVK_UNIT_TESTING_ENABLED)
+endif()
 
 # Disable deprecation warnings on the file that has the entrypoints.
 if (NOT MSVC)

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -26,7 +26,7 @@
 extern "C" void CL_API_CALL clvk_override_vklimits(cl_device_id device,
                                                    uint32_t x, uint32_t y,
                                                    uint32_t z) {
-    assert(is_valid_device(device));
+    assert(device != nullptr && icd_downcast(device)->is_valid());
     icd_downcast(device)->set_maxComputeWorkGroupCount(x, y, z);
 }
 

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -23,8 +23,9 @@
 #include <sys/system_properties.h>
 #endif
 
-extern "C" void CL_API_CALL clvk_override_vklimits(
-    cl_device_id device, uint32_t x, uint32_t y, uint32_t z) {
+extern "C" void CL_API_CALL clvk_override_vklimits(cl_device_id device,
+                                                   uint32_t x, uint32_t y,
+                                                   uint32_t z) {
     assert(is_valid_device(device));
     icd_downcast(device)->set_maxComputeWorkGroupCount(x, y, z);
 }

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -23,13 +23,6 @@
 #include <sys/system_properties.h>
 #endif
 
-extern "C" void CL_API_CALL clvk_override_vklimits(cl_device_id device,
-                                                   uint32_t x, uint32_t y,
-                                                   uint32_t z) {
-    assert(device != nullptr && icd_downcast(device)->is_valid());
-    icd_downcast(device)->set_maxComputeWorkGroupCount(x, y, z);
-}
-
 constexpr VkMemoryPropertyFlags cvk_device::buffer_supported_memory_types[];
 constexpr VkMemoryPropertyFlags cvk_device::image_supported_memory_types[];
 

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -23,6 +23,12 @@
 #include <sys/system_properties.h>
 #endif
 
+extern "C" void CL_API_CALL clvk_override_vklimits(
+    cl_device_id device, uint32_t x, uint32_t y, uint32_t z) {
+    assert(is_valid_device(device));
+    icd_downcast(device)->set_maxComputeWorkGroupCount(x, y, z);
+}
+
 constexpr VkMemoryPropertyFlags cvk_device::buffer_supported_memory_types[];
 constexpr VkMemoryPropertyFlags cvk_device::image_supported_memory_types[];
 

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -50,6 +50,10 @@ struct cvk_device : public _cl_device_id,
         : m_platform(platform), m_pdev(pd) {
         vkGetPhysicalDeviceProperties(m_pdev, &m_properties);
         vkGetPhysicalDeviceMemoryProperties(m_pdev, &m_mem_properties);
+        for (int each_dim = 0; each_dim < 3; ++each_dim) {
+            maxComputeWorkGroupCount[each_dim] =
+                m_properties.limits.maxComputeWorkGroupCount[each_dim];
+        }
     }
 
     static cvk_device* create(cvk_platform* platform, VkInstance instance,
@@ -61,6 +65,20 @@ struct cvk_device : public _cl_device_id,
             vkDestroyPipelineCache(m_dev, entry.second, nullptr);
         }
         vkDestroyDevice(m_dev, nullptr);
+    }
+
+    void set_maxComputeWorkGroupCount(uint32_t x, uint32_t y, uint32_t z) {
+        cvk_debug_fn("x: %u, y: %u, z: %u\n", x, y, z);
+        maxComputeWorkGroupCount[0] =
+            x == 0 ? m_properties.limits.maxComputeWorkGroupCount[0] : x;
+        maxComputeWorkGroupCount[1] =
+            y == 0 ? m_properties.limits.maxComputeWorkGroupCount[1] : y;
+        maxComputeWorkGroupCount[2] =
+            z == 0 ? m_properties.limits.maxComputeWorkGroupCount[2] : z;
+    }
+
+    const uint32_t* vulkan_limits_maxComputeWorkGroupCount() const {
+        return maxComputeWorkGroupCount;
     }
 
     const VkPhysicalDeviceLimits& vulkan_limits() const {
@@ -463,6 +481,7 @@ private:
     VkPhysicalDevice m_pdev;
     // Properties
     VkPhysicalDeviceProperties m_properties;
+    uint32_t maxComputeWorkGroupCount[3];
     VkPhysicalDeviceMemoryProperties m_mem_properties;
     VkPhysicalDeviceDriverPropertiesKHR m_driver_properties;
     VkPhysicalDeviceIDPropertiesKHR m_device_id_properties;

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -50,10 +50,6 @@ struct cvk_device : public _cl_device_id,
         : m_platform(platform), m_pdev(pd) {
         vkGetPhysicalDeviceProperties(m_pdev, &m_properties);
         vkGetPhysicalDeviceMemoryProperties(m_pdev, &m_mem_properties);
-        for (int each_dim = 0; each_dim < 3; ++each_dim) {
-            maxComputeWorkGroupCount[each_dim] =
-                m_properties.limits.maxComputeWorkGroupCount[each_dim];
-        }
     }
 
     static cvk_device* create(cvk_platform* platform, VkInstance instance,
@@ -67,19 +63,17 @@ struct cvk_device : public _cl_device_id,
         vkDestroyDevice(m_dev, nullptr);
     }
 
-    void set_maxComputeWorkGroupCount(uint32_t x, uint32_t y, uint32_t z) {
-        cvk_debug_fn("x: %u, y: %u, z: %u\n", x, y, z);
-        maxComputeWorkGroupCount[0] =
-            x == 0 ? m_properties.limits.maxComputeWorkGroupCount[0] : x;
-        maxComputeWorkGroupCount[1] =
-            y == 0 ? m_properties.limits.maxComputeWorkGroupCount[1] : y;
-        maxComputeWorkGroupCount[2] =
-            z == 0 ? m_properties.limits.maxComputeWorkGroupCount[2] : z;
+#ifdef CLVK_UNIT_TESTING_ENABLED
+
+    VkPhysicalDeviceLimits& vulkan_limits_writable() {
+        return m_properties.limits;
     }
 
-    const uint32_t* vulkan_limits_maxComputeWorkGroupCount() const {
-        return maxComputeWorkGroupCount;
+    void restore_device_properties() {
+        vkGetPhysicalDeviceProperties(m_pdev, &m_properties);
     }
+
+#endif
 
     const VkPhysicalDeviceLimits& vulkan_limits() const {
         return m_properties.limits;
@@ -481,7 +475,6 @@ private:
     VkPhysicalDevice m_pdev;
     // Properties
     VkPhysicalDeviceProperties m_properties;
-    uint32_t maxComputeWorkGroupCount[3];
     VkPhysicalDeviceMemoryProperties m_mem_properties;
     VkPhysicalDeviceDriverPropertiesKHR m_driver_properties;
     VkPhysicalDeviceIDPropertiesKHR m_device_id_properties;

--- a/src/exports.map
+++ b/src/exports.map
@@ -1,5 +1,12 @@
-OPENCL_1.0 {
+CLVK_UNIT_TESTING_FCT {
 global:
+    clvk_override_device_max_compute_work_group_count;
+    clvk_restore_device_properties;
+local:
+    *;
+};
+
+OPENCL_1.0 {
     clGetPlatformIDs;
     clGetPlatformInfo;
     clGetDeviceIDs;
@@ -66,10 +73,7 @@ global:
     clSetKernelArg;
     clUnloadCompiler;
     clWaitForEvents;
-    clvk_override_vklimits; /* for test purpose */
-local:
-    *;
-};
+} CLVK_UNIT_TESTING_FCT;
 
 OPENCL_1.1 {
     clCreateUserEvent;

--- a/src/exports.map
+++ b/src/exports.map
@@ -66,6 +66,7 @@ global:
     clSetKernelArg;
     clUnloadCompiler;
     clWaitForEvents;
+    clvk_override_vklimits; /* for test purpose */
 local:
     *;
 };

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -550,6 +550,11 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
         return m_binary.constant_data_buffer();
     }
 
+    bool has_region_offset() const {
+        return push_constant(pushconstant::region_offset) &&
+               push_constant(pushconstant::region_group_offset);
+    }
+
 private:
     void do_build();
     std::string prepare_build_options(const cvk_device* device) const;

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -711,6 +711,10 @@ private:
     void update_global_push_constants(cvk_command_buffer& command_buffer);
     CHECK_RETURN cl_int dispatch_uniform_region_within_vklimits(
         const cvk_ndrange& region, cvk_command_buffer& command_buffer);
+    CHECK_RETURN cl_int dispatch_uniform_region_iterate(
+        unsigned int dim, const cvk_ndrange& region, const size_t* region_lws,
+        size_t* region_gws, size_t* region_offset,
+        cvk_command_buffer& command_buffer, uint32_t* num_workgroups);
     CHECK_RETURN cl_int dispatch_uniform_region(
         const cvk_ndrange& region, cvk_command_buffer& command_buffer);
 

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -709,6 +709,8 @@ private:
     CHECK_RETURN cl_int
     build_and_dispatch_regions(cvk_command_buffer& command_buffer);
     void update_global_push_constants(cvk_command_buffer& command_buffer);
+    CHECK_RETURN cl_int dispatch_uniform_region_within_vklimits(
+        const cvk_ndrange& region, cvk_command_buffer& command_buffer);
     CHECK_RETURN cl_int dispatch_uniform_region(
         const cvk_ndrange& region, cvk_command_buffer& command_buffer);
 

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -1,0 +1,42 @@
+// Copyright 2021 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef CLVK_UNIT_TESTING_ENABLED
+
+#include "device.hpp"
+#include "log.hpp"
+
+#include <vulkan/vulkan.h>
+
+extern "C" {
+void CL_API_CALL clvk_override_device_max_compute_work_group_count(
+    cl_device_id device, uint32_t x, uint32_t y, uint32_t z) {
+    cvk_debug_fn("x: %u, y: %u, z: %u\n", x, y, z);
+    assert(device != nullptr && icd_downcast(device)->is_valid());
+    auto vklimits = icd_downcast(device)->vulkan_limits_writable();
+
+    vklimits.maxComputeWorkGroupCount[0] = x;
+    vklimits.maxComputeWorkGroupCount[1] = y;
+    vklimits.maxComputeWorkGroupCount[2] = z;
+}
+
+void CL_API_CALL clvk_restore_device_properties(cl_device_id device) {
+    cvk_debug_fn("device: %p\n", (void*)device);
+    assert(device != nullptr && icd_downcast(device)->is_valid());
+
+    icd_downcast(device)->restore_device_properties();
+}
+}
+
+#endif

--- a/src/unit.hpp
+++ b/src/unit.hpp
@@ -1,0 +1,30 @@
+// Copyright 2021 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef CLVK_UNIT_TESTING_ENABLED
+
+#include <CL/cl.h>
+
+extern "C" {
+
+void CL_API_CALL clvk_override_device_max_compute_work_group_count(
+    cl_device_id device, uint32_t x, uint32_t y, uint32_t z);
+
+void CL_API_CALL clvk_restore_device_properties(cl_device_id device);
+
+}
+
+#endif

--- a/src/unit.hpp
+++ b/src/unit.hpp
@@ -24,7 +24,6 @@ void CL_API_CALL clvk_override_device_max_compute_work_group_count(
     cl_device_id device, uint32_t x, uint32_t y, uint32_t z);
 
 void CL_API_CALL clvk_restore_device_properties(cl_device_id device);
-
 }
 
 #endif

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -60,9 +60,14 @@ static inline void* pointer_offset(const void* ptr, size_t offset) {
     return reinterpret_cast<void*>(ptrint + offset);
 }
 
+static inline uint32_t ceil_div(uint32_t num, uint32_t divisor) {
+    CVK_ASSERT(divisor != 0);
+    return (num + divisor - 1) / divisor;
+}
+
 static inline uint32_t round_up(uint32_t num, uint32_t multiple) {
     CVK_ASSERT(multiple != 0);
-    return ((num + multiple - 1) / multiple) * multiple;
+    return ceil_div(num, multiple) * multiple;
 }
 
 // Return the hex string representation of `bytes`.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,10 +26,14 @@ macro(add_gtest_executable name)
   include_directories(${LLVM_BINARY_DIR}/include)
   include_directories(${LLVM_SOURCE_DIR}/include)
   include_directories(${LLVM_SOURCE_DIR}/utils/unittest/googletest/include/)
+  include_directories(${CLVK_PROJECT_SOURCE_DIR}/src)
 
   target_link_libraries(${name} OpenCL gtest gtest_main)
   if (BUILD_SHARED_LIBS)
     target_link_libraries(${name} LLVMSupport)
+  endif()
+  if (CLVK_UNIT_TESTING)
+    target_compile_definitions(${name} PUBLIC CLVK_UNIT_TESTING_ENABLED)
   endif()
 
   set_target_properties(${name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -23,6 +23,7 @@ add_gtest_executable(api_tests
     simple.cpp
     simple_image.cpp
     simple_ubo.cpp
+    split_region.cpp
     workgroup.cpp
 )
 

--- a/tests/api/split_region.cpp
+++ b/tests/api/split_region.cpp
@@ -1,0 +1,103 @@
+// Copyright 2022 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testcl.hpp"
+
+static bool check(cl_int* src, cl_int* dst, size_t size) {
+    bool error = false;
+    for (int i = 0; i < size; ++i) {
+        if (src[i] != dst[i]) {
+            printf("ERROR: %u: %x != %x\n", i, src[i], dst[i]);
+            error = true;
+        }
+    }
+    return !error;
+}
+
+
+extern "C" void clvk_override_vklimits(cl_device_id, uint32_t, uint32_t,
+                                       uint32_t);
+
+TEST_F(WithCommandQueue, SplitRegion) {
+    static const char* source = R"(
+      kernel void test(global int *src, global int* dst) {
+        size_t gidx = get_global_id(0);
+        size_t gidy = get_global_id(1);
+        size_t gidz = get_global_id(2);
+        size_t xsize = get_global_size(0);
+        size_t ysize = get_global_size(1);
+
+        size_t gid = gidx + xsize * (gidy + ysize * gidz);
+
+        dst[gid] = src[gid];
+      }
+    )";
+
+    const size_t max_dim_size = 24;
+    const size_t max_nb_elems = max_dim_size * max_dim_size * max_dim_size;
+    const size_t buffer_size = max_nb_elems * sizeof(cl_int);
+
+    cl_int src_buf[max_nb_elems], dst_buf[max_nb_elems];
+
+    auto program = CreateAndBuildProgram(source, "-cl-std=CL3.0");
+    auto src = CreateBuffer(CL_MEM_READ_ONLY, buffer_size);
+    auto dst = CreateBuffer(CL_MEM_WRITE_ONLY, buffer_size);
+
+    auto kernel = CreateKernel(program, "test");
+    SetKernelArg(kernel, 0, src);
+    SetKernelArg(kernel, 1, dst);
+
+    clvk_override_vklimits(gDevice, 16, 16, 16);
+
+    const size_t scenarii[][3] = {
+        {10, 12, 11}, {16, 12, 14}, {16, 16, 13}, {16, 16, 16}, {20, 16, 16},
+        {19, 22, 16}, {21, 20, 18}, {23, 13, 10}, {23, 24, 12}, {22, 16, 11},
+    };
+    const int permutations[][3] = {{0, 1, 2}, {0, 2, 1}, {1, 0, 2},
+                                   {1, 2, 0}, {2, 0, 1}, {2, 1, 0}};
+    for (int each_scenario = 0;
+         each_scenario < sizeof(scenarii) / sizeof(scenarii[0]);
+         ++each_scenario) {
+        const size_t* sc = scenarii[each_scenario];
+        size_t nb_elems = sc[0] * sc[1] * sc[2];
+        ASSERT_TRUE(sc[0] <= max_dim_size && sc[1] <= max_dim_size &&
+                    sc[2] <= max_dim_size);
+
+        for (int each_permutation = 0;
+             each_permutation < sizeof(permutations) / sizeof(permutations[0]);
+             ++each_permutation) {
+            size_t gid[3] = {sc[permutations[each_permutation][0]],
+                             sc[permutations[each_permutation][1]],
+                             sc[permutations[each_permutation][2]]};
+
+            for (int each_elem = 0; each_elem < nb_elems; ++each_elem) {
+                src_buf[each_elem] = each_elem + (each_scenario << 16) +
+                                     (each_permutation << 24);
+            }
+
+            EnqueueWriteBuffer(src, true, 0, buffer_size, src_buf);
+
+            EnqueueNDRangeKernel(kernel, 3, nullptr, gid, nullptr);
+            Finish();
+
+            EnqueueReadBuffer(dst, true, 0, buffer_size, dst_buf);
+
+            bool status = check(src_buf, dst_buf, nb_elems);
+            if (!status) {
+                clvk_override_vklimits(gDevice, 0, 0, 0);
+            }
+            ASSERT_TRUE(status);
+        }
+    }
+}

--- a/tests/api/split_region.cpp
+++ b/tests/api/split_region.cpp
@@ -25,7 +25,6 @@ static bool check(cl_int* src, cl_int* dst, size_t size) {
     return !error;
 }
 
-
 extern "C" void clvk_override_vklimits(cl_device_id, uint32_t, uint32_t,
                                        uint32_t);
 

--- a/tests/api/split_region.cpp
+++ b/tests/api/split_region.cpp
@@ -99,4 +99,5 @@ TEST_F(WithCommandQueue, SplitRegion) {
             ASSERT_TRUE(status);
         }
     }
+    clvk_override_vklimits(gDevice, 0, 0, 0);
 }

--- a/tests/azure/pipeline-precommit.yml
+++ b/tests/azure/pipeline-precommit.yml
@@ -33,7 +33,7 @@ stages:
       namePrefix: Windows_2019_MSVC_2019_online_clspv
       vmImage: windows-2019
       os: windows
-      cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=1'
+      cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=1 -DCLVK_UNIT_TESTING=ON'
       buildType: Release
       artifactName: Windows_Builtin_Compiler
       onlineCompiler: true
@@ -60,7 +60,7 @@ stages:
       namePrefix: Ubuntu_18_04_offline_clspv
       vmImage: ubuntu-18.04
       os: linux
-      cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=0'
+      cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=0 -DCLVK_UNIT_TESTING=ON'
       buildType: Release
       artifactName: Linux_Separate_Compiler
       onlineCompiler: false
@@ -69,7 +69,7 @@ stages:
       namePrefix: macOS_X_Catalina_10_15_online_clspv
       vmImage: macOS-10.15
       os: osx
-      cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=1'
+      cmakeFlags: '-DCLVK_CLSPV_ONLINE_COMPILER=1 -DCLVK_UNIT_TESTING=ON'
       buildType: Release
       artifactName: macOS_Builtin_Compiler
       onlineCompiler: true


### PR DESCRIPTION
When a region is bigger than the vulkan limits, we need to split it in
smaller region to execute it.
Do that only if we are using 'region_offset' and 'region_group_offset'
otherwise it won't work properly.
Add a test for it. The test is using a export function that is not
part of OpenCL and thus not really documented that allow to change the
vulkan limits. It enables the test to make sense without having to
know the physical limits and to run in a short amount of time. This
function is an extern C function not to have to consider the mandling
in 'exports.map'. Shall not be used appart from this test.

Fix #266 