### PR TITLE
tests: api: images.cpp: remove include of utils.hpp

### DIFF
--- a/tests/api/images.cpp
+++ b/tests/api/images.cpp
@@ -15,7 +15,6 @@
 #define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 
 #include "testcl.hpp"
-#include "utils.hpp"
 
 TEST_F(WithContext, CreateImageLegacy) {
     cl_image_format format = {CL_RGBA, CL_UNORM_INT8};


### PR DESCRIPTION
utils.hpp has been added to use ARRAY_SIZE at some point in #387.
In the end, ARRAY_SIZE was not used but utils.hpp was still there.

Remove it as it is not needed, and on top of that, it is making the
clspv ci fail, as we are just lucky in clvk that the build system
managed to find "vulkan/vulkan.h" (which is a dependency of
"utils.hpp") while it should not be needed to build cl tests.