### PR TITLE
Fix 65fef82 (split of region bigger than vklimits)

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -740,6 +740,7 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
     options += " -global-offset ";
     options += " -long-vector ";
     options += " -module-constants-in-storage-buffer ";
+    options += " -cl-arm-non-uniform-work-group-size ";
 #if COMPILER_AVAILABLE
     options += " " + gCLSPVOptions + " ";
 #endif

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -27,9 +27,9 @@
 #include "spirv-tools/libspirv.h"
 #include "spirv/1.0/spirv.hpp"
 
+#include "init.hpp"
 #include "memory.hpp"
 #include "objects.hpp"
-#include "init.hpp"
 
 const int SPIR_WORD_SIZE = 4;
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -565,8 +565,11 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
     }
 
     bool can_split_region() {
-        return options_allow_split_region(m_build_options) ||
-               options_allow_split_region(gCLSPVOptions);
+        return options_allow_split_region(m_build_options)
+#if COMPILER_AVAILABLE
+               || options_allow_split_region(gCLSPVOptions)
+#endif
+            ;
     }
 
 private:

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -29,6 +29,7 @@
 
 #include "memory.hpp"
 #include "objects.hpp"
+#include "init.hpp"
 
 const int SPIR_WORD_SIZE = 4;
 
@@ -556,9 +557,16 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
         return m_binary.constant_data_buffer();
     }
 
-    bool has_region_offset() const {
-        return push_constant(pushconstant::region_offset) &&
-               push_constant(pushconstant::region_group_offset);
+    bool options_allow_split_region(std::string options) {
+        return options.find("-cl-std=CL2.0") != std::string::npos ||
+               options.find("-cl-std=CL3.0") != std::string::npos ||
+               options.find("cl-arm-non-uniform-work-group-size") !=
+                   std::string::npos;
+    }
+
+    bool can_split_region() {
+        return options_allow_split_region(m_build_options) ||
+               options_allow_split_region(gCLSPVOptions);
     }
 
 private:

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -557,32 +557,18 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
         return m_binary.constant_data_buffer();
     }
 
