### PR TITLE
allow smaller batch and early flush

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1358,9 +1358,13 @@ cvk_create_command_queue(cl_context context, cl_device_id device,
         return nullptr;
     }
 
+    auto cvk_device = icd_downcast(device);
     auto queue = std::make_unique<cvk_command_queue>(
-        icd_downcast(context), icd_downcast(device), properties,
-        std::move(properties_array));
+        icd_downcast(context), cvk_device, properties,
+        std::move(properties_array), cvk_device->get_max_batch_size(),
+        cvk_device->get_max_first_batch_size(),
+        cvk_device->get_max_group_size(),
+        cvk_device->get_max_first_group_size());
 
     cl_int err = queue->init();
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1361,10 +1361,7 @@ cvk_create_command_queue(cl_context context, cl_device_id device,
     auto cvk_device = icd_downcast(device);
     auto queue = std::make_unique<cvk_command_queue>(
         icd_downcast(context), cvk_device, properties,
-        std::move(properties_array), cvk_device->get_max_batch_size(),
-        cvk_device->get_max_first_batch_size(),
-        cvk_device->get_max_group_size(),
-        cvk_device->get_max_first_group_size());
+        std::move(properties_array));
 
     cl_int err = queue->init();
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1358,9 +1358,8 @@ cvk_create_command_queue(cl_context context, cl_device_id device,
         return nullptr;
     }
 
-    auto cvk_device = icd_downcast(device);
     auto queue = std::make_unique<cvk_command_queue>(
-        icd_downcast(context), cvk_device, properties,
+        icd_downcast(context), icd_downcast(device), properties,
         std::move(properties_array));
 
     cl_int err = queue->init();

--- a/src/config.def
+++ b/src/config.def
@@ -14,6 +14,9 @@
 
 OPTION(std::string, cache_dir, "")
 OPTION(uint32_t, max_batch_size, 10000u)
+OPTION(uint32_t, max_first_batch_size, 10000u)
+OPTION(uint32_t, max_group_size, UINT32_MAX)
+OPTION(uint32_t, max_first_group_size, UINT32_MAX)
 OPTION(bool, skip_spirv_capability_check, false)
 OPTION(bool, validation_layers, false)
 OPTION(bool, queue_profiling_use_timestamp_queries, false)

--- a/src/config.def
+++ b/src/config.def
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 OPTION(std::string, cache_dir, "")
-OPTION(uint32_t, max_batch_size, 10000u)
-OPTION(uint32_t, max_first_batch_size, 10000u)
-OPTION(uint32_t, max_group_size, UINT32_MAX)
-OPTION(uint32_t, max_first_group_size, UINT32_MAX)
+OPTION(uint32_t, max_cmd_batch_size, 10000u)
+OPTION(uint32_t, max_first_cmd_batch_size, 10000u)
+OPTION(uint32_t, max_cmd_group_size, UINT32_MAX)
+OPTION(uint32_t, max_first_cmd_group_size, UINT32_MAX)
 OPTION(bool, skip_spirv_capability_check, false)
 OPTION(bool, validation_layers, false)
 OPTION(bool, queue_profiling_use_timestamp_queries, false)

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -95,10 +95,10 @@ void cvk_device::init_vulkan_properties(VkInstance instance) {
 }
 
 void cvk_device::init_clvk_runtime_behaviors() {
-    m_max_batch_size = config.max_batch_size;
-    m_max_first_batch_size = config.max_first_batch_size;
-    m_max_group_size = config.max_group_size;
-    m_max_first_group_size = config.max_first_group_size;
+    m_max_cmd_batch_size = config.max_cmd_batch_size;
+    m_max_first_cmd_batch_size = config.max_first_cmd_batch_size;
+    m_max_cmd_group_size = config.max_cmd_group_size;
+    m_max_first_cmd_group_size = config.max_first_cmd_group_size;
 
 #define DEFAULT_DEVICE_CONFIG(option, val)                                     \
     do {                                                                       \
@@ -108,14 +108,14 @@ void cvk_device::init_clvk_runtime_behaviors() {
     } while (0)
 
     if (strstr(m_properties.deviceName, "Intel")) {
-        DEFAULT_DEVICE_CONFIG(max_first_batch_size, 10);
-        DEFAULT_DEVICE_CONFIG(max_group_size, 1);
+        DEFAULT_DEVICE_CONFIG(max_first_cmd_batch_size, 10);
+        DEFAULT_DEVICE_CONFIG(max_cmd_group_size, 1);
     }
 #undef DEFAULT_DEVICE_CONFIG
-    cvk_info_fn("max_batch_size: %u", m_max_batch_size);
-    cvk_info_fn("max_first_batch_size: %u", m_max_first_batch_size);
-    cvk_info_fn("max_group_size: %u", m_max_group_size);
-    cvk_info_fn("max_first_group_size: %u", m_max_first_group_size);
+    cvk_info_fn("max_cmd_batch_size: %u", m_max_cmd_batch_size);
+    cvk_info_fn("max_first_cmd_batch_size: %u", m_max_first_cmd_batch_size);
+    cvk_info_fn("max_cmd_group_size: %u", m_max_cmd_group_size);
+    cvk_info_fn("max_first_cmd_group_size: %u", m_max_first_cmd_group_size);
 }
 
 void cvk_device::init_opencl_properties() {

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -94,6 +94,30 @@ void cvk_device::init_vulkan_properties(VkInstance instance) {
     func(m_pdev, &properties);
 }
 
+void cvk_device::init_clvk_runtime_behaviors() {
+    m_max_batch_size = config.max_batch_size;
+    m_max_first_batch_size = config.max_first_batch_size;
+    m_max_group_size = config.max_group_size;
+    m_max_first_group_size = config.max_first_group_size;
+
+#define DEFAULT_DEVICE_CONFIG(option, val)                                     \
+    do {                                                                       \
+        if (!config.option.set) {                                              \
+            m_##option = val;                                                  \
+        }                                                                      \
+    } while (0)
+
+    if (strstr(m_properties.deviceName, "Intel")) {
+        DEFAULT_DEVICE_CONFIG(max_first_batch_size, 10);
+        DEFAULT_DEVICE_CONFIG(max_group_size, 1);
+    }
+#undef DEFAULT_DEVICE_CONFIG
+    cvk_info_fn("max_batch_size: %u", m_max_batch_size);
+    cvk_info_fn("max_first_batch_size: %u", m_max_first_batch_size);
+    cvk_info_fn("max_group_size: %u", m_max_group_size);
+    cvk_info_fn("max_first_group_size: %u", m_max_first_group_size);
+}
+
 void cvk_device::init_opencl_properties() {
     // Set default values for all properties.
     m_global_mem_cache_size = 0;
@@ -781,6 +805,8 @@ bool cvk_device::init(VkInstance instance) {
     if (!init_extensions()) {
         return false;
     }
+
+    init_clvk_runtime_behaviors();
 
     init_vulkan_properties(instance);
 

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -465,10 +465,10 @@ struct cvk_device : public _cl_device_id,
         };
     }
 
-    cl_uint get_max_batch_size() const { return m_max_batch_size; }
-    cl_uint get_max_first_batch_size() const { return m_max_first_batch_size; }
-    cl_uint get_max_group_size() const { return m_max_group_size; }
-    cl_uint get_max_first_group_size() const { return m_max_first_group_size; }
+    cl_uint get_max_cmd_batch_size() const { return m_max_cmd_batch_size; }
+    cl_uint get_max_first_cmd_batch_size() const { return m_max_first_cmd_batch_size; }
+    cl_uint get_max_cmd_group_size() const { return m_max_cmd_group_size; }
+    cl_uint get_max_first_cmd_group_size() const { return m_max_first_cmd_group_size; }
 
 private:
     std::string version_desc() const {
@@ -558,10 +558,10 @@ private:
     bool m_has_int8_support{};
     bool m_has_subgroups_support{};
 
-    cl_uint m_max_batch_size;
-    cl_uint m_max_first_batch_size;
-    cl_uint m_max_group_size;
-    cl_uint m_max_first_group_size;
+    cl_uint m_max_cmd_batch_size;
+    cl_uint m_max_first_cmd_batch_size;
+    cl_uint m_max_cmd_group_size;
+    cl_uint m_max_first_cmd_group_size;
 
     spv_target_env m_vulkan_spirv_env;
 };

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -465,6 +465,11 @@ struct cvk_device : public _cl_device_id,
         };
     }
 
