### PR TITLE
fix vec3 arg size check in clSetKernelArg

### DIFF
--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -212,11 +212,17 @@ struct cvk_kernel_argument_values {
     cl_int set_arg(const kernel_argument& arg, size_t size, const void* value) {
 
         if (arg.is_pod()) {
-            if (size != arg.size) {
+            // If the argument is a vec3, OpenCL requires to call clSetKernelArg
+            // with a size of 4 times the element size. But clspv arg size is
+            // only 3 times the element size. When size and arg.size do not
+            // match, make sure that we are not in this unusual case.
+            if (size != arg.size &&
+                !(arg.info.type_name[arg.info.type_name.length() - 1] == '3' &&
+                  (size == arg.size * 4 / 3))) {
                 return CL_INVALID_ARG_SIZE;
             }
 
-            memcpy(&pod_data()[arg.offset], value, size);
+            memcpy(&pod_data()[arg.offset], value, arg.size);
         } else if (arg.kind == kernel_argument_kind::local) {
             CVK_ASSERT(value == nullptr);
             m_local_args_size[arg.pos] = size;

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -217,8 +217,7 @@ struct cvk_kernel_argument_values {
             // only 3 times the element size. When size and arg.size do not
             // match, make sure that we are not in this unusual case.
             if (size != arg.size &&
-                !(arg.info.type_name[arg.info.type_name.length() - 1] == '3' &&
-                  (size == arg.size * 4 / 3))) {
+                !(arg.is_vec3() && (size == arg.size * 4 / 3))) {
                 return CL_INVALID_ARG_SIZE;
             }
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -661,10 +661,16 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
     }
 
     // Prepare options
-    std::string single_precision_option = "-cl-single-precision-constant";
-    if (options.find(single_precision_option) == std::string::npos) {
-        options += " " + single_precision_option + " ";
+    std::string necessary_options[] = {
+        "-cl-single-precision-constant",
+        "-cl-kernel-arg-info",
+    };
+    for (std::string option : necessary_options) {
+        if (options.find(option) == std::string::npos) {
+            options += " " + option + " ";
+        }
     }
+
     if (!devices_support_images()) {
         options += " -images=0 ";
     }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -52,6 +52,10 @@ struct kernel_argument_info {
     uint32_t address_qualifier;
     uint32_t access_qualifier;
     uint32_t type_qualifier;
+
+    bool is_vec3() const {
+        return extended_valid && type_name[type_name.length() - 1] == '3';
+    }
 };
 
 struct kernel_argument {
@@ -75,6 +79,8 @@ struct kernel_argument {
         return (kind == kernel_argument_kind::pod) ||
                (kind == kernel_argument_kind::pod_ubo);
     }
+
+    bool is_vec3() const { return info.is_vec3(); }
 };
 
 struct sampler_desc {


### PR DESCRIPTION
If a argument is a vec3, OpenCL requires the size passed to
clSetKernelArg to be 4 times the element size. Accept it even so clspv
arg size is 3 times the element size.