### PR TITLE
cvk_command_dep: add memory_objects method

### DIFF
--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -746,6 +746,8 @@ struct cvk_command_dep : public cvk_command {
         : cvk_command(type, q) {}
 
     CHECK_RETURN cl_int do_action() override final { return CL_COMPLETE; }
+
+    const std::vector<cvk_mem*> memory_objects() const override { return {}; }
 };
 
 struct cvk_command_buffer_image_copy final : public cvk_command_batchable {


### PR DESCRIPTION
This method is needed to avoid asserting on cvk_command virtual
implementation.

Ref #411