+    cl_uint get_max_batch_size() const { return m_max_batch_size; }
+    cl_uint get_max_first_batch_size() const { return m_max_first_batch_size; }
+    cl_uint get_max_group_size() const { return m_max_group_size; }
+    cl_uint get_max_first_group_size() const { return m_max_first_group_size; }
+
 private:
     std::string version_desc() const {
         std::string ret = "CLVK on Vulkan v";
@@ -475,6 +480,7 @@ private:
 
     CHECK_RETURN bool init_queues(uint32_t* num_queues, uint32_t* queue_family);
     CHECK_RETURN bool init_extensions();
+    void init_clvk_runtime_behaviors();
     void init_opencl_properties();
     void init_vulkan_properties(VkInstance instance);
     void init_driver_behaviors();
@@ -551,6 +557,11 @@ private:
     bool m_has_fp64_support{};
     bool m_has_int8_support{};
     bool m_has_subgroups_support{};
+
+    cl_uint m_max_batch_size;
+    cl_uint m_max_first_batch_size;
+    cl_uint m_max_group_size;
+    cl_uint m_max_first_group_size;
 
     spv_target_env m_vulkan_spirv_env;
 };

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -466,9 +466,13 @@ struct cvk_device : public _cl_device_id,
     }
 
     cl_uint get_max_cmd_batch_size() const { return m_max_cmd_batch_size; }
-    cl_uint get_max_first_cmd_batch_size() const { return m_max_first_cmd_batch_size; }
+    cl_uint get_max_first_cmd_batch_size() const {
+        return m_max_first_cmd_batch_size;
+    }
     cl_uint get_max_cmd_group_size() const { return m_max_cmd_group_size; }
-    cl_uint get_max_first_cmd_group_size() const { return m_max_first_cmd_group_size; }
+    cl_uint get_max_first_cmd_group_size() const {
+        return m_max_first_cmd_group_size;
+    }
 
 private:
     std::string version_desc() const {


### PR DESCRIPTION
add more config values to configure clvk:
- max_first_cmd_batch_size
- max_cmd_group_size
 - max_first_cmd_group_size

  Those configs have default value on a device level

  Keep track of the number of batch enqueued to be able to have a
  smaller one when no batch has been enqueued to allow the GPU to start
  computing earlier.
  Keep track of the number of groups sent to the executor to be able to
  have early flush of smaller group to allow an early execution of
  commands.