### PR TITLE
allow main thread to exec instead of executor when calling clFinish

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1162,8 +1162,8 @@ cl_event CLVK_API_CALL clCreateUserEvent(cl_context context,
         }
     }
 
-    auto event = new cvk_event(icd_downcast(context), CL_SUBMITTED,
-                               CL_COMMAND_USER, nullptr);
+    auto event = new cvk_event(icd_downcast(context), nullptr, nullptr);
+    event->set_status(CL_SUBMITTED);
 
     if (errcode_ret != nullptr) {
         *errcode_ret = CL_SUCCESS;

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1163,7 +1163,6 @@ cl_event CLVK_API_CALL clCreateUserEvent(cl_context context,
     }
 
     auto event = new cvk_event(icd_downcast(context), nullptr, nullptr);
-    event->set_status(CL_SUBMITTED);
 
     if (errcode_ret != nullptr) {
         *errcode_ret = CL_SUCCESS;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -974,6 +974,8 @@ cl_int cvk_device::get_device_host_timer(cl_ulong* device_timestamp,
         vkdev, num_requested_timestamps, timestamp_infos, timestamps,
         &max_deviation);
     if (res != VK_SUCCESS) {
+        cvk_error_fn("vkGetCalibratedTimestampsEXT failed %d %s", res,
+                     vulkan_error_string(res));
         return CL_OUT_OF_RESOURCES;
     }
 

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -33,7 +33,7 @@ void cvk_event::set_status(cl_int status) {
     cvk_debug("cvk_event::set_status: event = %p, status = %d", this, status);
     std::lock_guard<std::mutex> lock(m_lock);
 
-    CVK_ASSERT(status <= m_status);
+    CVK_ASSERT(status < m_status);
     m_status = status;
 
     if (m_queue && m_queue->has_property(CL_QUEUE_PROFILING_ENABLE) && m_cmd &&

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -13,3 +13,51 @@
 // limitations under the License.
 
 #include "event.hpp"
+#include "queue.hpp"
+
+static const cl_profiling_info status_to_profiling_info[4] = {
+    CL_PROFILING_COMMAND_END,
+    CL_PROFILING_COMMAND_START,
+    CL_PROFILING_COMMAND_SUBMIT,
+    CL_PROFILING_COMMAND_QUEUED,
+};
+
+cl_command_type cvk_event::command_type() const {
+    if (m_cmd)
+        return m_cmd->type();
+    else
+        return CL_COMMAND_USER;
+}
+
+void cvk_event::set_status_no_notify_no_lock(cl_int status) {
+    CVK_ASSERT(status <= m_status);
+    m_status = status;
+
+    if (m_queue && m_queue->has_property(CL_QUEUE_PROFILING_ENABLE) &&
+        status >= CL_COMPLETE && status <= CL_QUEUED) {
+        cl_profiling_info pinfo = status_to_profiling_info[status];
+        if (get_profiling_info(pinfo) ==
+            0) { // profiling could have already been set. In particular in the
+                 // case of the command_batch
+            m_status = m_cmd->set_profiling_info(pinfo, m_status);
+        }
+    }
+}
+
+void cvk_event::set_status(cl_int status) {
+    cvk_debug("cvk_event::set_status: event = %p, status = %d", this, status);
+    std::lock_guard<std::mutex> lock(m_lock);
+
+    set_status_no_notify_no_lock(status);
+
+    if (completed() || terminated()) {
+
+        for (auto& type_cb : m_callbacks) {
+            for (auto& cb : type_cb.second) {
+                execute_callback(cb);
+            }
+        }
+
+        m_cv.notify_all();
+    }
+}

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -36,16 +36,7 @@ struct cvk_event_callback {
 
 struct cvk_event : public _cl_event, api_object<object_magic::event> {
 
-    cvk_event(cvk_context* ctx, cvk_command* cmd, cvk_command_queue* queue)
-        : api_object(ctx), m_cmd(cmd), m_queue(queue) {
-        if (cmd == nullptr) {
-            m_status = CL_SUBMITTED;
-        } else {
-            m_status = CL_QUEUED;
-            set_profiling_info_from_monotonic_clock(
-                CL_PROFILING_COMMAND_QUEUED);
-        }
-    }
+    cvk_event(cvk_context* ctx, cvk_command* cmd, cvk_command_queue* queue);
 
     bool completed() { return m_status == CL_COMPLETE; }
 
@@ -68,7 +59,7 @@ struct cvk_event : public _cl_event, api_object<object_magic::event> {
     }
 
     cl_int get_status() const { return m_status; }
-    cl_command_type command_type() const;
+    cl_command_type command_type() const { return m_command_type; };
 
     bool is_user_event() const { return command_type() == CL_COMMAND_USER; }
 
@@ -123,6 +114,7 @@ private:
     std::condition_variable m_cv;
     cl_int m_status;
     cl_ulong m_profiling_data[4]{};
+    cl_command_type m_command_type;
     cvk_command* m_cmd;
     cvk_command_queue* m_queue;
     std::unordered_map<cl_int, std::vector<cvk_event_callback>> m_callbacks;

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -59,9 +59,9 @@ struct cvk_event : public _cl_event, api_object<object_magic::event> {
     }
 
     cl_int get_status() const { return m_status; }
-    cl_command_type command_type() const { return m_command_type; };
+    cl_command_type command_type() const { return m_command_type; }
 
-    bool is_user_event() const { return command_type() == CL_COMMAND_USER; }
+    bool is_user_event() const { return m_command_type == CL_COMMAND_USER; }
 
     cvk_command_queue* queue() const {
         CVK_ASSERT(!is_user_event());

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -161,8 +161,6 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
 
     cvk_debug_fn("enqueued command %p, event %p", cmd, cmd->event());
 
-    cmd->set_status(CL_QUEUED);
-
     if (event != nullptr) {
         // The event will be returned to the app, retain it for the user
         cmd->event()->retain();
@@ -331,7 +329,7 @@ cl_int cvk_command_queue::flush_no_lock() {
 
     // Set event state and profiling info
     for (auto cmd : group->commands) {
-        cmd->set_status(CL_SUBMITTED);
+        cmd->set_event_status(CL_SUBMITTED);
     }
 
     // Create execution thread if it doesn't exist

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -272,7 +272,6 @@ void cvk_executor_thread::executor() {
         if (m_shutdown) {
             continue;
         }
-        m_running = true;
 
         auto group = std::move(m_groups.front());
         m_groups.pop_front();

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -384,7 +384,9 @@ struct cvk_command {
         return {};
     }
 
-    virtual void set_event_status(cl_int status) { m_event->set_status(status); }
+    virtual void set_event_status(cl_int status) {
+        m_event->set_status(status);
+    }
 
     CHECK_RETURN virtual cl_int set_profiling_info(cl_profiling_info pinfo,
                                                    cl_int status) {

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -781,7 +781,8 @@ struct cvk_command_batch : public cvk_command {
 
     cl_uint batch_size() { return m_commands.size(); }
 
-    CHECK_RETURN cl_int set_profiling_info(cl_profiling_info pinfo) override final {
+    CHECK_RETURN cl_int
+    set_profiling_info(cl_profiling_info pinfo) override final {
         cl_int status = cvk_command::set_profiling_info(pinfo);
         if (m_queue->profiling_on_device()) {
             if (pinfo == CL_PROFILING_COMMAND_START) {

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -57,7 +57,9 @@ struct cvk_executor_thread {
     void wait_idle() {
         std::unique_lock<std::mutex> lock(m_lock);
         while (m_running) {
+            TRACE_BEGIN("wait_idle");
             m_running_cv.wait(lock);
+            TRACE_END();
         }
     }
 


### PR DESCRIPTION
Explicit inorder dependency between commands in order to allow main thread to steal commands from the executor when main thread reach a clFinish call, a clWaitForEvents call or a blocking enqueue command.

For clWaitForEvents, execute instead of executor only if all events are associated to one unique queue.

extract_cmds_dominated_by has a boolean to extract only non-batch commands. It will be very important when clvk will be able to use timeline semaphore.