### PR TITLE
Implement printf

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(OpenCL-objects OBJECT
   kernel.cpp
   log.cpp
   memory.cpp
+  printf.cpp
   program.cpp
   queue.cpp
   sha1.cpp

--- a/src/config.def
+++ b/src/config.def
@@ -29,6 +29,7 @@ OPTION(uint32_t, percentage_of_available_memory_reported, 100u)
 OPTION(uint32_t, spirv_validation, 2u)
 OPTION(std::string, spirv_arch, "spir")
 OPTION(bool, physical_addressing, false)
+OPTION(uint32_t, printf_buffer_size, 1048576u)
 
 #if COMPILER_AVAILABLE
 OPTION(std::string, clspv_options, "")

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -162,7 +162,7 @@ bool cvk_kernel_argument_values::setup_descriptor_sets() {
     // Setup module-scope variables
     if (program->module_constant_data_buffer() != nullptr &&
         program->module_constant_data_buffer_info()->type ==
-            constant_data_buffer_type::storage_buffer) {
+            module_buffer_type::storage_buffer) {
         auto buffer = program->module_constant_data_buffer();
         auto info = program->module_constant_data_buffer_info();
         cvk_debug_fn(

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -19,6 +19,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "spirv/unified1/NonSemanticClspvReflection.h"
+
 #include "memory.hpp"
 #include "objects.hpp"
 #include "program.hpp"
@@ -34,9 +36,7 @@ struct cvk_kernel : public _cl_kernel, api_object<object_magic::kernel> {
     CHECK_RETURN cl_int init();
     std::unique_ptr<cvk_kernel> clone(cl_int* errcode_ret) const;
 
-    virtual ~cvk_kernel() {
-        m_argument_values.reset();
-    }
+    virtual ~cvk_kernel() { m_argument_values.reset(); }
 
     std::shared_ptr<cvk_kernel_argument_values> argument_values() const {
         return m_argument_values;
@@ -141,6 +141,13 @@ struct cvk_kernel : public _cl_kernel, api_object<object_magic::kernel> {
     cl_kernel_arg_type_qualifier arg_type_qualifier(cl_uint arg_index) const {
         return m_args.at(arg_index).info.type_qualifier;
     }
+
+    bool uses_printf() const {
+        return m_program->kernel_flags(m_name) &
+               NonSemanticClspvReflectionMayUsePrintf;
+    }
+
+    bool requires_serialized_execution() const { return uses_printf(); }
 
 private:
     friend cvk_kernel_argument_values;

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -1,0 +1,247 @@
+// Copyright 2022 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sstream>
+
+#include "printf.hpp"
+
+// Extract the conversion specifier from a format string
+char get_fmt_conversion(std::string_view fmt) {
+    auto conversionSpecPos = fmt.find_first_of("diouxXfFeEgGaAcsp");
+    return fmt.at(conversionSpecPos);
+}
+
+// Read type T from given pointer
+template <typename T> T read_buff(const char* data) {
+    return *(reinterpret_cast<const T*>(data));
+}
+
+// Read type T from given pointer then increment the pointer
+template <typename T> T read_inc_buff(char*& data) {
+    T out = *(reinterpret_cast<T*>(data));
+    data += sizeof(T);
+    return out;
+}
+
+// Extract the optional vector flag and return a modified format string suitable
+// for calling snprintf on individual vector elements
+std::string get_vector_fmt(std::string fmt, int& vector_size, int& element_size,
+                           std::string& remaining_fmt) {
+    // Consume flags (skipping initial '%')
+    auto pos = fmt.find_first_not_of(" +-#0", 1ul);
+    // Consume precision and field width
+    pos = fmt.find_first_not_of("123456789.", pos);
+
+    if (fmt.at(pos) != 'v') {
+        vector_size = 1;
+        return std::string{fmt};
+    }
+
+    // Trim the data after the conversion specifier and store it in
+    // `remaining_fmt`
+    auto pos_conversion = fmt.find_first_of("diouxXfFeEgGaAcsp");
+    auto fmt_specifier = fmt.substr(0, pos_conversion + 1);
+    remaining_fmt = fmt.substr(pos_conversion + 1);
+    fmt = fmt_specifier;
+
+    size_t vec_length_pos_start = ++pos;
+    size_t vec_length_pos_end =
+        fmt.find_first_not_of("23468", vec_length_pos_start);
+    auto vec_length_str = fmt.substr(vec_length_pos_start,
+                                     vec_length_pos_end - vec_length_pos_start);
+    int vec_length = std::atoi(vec_length_str.c_str());
+
+    auto fmt_pre_vec_len = fmt.substr(0, vec_length_pos_start - 1);
+    auto fmt_post_vec_len = fmt.substr(vec_length_pos_end, fmt.size());
+    fmt = fmt_pre_vec_len + fmt_post_vec_len;
+
+    // The length modifier is required with vectors
+    if (fmt_post_vec_len.find("hh") != std::string::npos) {
+        element_size = 1;
+    } else if (fmt_post_vec_len.find("hl") != std::string::npos) {
+        element_size = 4;
+    } else if (fmt_post_vec_len.find("h") != std::string::npos) {
+        element_size = 2;
+    } else if (fmt_post_vec_len.find("l") != std::string::npos) {
+        element_size = 8;
+    }
+
+    // If 'hl' length modifier is present, strip it as snprintf doesn't
+    // understand it
+    size_t hl = fmt.find("hl");
+    if (hl != std::string::npos) {
+        fmt.erase(hl, 2);
+    }
+
+    vector_size = vec_length;
+    return fmt;
+}
+
+// Print the format part containing exactly one arg using snprintf
+std::string print_part(const std::string& fmt, const char* data, size_t size) {
+    // We don't know the exact size of the output string, but given we have a
+    // single argument, the size of the format string plus 1024 bytes is more
+    // than likely to fit everything. If it doesn't fit, just keep retrying with
+    // double the output size.
+    size_t out_size = fmt.size() + 1024;
+    std::vector<char> out;
+    out.reserve(out_size);
+    out[0] = '\0';
+
+    auto conversion = std::tolower(get_fmt_conversion(fmt));
+    bool finished = false;
+    while (!finished) {
+        int written = 0;
+        switch (conversion) {
+        case 's': {
+            written = snprintf(out.data(), out_size, fmt.c_str(), data);
+            break;
+        }
+        case 'f':
+        case 'e':
+        case 'g':
+        case 'a': {
+            if (size == 4)
+                written = snprintf(out.data(), out_size, fmt.c_str(),
+                                   read_buff<float>(data));
+            else
+                written = snprintf(out.data(), out_size, fmt.c_str(),
+                                   read_buff<double>(data));
+            break;
+        }
+        default: {
+            if (size == 1)
+                written = snprintf(out.data(), out_size, fmt.c_str(),
+                                   read_buff<uint8_t>(data));
+            else if (size == 2)
+                written = snprintf(out.data(), out_size, fmt.c_str(),
+                                   read_buff<uint16_t>(data));
+            else if (size == 4)
+                written = snprintf(out.data(), out_size, fmt.c_str(),
+                                   read_buff<uint32_t>(data));
+            else
+                written = snprintf(out.data(), out_size, fmt.c_str(),
+                                   read_buff<uint64_t>(data));
+            break;
+        }
+        }
+
+        // Finish if the string fit in the output buffer or snprintf failed,
+        // otherwise double the output buffer and try again. If snprintf failed,
+        // set the output to an empty string.
+        if (written < 0) {
+            out[0] = '\0';
+            finished = true;
+        } else if (written < static_cast<long>(out_size)) {
+            finished = true;
+        } else {
+            out_size *= 2;
+            out.reserve(out_size);
+        }
+    }
+
+    return std::string(out.data());
+}
+
+void process_printf(char*& data, const printf_descriptor_map_t& descs) {
+
+    uint32_t printf_id = read_inc_buff<uint32_t>(data);
+    auto& format_string = descs.at(printf_id).format_string;
+
+    std::stringstream printf_out{};
+
+    // Firstly print the part of the format string up to the first '%'
+    size_t next_part = format_string.find_first_of('%');
+    printf_out << format_string.substr(0, next_part);
+
+    // Decompose the remaining format string into individual strings with
+    // one format specifier each, handle each one individually
+    size_t arg_idx = 0;
+    while (next_part < format_string.size() - 1) {
+        // Get the part of the format string before the next format specifier
+        size_t part_start = next_part;
+        size_t part_end = format_string.find_first_of('%', part_start + 1);
+        auto part_fmt = format_string.substr(part_start, part_end - part_start);
+
+        // Handle special cases
+        if (part_end == part_start + 1) {
+            printf_out << "%";
+            next_part = part_end + 1;
+            continue;
+        } else if (part_end == std::string::npos &&
+                   arg_idx >= descs.at(printf_id).arg_sizes.size()) {
+            // If there are no remaining arguments, the rest of the format
+            // should be printed verbatim
+            printf_out << part_fmt;
+            break;
+        }
+
+        // The size of the argument that this format part will consume
+        auto& size = descs.at(printf_id).arg_sizes[arg_idx];
+
+        // Check to see if we have a vector format specifier
+        int vec_len = 0;
+        int el_size = 0;
+        std::string remaining_str;
+        part_fmt = get_vector_fmt(part_fmt, vec_len, el_size, remaining_str);
+
+        // Scalar argument
+        if (vec_len < 2) {
+            // Special case for %s
+            if (get_fmt_conversion(part_fmt) == 's') {
+                uint32_t string_id = read_buff<uint32_t>(data);
+                printf_out << print_part(
+                    part_fmt, descs.at(string_id).format_string.c_str(), size);
+            } else {
+                printf_out << print_part(part_fmt, data, size);
+            }
+            data += size;
+        } else {
+            // Vector argument
+            auto* data_start = data;
+            for (int i = 0; i < vec_len - 1; i++) {
+                printf_out << print_part(part_fmt, data, size / vec_len) << ",";
+                data += el_size;
+            }
+            printf_out << print_part(part_fmt, data, size / vec_len)
+                       << remaining_str;
+            data = data_start + size;
+        }
+
+        // Move to the next format part and prepare to handle the next arg
+        next_part = part_end;
+        arg_idx++;
+    }
+
+    printf("%s", printf_out.str().c_str());
+}
+
+void cvk_printf(cvk_mem* printf_buffer,
+                const printf_descriptor_map_t& descriptors) {
+    if (!printf_buffer->map()) {
+        cvk_error("Could not map printf buffer");
+        return;
+    }
+    char* data = static_cast<char*>(printf_buffer->host_va());
+    auto buffer_size = printf_buffer->size();
+    auto bytes_written = read_inc_buff<uint32_t>(data) * 4;
+    auto* data_start = data;
+
+    while (static_cast<size_t>(data - data_start) < bytes_written &&
+           static_cast<size_t>(data - data_start) < buffer_size) {
+        process_printf(data, descriptors);
+    }
+
+    printf_buffer->unmap();
+}

--- a/src/printf.hpp
+++ b/src/printf.hpp
@@ -1,0 +1,31 @@
+// Copyright 2022 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "memory.hpp"
+
+#include <vector>
+
+struct printf_descriptor {
+    uint32_t printf_id;
+    std::string format_string;
+    std::vector<uint32_t> arg_sizes;
+};
+
+using printf_descriptor_map_t = std::unordered_map<uint32_t, printf_descriptor>;
+
+// Process the contents of the printf buffer and print the results to stdout
+void cvk_printf(cvk_mem* printf_buffer,
+                const printf_descriptor_map_t& descriptors);

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -147,6 +147,8 @@ spv_result_t parse_reflection(void* user_data,
             return pushconstant::image_metadata;
         case NonSemanticClspvReflectionConstantDataPointerPushConstant:
             return pushconstant::module_constants_pointer;
+        case NonSemanticClspvReflectionPrintfBufferPointerPushConstant:
+            return pushconstant::printf_buffer_pointer;
         default:
             cvk_error_fn("Unhandled reflection instruction for push constant");
             break;
@@ -179,8 +181,9 @@ spv_result_t parse_reflection(void* user_data,
                 // Record the kernel name.
                 const auto& name = parse_data->strings[inst->words[6]];
                 const auto& num_args = parse_data->constants[inst->words[7]];
+                const auto& flags = parse_data->constants[inst->words[8]];
                 parse_data->strings[inst->result_id] = name;
-                parse_data->binary->add_kernel(name, num_args);
+                parse_data->binary->add_kernel(name, num_args, flags);
                 break;
             }
             case NonSemanticClspvReflectionArgumentInfo: {
@@ -434,25 +437,56 @@ spv_result_t parse_reflection(void* user_data,
                                  "number of digits)");
                     return SPV_ERROR_INVALID_DATA;
                 }
-                constant_data_buffer_info binfo;
+                constant_data_buffer_info binfo{};
                 auto data_size = data.size() / 2;
                 binfo.data.resize(data_size);
                 hex2bin(data.c_str(), binfo.data.data());
                 if (ext_inst ==
                     NonSemanticClspvReflectionConstantDataStorageBuffer) {
-                    binfo.type = constant_data_buffer_type::storage_buffer;
+                    binfo.type = module_buffer_type::storage_buffer;
                     binfo.set = parse_data->constants[inst->words[5]];
                     binfo.binding = parse_data->constants[inst->words[6]];
 
                 } else {
-                    binfo.type =
-                        constant_data_buffer_type::pointer_push_constant;
+                    binfo.type = module_buffer_type::pointer_push_constant;
                     binfo.pc_offset = parse_data->constants[inst->words[5]];
                     parse_data->binary->add_push_constant(
                         pushconstant::module_constants_pointer,
                         {binfo.pc_offset, 8u});
                 }
                 parse_data->binary->set_constant_data_buffer(binfo);
+                break;
+            }
+            case NonSemanticClspvReflectionPrintfInfo: {
+                uint32_t printf_id = parse_data->constants[inst->words[5]];
+                std::string printf_string = parse_data->strings[inst->words[6]];
+                std::vector<uint32_t> printf_arg_sizes;
+                for (int i = 6; i < inst->num_operands; i++) {
+                    printf_arg_sizes.push_back(
+                        parse_data
+                            ->constants[inst->words[inst->operands[i].offset]]);
+                }
+                parse_data->binary->add_printf_descriptor(
+                    {printf_id, printf_string, printf_arg_sizes});
+                break;
+            }
+            case NonSemanticClspvReflectionPrintfBufferStorageBuffer: {
+                printf_buffer_desc_info binfo;
+                binfo.type = module_buffer_type::storage_buffer;
+                binfo.set = parse_data->constants[inst->words[5]];
+                binfo.binding = parse_data->constants[inst->words[6]];
+                binfo.size = parse_data->constants[inst->words[7]];
+                parse_data->binary->set_printf_buffer_info(binfo);
+                break;
+            }
+            case NonSemanticClspvReflectionPrintfBufferPointerPushConstant: {
+                printf_buffer_desc_info binfo;
+                binfo.type = module_buffer_type::pointer_push_constant;
+                binfo.pc_offset = parse_data->constants[inst->words[5]];
+                binfo.size = parse_data->constants[inst->words[7]];
+                parse_data->binary->set_printf_buffer_info(binfo);
+                parse_data->binary->add_push_constant(
+                    pushconstant::printf_buffer_pointer, {binfo.pc_offset, 8u});
                 break;
             }
             default:
@@ -901,6 +935,11 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
             options.back() = ' '; // replace the final comma
         }
     }
+
+    options += " -enable-printf ";
+    options +=
+        " -printf-buffer-size=" + std::to_string(config.printf_buffer_size) +
+        " ";
 
 #if COMPILER_AVAILABLE
     options += " " + config.clspv_options() + " ";
@@ -1584,11 +1623,39 @@ bool cvk_entry_point::
         auto info = m_program->module_constant_data_buffer_info();
         // If the program scope buffer isn't passed as a storage buffer (i.e.
         // it is passed a pointer push constant), there is nothing to bind here
-        if (info->type != constant_data_buffer_type::storage_buffer) {
+        if (info->type != module_buffer_type::storage_buffer) {
             return true;
         }
         VkDescriptorSetLayoutBinding binding = {
             info->binding,                     // binding
+            VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, // descriptorType
+            1,                                 // decriptorCount
+            VK_SHADER_STAGE_COMPUTE_BIT,       // stageFlags
+            nullptr                            // pImmutableSamplers
+        };
+        layoutBindings.push_back(binding);
+        smap[binding.descriptorType]++;
+    }
+
+    if (!build_descriptor_set_layout(layoutBindings)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool cvk_entry_point::build_descriptor_sets_layout_bindings_for_printf_buffer(
+    binding_stat_map& smap) {
+    std::vector<VkDescriptorSetLayoutBinding> layoutBindings;
+    if (m_program->printf_buffer_info().size > 0 &&
+        (m_program->kernel_flags(m_name) &
+         NonSemanticClspvReflectionMayUsePrintf)) {
+        auto info = m_program->printf_buffer_info();
+        if (info.type != module_buffer_type::storage_buffer) {
+            return true;
+        }
+        VkDescriptorSetLayoutBinding binding = {
+            info.binding,                      // binding
             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, // descriptorType
             1,                                 // decriptorCount
             VK_SHADER_STAGE_COMPUTE_BIT,       // stageFlags
@@ -1638,6 +1705,10 @@ cl_int cvk_entry_point::init() {
         return CL_INVALID_VALUE;
     }
     if (!build_descriptor_sets_layout_bindings_for_program_scope_buffers(
+            bindingTypes)) {
+        return CL_INVALID_VALUE;
+    }
+    if (!build_descriptor_sets_layout_bindings_for_printf_buffer(
             bindingTypes)) {
         return CL_INVALID_VALUE;
     }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -32,6 +32,7 @@
 #include "init.hpp"
 #include "memory.hpp"
 #include "objects.hpp"
+#include "printf.hpp"
 
 const int SPIR_WORD_SIZE = 4;
 
@@ -124,6 +125,7 @@ enum class pushconstant
     region_group_offset,
     image_metadata,
     module_constants_pointer,
+    printf_buffer_pointer,
 };
 
 struct pushconstant_desc {
@@ -143,18 +145,26 @@ enum class spec_constant
     subgroup_max_size,
 };
 
-enum class constant_data_buffer_type
+enum class module_buffer_type
 {
     storage_buffer,
     pointer_push_constant,
 };
 
 struct constant_data_buffer_info {
-    constant_data_buffer_type type;
+    module_buffer_type type;
     uint32_t set;
     uint32_t binding;
     uint32_t pc_offset;
     std::vector<char> data;
+};
+
+struct printf_buffer_desc_info {
+    module_buffer_type type;
+    uint32_t set;
+    uint32_t binding;
+    uint32_t pc_offset;
+    uint32_t size = 0;
 };
 
 struct spirv_validation_options {
@@ -182,6 +192,7 @@ class spir_binary {
         std::unordered_map<std::string, std::vector<kernel_argument>>;
     using kernels_reqd_work_group_size_map =
         std::unordered_map<std::string, std::array<uint32_t, 3>>;
+    using kernels_flags_map = std::unordered_map<std::string, uint32_t>;
 
 public:
     spir_binary(spv_target_env env)
@@ -238,7 +249,13 @@ public:
         }
     }
 
-    void add_kernel(const std::string& name, uint32_t num_args) {
+    const printf_descriptor_map_t& printf_descriptors() const {
+        return m_printf_descriptors;
+    }
+
+    void add_kernel(const std::string& name, uint32_t num_args,
+                    uint32_t flags) {
+        m_flags[name] = flags;
         auto& args = m_dmaps[name];
         kernel_argument unused = {
             {}, 0, 0, 0, 0, 0, kernel_argument_kind::unused, 0, 0};
@@ -250,7 +267,6 @@ public:
         for (auto& arg : args) {
             arg.pos = pos++;
         }
-        m_reqd_work_group_sizes[name] = {0, 0, 0};
     }
 
     void add_kernel_argument(const std::string& name, kernel_argument&& arg) {
@@ -295,6 +311,24 @@ public:
         m_image_metadata[name][ordinal].set_data_type(offset);
     }
 
+    void add_printf_descriptor(printf_descriptor&& desc) {
+        m_printf_descriptors[desc.printf_id] = desc;
+    }
+
+    void set_printf_buffer_info(const printf_buffer_desc_info& info) {
+        m_printf_buffer_info = info;
+    }
+
+    const printf_buffer_desc_info& printf_buffer_info() const {
+        return m_printf_buffer_info;
+    }
+
+    const printf_descriptor_map_t& get_printf_descriptors() const {
+        return m_printf_descriptors;
+    }
+
+    const kernels_flags_map& kernels_flags() const { return m_flags; }
+
 private:
     spv_context m_context;
     std::vector<uint32_t> m_code;
@@ -302,9 +336,12 @@ private:
     std::unordered_map<pushconstant, pushconstant_desc> m_push_constants;
     std::unordered_map<spec_constant, uint32_t> m_spec_constants;
     image_metadata_map m_image_metadata;
+    std::unordered_map<uint32_t, printf_descriptor> m_printf_descriptors;
+    printf_buffer_desc_info m_printf_buffer_info;
     std::unique_ptr<constant_data_buffer_info> m_constant_data_buffer;
     kernels_arguments_map m_dmaps;
     kernels_reqd_work_group_size_map m_reqd_work_group_sizes;
+    kernels_flags_map m_flags;
     bool m_loaded_from_binary;
     spv_target_env m_target_env;
 };
@@ -414,6 +451,8 @@ private:
     bool build_descriptor_sets_layout_bindings_for_literal_samplers(
         binding_stat_map& smap);
     bool build_descriptor_sets_layout_bindings_for_program_scope_buffers(
+        binding_stat_map& smap);
+    bool build_descriptor_sets_layout_bindings_for_printf_buffer(
         binding_stat_map& smap);
 
     // Structures for caching pipelines based on specialization constants
@@ -553,6 +592,11 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
 
     unsigned num_kernels() const { return m_binary.num_kernels(); }
     bool loaded_from_binary() const { return m_binary.loaded_from_binary(); }
+    bool uses_printf() { return !m_binary.printf_descriptors().empty(); }
+    const std::unordered_map<uint32_t, printf_descriptor>&
+    printf_descriptors() {
+        return m_binary.get_printf_descriptors();
+    }
 
     const std::vector<kernel_argument>* args_for_kernel(std::string& name) {
         auto const& args = m_binary.kernels_arguments().find(name);
@@ -650,6 +694,10 @@ public:
         return m_binary.constant_data_buffer();
     }
 
+    const printf_buffer_desc_info& printf_buffer_info() const {
+        return m_binary.printf_buffer_info();
+    }
+
     bool options_allow_split_region(std::string options) {
         if (options.find("-uniform-workgroup-size") != std::string::npos)
             return false;
@@ -662,6 +710,10 @@ public:
         status &= options_allow_split_region(config.clspv_options);
 #endif
         return status;
+    }
+
+    uint32_t kernel_flags(const std::string& kernel) const {
+        return m_binary.kernels_flags().at(kernel);
     }
 
 private:
@@ -712,6 +764,7 @@ private:
     std::vector<uint32_t> m_stripped_binary;
     VkPipelineCache m_pipeline_cache;
     std::unique_ptr<cvk_buffer> m_module_constant_data_buffer;
+    std::unique_ptr<cvk_buffer> m_printf_buffer;
 };
 
 static inline cvk_program* icd_downcast(cl_program program) {

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -488,6 +488,25 @@ void cvk_command_kernel::update_global_push_constants(
                            &dev_addr);
     }
 
+    if (auto pc = program->push_constant(pushconstant::printf_buffer_pointer)) {
+        CVK_ASSERT(pc->size == 8);
+        CVK_ASSERT(program->uses_printf());
+
+        auto buffer = m_queue->printf_buffer();
+        VkBufferDeviceAddressInfo info{};
+        info.buffer = buffer->vulkan_buffer();
+        info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
+        info.pNext = NULL;
+
+        auto dev_addr = vkGetBufferDeviceAddress(
+            m_kernel->context()->device()->vulkan_device(), &info);
+        dev_addr += buffer->vulkan_buffer_offset();
+
+        vkCmdPushConstants(command_buffer, m_kernel->pipeline_layout(),
+                           VK_SHADER_STAGE_COMPUTE_BIT, pc->offset, pc->size,
+                           &dev_addr);
+    }
+
     uint32_t image_metadata_pc_start = UINT32_MAX;
     uint32_t image_metadata_pc_end = 0;
     if (const auto* md = m_kernel->get_image_metadata()) {
@@ -652,6 +671,32 @@ cl_int cvk_command_kernel::dispatch_uniform_region_within_vklimits(
     vkCmdDispatch(command_buffer, num_workgroups[0], num_workgroups[1],
                   num_workgroups[2]);
 
+    // If we have a kernel that requires serial execution (i.e. regions are not
+    // executed in parallel with other regions or other kernels) then serialize
+    // the command buffer
+    if (m_kernel->requires_serialized_execution()) {
+        VkMemoryBarrier memoryBarrier = {VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+                                         nullptr, VK_ACCESS_SHADER_WRITE_BIT,
+                                         VK_ACCESS_MEMORY_READ_BIT |
+                                             VK_ACCESS_MEMORY_WRITE_BIT};
+
+        // Workaround for a bug on some NVIDIA devices.
+        // This should already be covered by VK_ACCESS_MEMORY_READ_BIT.
+        memoryBarrier.dstAccessMask |= VK_ACCESS_SHADER_READ_BIT;
+
+        vkCmdPipelineBarrier(
+            command_buffer,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, // srcStageMask
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, // dstStageMask
+            0,                                    // dependencyFlags
+            1,                                    // memoryBarrierCount
+            &memoryBarrier,
+            0,        // bufferMemoryBarrierCount
+            nullptr,  // pBufferMemoryBarriers
+            0,        // imageMemoryBarrierCount
+            nullptr); // pImageMemoryBarriers
+    }
+
     return CL_SUCCESS;
 }
 
@@ -807,6 +852,41 @@ cvk_command_kernel::build_batchable_inner(cvk_command_buffer& command_buffer) {
         return CL_OUT_OF_RESOURCES;
     }
 
+    // Setup printf buffer descriptor if needed
+    if (m_kernel->program()->uses_printf()) {
+        // Create and initialize the printf buffer
+        auto buffer = m_queue->printf_buffer();
+        if (buffer->map()) {
+            memset(buffer->host_va(), 0, 4);
+            buffer->unmap();
+        }
+
+        if (m_kernel->program()->printf_buffer_info().type ==
+            module_buffer_type::storage_buffer) {
+
+            VkDescriptorBufferInfo bufferInfo = {buffer->vulkan_buffer(),
+                                                 0, // offset
+                                                 VK_WHOLE_SIZE};
+
+            auto* ds = m_argument_values->descriptor_sets();
+            VkWriteDescriptorSet writeDescriptorSet = {
+                VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                nullptr,
+                ds[m_kernel->program()->printf_buffer_info().set],
+                m_kernel->program()->printf_buffer_info().binding,
+                0,                                 // dstArrayElement
+                1,                                 // descriptorCount
+                VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, // descriptorType
+                nullptr,                           // pImageInfo
+                &bufferInfo,
+                nullptr, // pTexelBufferView
+            };
+
+            vkUpdateDescriptorSets(m_queue->device()->vulkan_device(), 1u,
+                                   &writeDescriptorSet, 0, nullptr);
+        }
+    }
+
     // Bind descriptors and update push constants
     if (m_kernel->num_set_layouts() > 0) {
         vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
@@ -846,6 +926,15 @@ cvk_command_kernel::build_batchable_inner(cvk_command_buffer& command_buffer) {
         nullptr,  // pBufferMemoryBarriers
         0,        // imageMemoryBarrierCount
         nullptr); // pImageMemoryBarriers
+
+    return CL_SUCCESS;
+}
+
+cl_int cvk_command_kernel::do_post_action() {
+    if (m_kernel->uses_printf()) {
+        cvk_printf(m_queue->printf_buffer(),
+                   m_kernel->program()->printf_descriptors());
+    }
 
     return CL_SUCCESS;
 }
@@ -968,7 +1057,7 @@ cl_int cvk_command_batchable::do_action() {
         return CL_OUT_OF_RESOURCES;
     }
 
-    return CL_COMPLETE;
+    return do_post_action();
 }
 
 cl_int cvk_command_batch::do_action() {
@@ -980,7 +1069,6 @@ cl_int cvk_command_batch::do_action() {
     }
 
     m_queue->batch_completed();
-
     return CL_COMPLETE;
 }
 


### PR DESCRIPTION
Clspv provides a printf definition that stores the value of each argument in a program-wide printf storage buffer. This implementation uses the appropriate ClspvReflection instructions to parse this data and print the resulting strings at runtime.

This fixes all failing printf CTS tests, other than one which requires physical addressing (to print the value of a pointer).

Related Pull Requests:
https://github.com/KhronosGroup/SPIRV-Registry/pull/168
https://github.com/KhronosGroup/SPIRV-Headers/pull/290
https://github.com/google/clspv/pull/925

This contribution is being made by Codeplay on behalf of Samsung.