### PR TITLE
Add missing headers to event.hpp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 add_library(OpenCL-objects OBJECT
   api.cpp
   device.cpp
+  event.cpp
   init.cpp
   kernel.cpp
   log.cpp

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -1,0 +1,15 @@
+// Copyright 2022 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "event.hpp"

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -15,6 +15,9 @@
 #pragma once
 
 #include "cl_headers.hpp"
+#include "icd.hpp"
+#include "objects.hpp"
+#include "utils.hpp"
 
 #include <mutex>
 #include <unordered_map>


### PR DESCRIPTION
Also add an event.cpp to include event.hpp to ensure the file can be
included without needing to include dependent headers first.