-    enum split_allow
-    {
-        SPLIT_ALLOW = 2,
-        SPLIT_DISALLOW = 0,
-        SPLIT_UNKNOWN = 1,
-    };
-
-    enum split_allow options_allow_split_region(std::string options)
-    {
+    bool options_allow_split_region(std::string options) {
         if (options.find("-uniform-workgroup-size") != std::string::npos)
-            return SPLIT_DISALLOW;
-        if (options.find("-cl-std=CL2.0") != std::string::npos ||
-            options.find("-cl-std=CL3.0") != std::string::npos ||
-            options.find("-cl-std=CLC++") != std::string::npos ||
-            options.find("-cl-arm-non-uniform-work-group-size") !=
-                std::string::npos)
-            return SPLIT_ALLOW;
-        return SPLIT_UNKNOWN;
+            return false;
+        return true;
     }
 
     bool can_split_region() {
         int status = options_allow_split_region(m_build_options);
 #if COMPILER_AVAILABLE
-        status *= options_allow_split_region(gCLSPVOptions);
+        status &= options_allow_split_region(gCLSPVOptions);
 #endif
-        return status >= SPLIT_ALLOW;
+        return status;
     }
 
 private:

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -549,8 +549,8 @@ cl_int cvk_command_kernel::dispatch_uniform_region_iterate(
 
     size_t num_splitted_regions =
         ceil_div(num_workgroups[dim], vklimits.maxComputeWorkGroupCount[dim]);
-    size_t splitted_region_gws =
-        ceil_div(region.gws[dim], num_splitted_regions);
+    size_t splitted_region_gws = round_up(
+        ceil_div(region.gws[dim], num_splitted_regions), region_lws[dim]);
 
     for (size_t i = 0; i < num_splitted_regions; ++i) {
         size_t splitted_offset = i * splitted_region_gws;
@@ -588,7 +588,7 @@ cl_int cvk_command_kernel::dispatch_uniform_region(
 
     auto program = m_kernel->program();
     auto& vklimits = m_queue->device()->vulkan_limits();
-    if (!program->has_region_offset()) {
+    if (!program->can_split_region()) {
         for (cl_uint i = 0; i < 3; ++i) {
             if (num_workgroups[i] > vklimits.maxComputeWorkGroupCount[i]) {
                 cvk_error_fn("Number of workgroups (%d, %d, %d) required to "
@@ -602,8 +602,8 @@ cl_int cvk_command_kernel::dispatch_uniform_region(
                 cvk_error_fn(
                     "Splitting this region is required, but it is not possible "
                     "because the support is not enabled. Compiling the kernel "
-                    "with either '-cl-std=2.0', "
-                    "'-cl-std=3.0' or 'cl-arm-non-uniform-work-group-size' "
+                    "with either '-cl-std=CL2.0', "
+                    "'-cl-std=CL3.0' or 'cl-arm-non-uniform-work-group-size' "
                     "should allow to exceed the device limits");
 
                 return CL_INVALID_WORK_ITEM_SIZE;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -549,8 +549,8 @@ cl_int cvk_command_kernel::dispatch_uniform_region_iterate(
 
     size_t num_splitted_regions =
         ceil_div(num_workgroups[dim], vklimits.maxComputeWorkGroupCount[dim]);
-    size_t splitted_region_gws = round_up(
-        ceil_div(region.gws[dim], num_splitted_regions), region_lws[dim]);
+    size_t splitted_region_gws =
+        vklimits.maxComputeWorkGroupCount[dim] * region_lws[dim];
 
     for (size_t i = 0; i < num_splitted_regions; ++i) {
         size_t splitted_offset = i * splitted_region_gws;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -601,10 +601,8 @@ cl_int cvk_command_kernel::dispatch_uniform_region(
                              vklimits.maxComputeWorkGroupCount[2]);
                 cvk_error_fn(
                     "Splitting this region is required, but it is not possible "
-                    "because the support is not enabled. Compiling the kernel "
-                    "with either '-cl-std=CL2.0', "
-                    "'-cl-std=CL3.0' or 'cl-arm-non-uniform-work-group-size' "
-                    "should allow to exceed the device limits");
+                    "because the support has been disabled (most probably by "
+                    "'-uniform-workgroup-size').");
 
                 return CL_INVALID_WORK_ITEM_SIZE;
             }

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -24,7 +24,7 @@ void CL_API_CALL clvk_override_device_max_compute_work_group_count(
     cl_device_id device, uint32_t x, uint32_t y, uint32_t z) {
     cvk_debug_fn("x: %u, y: %u, z: %u\n", x, y, z);
     assert(device != nullptr && icd_downcast(device)->is_valid());
-    auto vklimits = icd_downcast(device)->vulkan_limits_writable();
+    auto& vklimits = icd_downcast(device)->vulkan_limits_writable();
 
     vklimits.maxComputeWorkGroupCount[0] = x;
     vklimits.maxComputeWorkGroupCount[1] = y;

--- a/tests/api/split_region.cpp
+++ b/tests/api/split_region.cpp
@@ -43,6 +43,8 @@ TEST_F(WithCommandQueue, SplitRegion) {
       }
     )";
 
+    clvk_override_device_max_compute_work_group_count(gDevice, 4, 4, 4);
+
     const size_t max_dim_size = 24;
     const size_t max_nb_elems = max_dim_size * max_dim_size * max_dim_size;
     const size_t buffer_size = max_nb_elems * sizeof(cl_int);
@@ -56,8 +58,6 @@ TEST_F(WithCommandQueue, SplitRegion) {
     auto kernel = CreateKernel(program, "test");
     SetKernelArg(kernel, 0, src);
     SetKernelArg(kernel, 1, dst);
-
-    clvk_override_device_max_compute_work_group_count(gDevice, 16, 16, 16);
 
     const size_t scenarii[][3] = {
         {10, 12, 11}, {16, 12, 14}, {16, 16, 13}, {16, 16, 16}, {20, 16, 16},
@@ -82,7 +82,8 @@ TEST_F(WithCommandQueue, SplitRegion) {
 
             EnqueueWriteBuffer(src, true, 0, buffer_size, src_buf);
 
-            EnqueueNDRangeKernel(kernel, 3, nullptr, gid, nullptr);
+            const size_t lid[] = {3, 3, 3};
+            EnqueueNDRangeKernel(kernel, 3, nullptr, gid, lid);
 
             EnqueueReadBuffer(dst, true, 0, buffer_size, dst_buf);
 


### PR DESCRIPTION
Looking for region_offset and region_group_offset to know if we can
split the region is not enough as a test using only one of them can
still be split. But it will not be accepted by clvk with the current
test.
Instead let's looking into the kernel options to choose whether we try
it or not.

Also round_up the size of the workgroup to the local size in order to
keep region uniform.