### PR TITLE
Fix istream passed to readSpirv

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -52,6 +52,32 @@ struct membuf : public std::streambuf {
         auto send = reinterpret_cast<char*>(end);
         setp(sbegin, send);
     }
+    virtual pos_type seekoff(off_type off, std::ios_base::seekdir dir,
+                             std::ios_base::openmode which) {
+        if (off != 0)
+            return -1;
+        char* whence = eback();
+        if (dir == std::ios_base::cur) {
+            whence = gptr();
+        } else if (dir == std::ios_base::end) {
+            whence = egptr();
+        }
+        char* to = whence + off;
+        if (to >= eback() && to <= egptr()) {
+            setg(eback(), to, egptr());
+            return gptr() - eback();
+        }
+        return -1;
+    }
+
+    virtual pos_type seekpos(pos_type pos, std::ios_base::openmode which) {
+        char* to = eback() + pos;
+        if (to >= eback() && to <= egptr()) {
+            setg(eback(), to, egptr());
+            return gptr() - eback();
+        }
+        return -1;
+    }
 };
 
 struct reflection_parse_data {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -52,10 +52,8 @@ struct membuf : public std::streambuf {
         auto send = reinterpret_cast<char*>(end);
         setp(sbegin, send);
     }
-    virtual pos_type seekoff(off_type off, std::ios_base::seekdir dir,
-                             std::ios_base::openmode which) {
-        if (off != 0)
-            return -1;
+    pos_type seekoff(off_type off, std::ios_base::seekdir dir,
+                     std::ios_base::openmode which) override {
         char* whence = eback();
         if (dir == std::ios_base::cur) {
             whence = gptr();
@@ -70,7 +68,7 @@ struct membuf : public std::streambuf {
         return -1;
     }
 
-    virtual pos_type seekpos(pos_type pos, std::ios_base::openmode which) {
+    pos_type seekpos(pos_type pos, std::ios_base::openmode which) override {
         char* to = eback() + pos;
         if (to >= eback() && to <= egptr()) {
             setg(eback(), to, egptr());

--- a/tests/simple-from-il-binary/simple.cl
+++ b/tests/simple-from-il-binary/simple.cl
@@ -1,5 +1,10 @@
+struct ParamStruct {
+    char a;
+};
+
 kernel void test_simple(global uint* out)
 {
+    struct ParamStruct a;
     size_t gid = get_global_id(0);
     out[gid] = gid;
 }


### PR DESCRIPTION
llvm::readSpirv assumes that the input stream containig SPIR-V is seekable.
In particular, when the input SPIR-V contains an OpType* that gets parsed
with SPIRVDecoder::getContinuedInstructions, tellg() and seekg() are called
on the istream.

This CL adds seeking support to the stream we pass as input of readSpirv.