### PR TITLE
memory: fix free of cvk_memory_allocation when using image1dbuffer

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -108,7 +108,7 @@ bool cvk_buffer::init() {
     }
 
     // Allocate memory
-    m_memory = std::make_unique<cvk_memory_allocation>(
+    m_memory = std::make_shared<cvk_memory_allocation>(
         vkdev, params.size, params.memory_type_index);
     res = m_memory->allocate();
 
@@ -341,7 +341,7 @@ bool cvk_image::init() {
 
     if (m_desc.image_type == CL_MEM_OBJECT_IMAGE1D_BUFFER) {
         auto buffer = static_cast<cvk_mem*>(m_desc.buffer);
-        m_memory = std::unique_ptr<cvk_memory_allocation>(buffer->memory());
+        m_memory = buffer->memory();
         buffer->retain();
     } else {
         // Select memory type

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -128,9 +128,9 @@ struct cvk_mem : public _cl_mem, api_object<object_magic::memory_object> {
         return m_properties;
     }
 
-    cvk_memory_allocation* memory() const {
+    std::shared_ptr<cvk_memory_allocation> memory() const {
         if (m_parent == nullptr) {
-            return m_memory.get();
+            return m_memory;
         } else {
             return m_parent->memory();
         }
@@ -224,7 +224,7 @@ protected:
     void* m_host_ptr;
     cvk_mem_holder m_parent;
     size_t m_parent_offset;
-    std::unique_ptr<cvk_memory_allocation> m_memory;
+    std::shared_ptr<cvk_memory_allocation> m_memory;
 };
 
 static inline cvk_mem* icd_downcast(cl_mem mem) {

--- a/tests/api/images.cpp
+++ b/tests/api/images.cpp
@@ -412,3 +412,27 @@ TEST_F(WithCommandQueue, ImageWriteOffset) {
 
     EXPECT_TRUE(success);
 }
+
+TEST_F(WithContext, Image1DBuffer) {
+    const size_t IMAGE_HEIGHT = 128;
+    const size_t IMAGE_WIDTH = 128;
+
+    auto buffer_size = IMAGE_HEIGHT * IMAGE_WIDTH * sizeof(cl_float4);
+    auto buffer = CreateBuffer(CL_MEM_READ_WRITE, buffer_size, nullptr);
+
+    cl_image_format format = {CL_RGBA, CL_FLOAT};
+    cl_image_desc desc = {
+        CL_MEM_OBJECT_IMAGE1D_BUFFER, // image_type
+        IMAGE_WIDTH,                  // image_width
+        IMAGE_HEIGHT,                 // image_height
+        1,                            // image_depth
+        1,                            // image_array_size
+        0,                            // image_row_pitch
+        0,                            // image_slice_pitch
+        0,                            // num_mip_levels
+        0,                            // num_samples
+        buffer,                       // buffer
+    };
+
+    auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc);
+}


### PR DESCRIPTION
Add a test which is segfaulting without this fix due to a double free.