### PR TITLE
Define OpenCL as an application framework on Apple OSes.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,10 +127,18 @@ endfunction(CLLibrary)
 CLLibrary(OpenCL SHARED)
 CLLibrary(OpenCL-static STATIC)
 
-set_target_properties(OpenCL PROPERTIES
+if(NOT APPLE)
+  set_target_properties(OpenCL PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION 1)
-
+else()
+  set_target_properties(OpenCL PROPERTIES
+    FRAMEWORK TRUE
+    FRAMEWORK_VERSION A
+    MACOSX_FRAMEWORK_IDENTIFIER com.apple.opencl
+    SOVERSION 1.0.0
+  )
+endif()
 # Basic install rules
 install(TARGETS OpenCL DESTINATION .)
 if (NOT CLVK_CLSPV_ONLINE_COMPILER AND CLVK_COMPILER_AVAILABLE)


### PR DESCRIPTION
This allows straightforward replacement and easy use of install_name_tool down the road to use this on existing application binaries.