### PR TITLE
Fix device enumeration logic and add tests

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -94,7 +94,8 @@ bool is_same_context(cl_command_queue queue, cl_uint num_events,
 }
 
 bool is_valid_device_type(cl_device_type type) {
-    return type <= CL_DEVICE_TYPE_CUSTOM || type == CL_DEVICE_TYPE_ALL;
+    return (type < (CL_DEVICE_TYPE_CUSTOM << 1)) ||
+           (type == CL_DEVICE_TYPE_ALL);
 }
 
 bool map_flags_are_valid(cl_map_flags flags) {
@@ -322,9 +323,7 @@ cl_int CLVK_API_CALL clGetDeviceIDs(cl_platform_id platform,
     cl_uint num = 0;
 
     for (auto dev : icd_downcast(platform)->devices()) {
-        if ((device_type == CL_DEVICE_TYPE_DEFAULT) ||
-            (device_type == CL_DEVICE_TYPE_ALL) ||
-            (dev->type() == device_type)) {
+        if (dev->type() & device_type) {
             if ((devices != nullptr) && (num < num_entries)) {
                 devices[num] = dev;
             }

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -27,8 +27,8 @@ constexpr VkMemoryPropertyFlags cvk_device::buffer_supported_memory_types[];
 constexpr VkMemoryPropertyFlags cvk_device::image_supported_memory_types[];
 
 cvk_device* cvk_device::create(cvk_platform* platform, VkInstance instance,
-                               VkPhysicalDevice pdev) {
-    cvk_device* device = new cvk_device(platform, pdev);
+                               VkPhysicalDevice pdev, bool is_default) {
+    cvk_device* device = new cvk_device(platform, pdev, is_default);
 
     if (!device->init(instance)) {
         delete device;

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -19,6 +19,7 @@ add_gtest_executable(api_tests
     images.cpp
     local_buffer.cpp
     main.cpp
+    platform.cpp
     profiling.cpp
     simple.cpp
     simple_image.cpp

--- a/tests/api/platform.cpp
+++ b/tests/api/platform.cpp
@@ -1,0 +1,75 @@
+// Copyright 2022 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testcl.hpp"
+
+#include <unordered_set>
+
+TEST(Platform, HasOneDefaultDevice) {
+    cl_int err;
+    cl_uint num_devices;
+    err =
+        clGetDeviceIDs(gPlatform, CL_DEVICE_TYPE_ALL, 0, nullptr, &num_devices);
+    ASSERT_EQ(err, CL_SUCCESS);
+
+    std::vector<cl_device_id> devices(num_devices);
+
+    err = clGetDeviceIDs(gPlatform, CL_DEVICE_TYPE_ALL, num_devices,
+                         devices.data(), nullptr);
+    ASSERT_EQ(err, CL_SUCCESS);
+
+    unsigned num_default = 0;
+
+    for (auto dev : devices) {
+        cl_device_type dtype;
+        err = clGetDeviceInfo(dev, CL_DEVICE_TYPE, sizeof(dtype), &dtype,
+                              nullptr);
+        ASSERT_EQ(err, CL_SUCCESS);
+
+        if (dtype & CL_DEVICE_TYPE_DEFAULT) {
+            num_default++;
+        }
+    }
+
+    ASSERT_EQ(num_default, 1);
+}
+
+TEST(Platform, DeviceQueryWithMultipleTypes) {
+    cl_int err;
+
+    // Get the type of the already selected device
+    cl_device_type dtype;
+    err = clGetDeviceInfo(gDevice, CL_DEVICE_TYPE, sizeof(dtype), &dtype,
+                          nullptr);
+    ASSERT_EQ(err, CL_SUCCESS);
+
+    // Check its type is one of the expected values
+    dtype &= ~CL_DEVICE_TYPE_DEFAULT;
+    ASSERT_TRUE(dtype == CL_DEVICE_TYPE_GPU || dtype == CL_DEVICE_TYPE_CPU ||
+                dtype == CL_DEVICE_TYPE_ACCELERATOR);
+
+    std::unordered_set<cl_device_type> other_types = {
+        CL_DEVICE_TYPE_DEFAULT, CL_DEVICE_TYPE_CPU, CL_DEVICE_TYPE_GPU,
+        CL_DEVICE_TYPE_ACCELERATOR, CL_DEVICE_TYPE_CUSTOM};
+
+    other_types.erase(dtype);
+
+    // Check that the device can still be enumerated when the requested device
+    // type specifies other device types as well
+    for (auto otype : other_types) {
+        cl_device_id device;
+        err = clGetDeviceIDs(gPlatform, dtype | otype, 1, &device, nullptr);
+        ASSERT_EQ(err, CL_SUCCESS);
+    }
+}


### PR DESCRIPTION
- Report the first device as the default device and add a test that checks
  exactly one default device is reported.
- Support enumeration when application pass a mask of device types with
  multiple bits set and add a test.


Signed-off-by: Kévin Petit <kpet@free.fr>