### PR TITLE
fix build of api_tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ macro(add_gtest_executable name)
   include_directories(${LLVM_SOURCE_DIR}/include)
   include_directories(${LLVM_SOURCE_DIR}/utils/unittest/googletest/include/)
   include_directories(${CLVK_PROJECT_SOURCE_DIR}/src)
+  include_directories(${Vulkan_INCLUDE_DIRS})
 
   target_link_libraries(${name} OpenCL llvm_gtest llvm_gtest_main)
   if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
`tests/api/split_region.cpp` has a dependency on `utils.hpp` for
`ARRAY_SIZE`.
And `utils.hpp` has a dependency on `vulkan.h`. This header is not
always in the includes path, making the build fail.