### PR TITLE
Explicitly include tmp folder for ONLINE compilation

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -824,8 +824,15 @@ cl_build_status cvk_program::compile_source(const cvk_device* device) {
     }
 #endif
 
+    // Prepare build options
+    auto build_options = prepare_build_options(device);
+    if (build_from_il) {
+        build_options += " -x ir ";
+    }
+
     // Save headers
     if (save_headers) {
+        build_options += "-I" + tmp_folder;
         for (cl_uint i = 0; i < m_num_input_programs; i++) {
             std::string fname{tmp_folder + "/" + m_header_include_names[i]};
             temps.push(fname);
@@ -834,12 +841,6 @@ cl_build_status cvk_program::compile_source(const cvk_device* device) {
                 return CL_BUILD_ERROR;
             }
         }
-    }
-
-    // Prepare build options
-    auto build_options = prepare_build_options(device);
-    if (build_from_il) {
-        build_options += " -x ir ";
     }
 
     // Select operation

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -782,12 +782,10 @@ cl_build_status cvk_program::compile_source(const cvk_device* device) {
 #else // !COMPILER_AVAILABLE
     bool build_from_il = m_il.size() > 0;
     bool use_tmp_folder = true;
-    bool save_headers = true;
     temp_file_deletion_stack temps;
 #ifdef CLSPV_ONLINE_COMPILER
     use_tmp_folder =
         m_operation == build_operation::compile && m_num_input_programs > 0;
-    save_headers = m_operation == build_operation::compile;
 #endif
 
     std::string tmp_folder;
@@ -831,7 +829,7 @@ cl_build_status cvk_program::compile_source(const cvk_device* device) {
     }
 
     // Save headers
-    if (save_headers) {
+    if (use_tmp_folder) {
         build_options += "-I" + tmp_folder;
         for (cl_uint i = 0; i < m_num_input_programs; i++) {
             std::string fname{tmp_folder + "/" + m_header_include_names[i]};


### PR DESCRIPTION
In ONLINE compilation mode, clspv does not include any path by
default (which it does with the input path in OFFLINE compilation
mode).
Explicitly add tmp folder to cover this case