### PR TITLE
fix ceil-div to avoid overflow

### DIFF
--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -17,7 +17,6 @@
 #include "log.hpp"
 
 #include <cassert>
-#include <cstdint>
 
 #include <vulkan/vulkan.h>
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -61,8 +61,8 @@ static inline void* pointer_offset(const void* ptr, size_t offset) {
 }
 
 static inline uint32_t ceil_div(uint32_t num, uint32_t divisor) {
-    CVK_ASSERT(divisor != 0 && num != 0);
-    return 1 + (num - 1) / divisor;
+    CVK_ASSERT(divisor != 0);
+    return num / divisor + (num % divisor != 0);
 }
 
 static inline uint32_t round_up(uint32_t num, uint32_t multiple) {

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -17,6 +17,7 @@
 #include "log.hpp"
 
 #include <cassert>
+#include <cstdint>
 
 #include <vulkan/vulkan.h>
 
@@ -61,6 +62,12 @@ static inline void* pointer_offset(const void* ptr, size_t offset) {
 }
 
 static inline uint32_t ceil_div(uint32_t num, uint32_t divisor) {
+    if (divisor > (UINT32_MAX >> 1)) {
+        if (num > divisor)
+            return 2;
+        else
+            return 1;
+    }
     CVK_ASSERT(divisor != 0);
     return (num + divisor - 1) / divisor;
 }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -62,14 +62,8 @@ static inline void* pointer_offset(const void* ptr, size_t offset) {
 }
 
 static inline uint32_t ceil_div(uint32_t num, uint32_t divisor) {
-    if (divisor > (UINT32_MAX >> 1)) {
-        if (num > divisor)
-            return 2;
-        else
-            return 1;
-    }
-    CVK_ASSERT(divisor != 0);
-    return (num + divisor - 1) / divisor;
+    CVK_ASSERT(divisor != 0 && num != 0);
+    return 1 + (num - 1) / divisor;
 }
 
 static inline uint32_t round_up(uint32_t num, uint32_t multiple) {


### PR DESCRIPTION
some platform have maxComputeWorkGroupCount equal to UINT_MAX.
It generates an overflow when computing num_splitted_regions in
cvk_command_kernel::dispatch_uniform_region_iterate