### PR TITLE
Centralise management of configuration options and environment variables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 
 add_library(OpenCL-objects OBJECT
   api.cpp
+  config.cpp
   device.cpp
   event.cpp
   init.cpp

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,93 @@
+// Copyright 2022 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "config.hpp"
+
+#include <cassert>
+
+const config_struct config;
+
+namespace {
+
+template <typename T> constexpr config_option_type option_type() = delete;
+
+#define DEFINE_OPTION_TYPE_GETTER(ctype, type)                                 \
+    template <> constexpr config_option_type option_type<ctype>() {            \
+        return type;                                                           \
+    }
+
+DEFINE_OPTION_TYPE_GETTER(std::string, config_option_type::string)
+DEFINE_OPTION_TYPE_GETTER(uint32_t, config_option_type::uint32)
+DEFINE_OPTION_TYPE_GETTER(bool, config_option_type::boolean)
+
+config_option gConfigOptions[] = {
+#define OPTION(type, name, valdef) {option_type<type>(), #name, &config.name},
+#include "config.def"
+#undef OPTION
+};
+
+void parse_string(void* value_ptr, const char* txt) {
+    auto cfgval = static_cast<config_value<std::string>*>(value_ptr);
+    cfgval->value.assign(txt);
+    cfgval->set = true;
+}
+
+void parse_boolean(void* value_ptr, const char* txt) {
+    auto cfgval = static_cast<config_value<bool>*>(value_ptr);
+    cfgval->value = atoi(txt);
+    cfgval->set = true;
+}
+
+void parse_uint32(void* value_ptr, const char* txt) {
+    auto cfgval = static_cast<config_value<uint32_t>*>(value_ptr);
+    cfgval->value = atoi(txt);
+    cfgval->set = true;
+}
+
+void parse_env() {
+    for (auto& opt : gConfigOptions) {
+        std::string var_name = "CLVK_";
+        std::string optname_upper(opt.name);
+        std::transform(optname_upper.begin(), optname_upper.end(),
+                       optname_upper.begin(), ::toupper);
+        var_name += optname_upper;
+        // printf("var_name = '%s' ", var_name.c_str());
+        const char* txt = getenv(var_name.c_str());
+        if (txt == nullptr) {
+            //    printf("is not set\n");
+            continue;
+        }
+        // printf("is set\n");
+        void* optval = const_cast<void*>(opt.value);
+        switch (opt.type) {
+        case config_option_type::string:
+            parse_string(optval, txt);
+            break;
+        case config_option_type::boolean:
+            parse_boolean(optval, txt);
+            break;
+        case config_option_type::uint32:
+            parse_uint32(optval, txt);
+            break;
+        }
+    }
+}
+
+} // namespace
+
+void init_config() {
+    // TODO Parse config file
+    // Parse environment
+    parse_env();
+}

--- a/src/config.def
+++ b/src/config.def
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 OPTION(std::string, cache_dir, "")
-OPTION(uint32_t, max_batch_size, 10000)
+OPTION(uint32_t, max_batch_size, 10000u)
 OPTION(bool, skip_spirv_capability_check, false)
 OPTION(bool, validation_layers, false)
 OPTION(bool, queue_profiling_use_timestamp_queries, false)
@@ -21,7 +21,7 @@ OPTION(bool, keep_temporaries, false)
 OPTION(uint32_t, log, 0u)
 OPTION(bool, log_colour, false)
 OPTION(std::string, log_dest, "")
-OPTION(uint32_t, spirv_validation, 2)
+OPTION(uint32_t, spirv_validation, 2u)
 
 #if COMPILER_AVAILABLE
 OPTION(std::string, clspv_options, "")

--- a/src/config.def
+++ b/src/config.def
@@ -1,0 +1,33 @@
+// Copyright 2022 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+OPTION(std::string, cache_dir, "")
+OPTION(uint32_t, max_batch_size, 10000)
+OPTION(bool, skip_spirv_capability_check, false)
+OPTION(bool, validation_layers, false)
+OPTION(bool, queue_profiling_use_timestamp_queries, false)
+OPTION(bool, keep_temporaries, false)
+OPTION(uint32_t, log, 0u)
+OPTION(bool, log_colour, false)
+OPTION(std::string, log_dest, "")
+OPTION(uint32_t, spirv_validation, 2)
+
+#if COMPILER_AVAILABLE
+OPTION(std::string, clspv_options, "")
+#if !CLSPV_ONLINE_COMPILER
+OPTION(std::string, clspv_path, DEFAULT_CLSPV_BINARY_PATH)
+OPTION(std::string, llvmspirv_bin, DEFAULT_LLVMSPIRV_BINARY_PATH)
+#endif // !CLSPV_ONLINE_COMPILER
+#endif // COMPILER_AVAILABLE
+

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,0 +1,53 @@
+// Copyright 2022 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+enum class config_option_type
+{
+    string,
+    uint32,
+    boolean,
+};
+
+struct config_option {
+    config_option_type type;
+    std::string name;
+    const void* value;
+};
+
+template <typename T> struct config_value {
+    config_value(const char* val) : value(val) {}
+    config_value(uint32_t val) : value(val) {}
+    bool set;
+    T value;
+    operator T() const { return value; }
+    T& operator()() { return value; }
+    const T& operator()() const { return value; }
+};
+
+struct config_struct {
+#define OPTION(type, name, valdef) const config_value<type> name = valdef;
+#include "config.def"
+#undef OPTION
+};
+
+extern const config_struct config;
+
+extern void init_config();

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -33,8 +33,9 @@ struct config_option {
 };
 
 template <typename T> struct config_value {
-    config_value(const char* val) : value(val) {}
-    config_value(uint32_t val) : value(val) {}
+    explicit config_value(const char* val) : value(val) {}
+    explicit config_value(uint32_t val) : value(val) {}
+    explicit config_value(bool val) : value(val) {}
     bool set;
     T value;
     operator T() const { return value; }
@@ -43,7 +44,7 @@ template <typename T> struct config_value {
 };
 
 struct config_struct {
-#define OPTION(type, name, valdef) const config_value<type> name = valdef;
+#define OPTION(type, name, valdef) const config_value<type> name{valdef};
 #include "config.def"
 #undef OPTION
 };

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -14,6 +14,7 @@
 
 #include <fstream>
 
+#include "config.hpp"
 #include "device.hpp"
 #include "init.hpp"
 #include "log.hpp"
@@ -582,14 +583,13 @@ bool cvk_device::init_time_management(VkInstance instance) {
 // If pipeline cache serialization is not enabled, an empty string is returned.
 std::string
 cvk_device::get_pipeline_cache_filename(const cvk_sha1_hash& sha1) const {
-    const char* cache_dir = getenv("CLVK_CACHE_DIR");
-    if (cache_dir == nullptr) {
+    if (config.cache_dir().empty()) {
         return "";
     }
 
     // The pipeline cache file path is:
     // ${CLVK_CACHE_DIR}/clvk-pipeline-cache.<UUID>.<SHA1>.bin
-    std::string cache_path = cache_dir;
+    std::string cache_path = config.cache_dir;
     cache_path += "/";
     cache_path += "clvk-pipeline-cache.";
     cache_path += to_hex_string(m_properties.pipelineCacheUUID, VK_UUID_SIZE);

--- a/src/init.hpp
+++ b/src/init.hpp
@@ -19,14 +19,6 @@
 
 #include <vulkan/vulkan.h>
 
-#if COMPILER_AVAILABLE
-extern std::string gCLSPVPath;
-extern std::string gLLVMSPIRVPath;
-extern std::string gCLSPVOptions;
-#endif
-extern bool gQueueProfilingUsesTimestampQueries;
-extern bool gKeepTemporaries;
-
 struct cvk_platform;
 struct cvk_executor_thread_pool;
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "log.hpp"
+#include "config.hpp"
 
 #include <cerrno>
 #include <cstdarg>
@@ -33,23 +34,20 @@ static bool gLoggingColour;
 static FILE* gLoggingFile;
 
 void init_logging() {
-    char* logging = getenv("CLVK_LOG");
-    if (logging) {
-        loglevel setting = static_cast<loglevel>(atoi(logging));
-        if ((setting < loglevel::fatal) || (setting > loglevel::debug)) {
+    loglevel setting = static_cast<loglevel>(config.log());
+    if (config.log.set) {
+        if ((config.log < loglevel::fatal) || (config.log > loglevel::debug)) {
             // FIXME handle all errors
-            fprintf(stderr, "FATAL: Unknown log level '%s'.\n", logging);
+            fprintf(stderr, "FATAL: Unknown log level '%u'.\n", config.log());
             exit(EXIT_FAILURE);
         }
-        gLoggingLevel = setting;
-    } else {
-        gLoggingLevel = loglevel::fatal;
+        setting = static_cast<loglevel>(config.log());
     }
+    gLoggingLevel = setting;
 
-    char* logging_dest = getenv("CLVK_LOG_DEST");
-    if (logging_dest) {
+    if (config.log_dest.set) {
 
-        std::string val(logging_dest);
+        std::string val(config.log_dest);
 
         if (val == "stdout") {
             gLoggingFile = stdout;
@@ -82,15 +80,8 @@ void init_logging() {
         gLoggingColour = false;
     }
 
-    char* logging_colour = getenv("CLVK_LOG_COLOUR");
-    if (logging_colour) {
-        int val = atoi(logging_colour);
-        // FIXME handle errors
-        if (val == 0) {
-            gLoggingColour = false;
-        } else {
-            gLoggingColour = true;
-        }
+    if (config.log_colour.set) {
+        gLoggingColour = config.log_colour;
     }
 }
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -28,6 +28,7 @@
 #include "spirv-tools/libspirv.h"
 #include "spirv/1.0/spirv.hpp"
 
+#include "config.hpp"
 #include "init.hpp"
 #include "memory.hpp"
 #include "objects.hpp"
@@ -625,7 +626,7 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
     bool can_split_region() {
         int status = options_allow_split_region(m_build_options);
 #if COMPILER_AVAILABLE
-        status &= options_allow_split_region(gCLSPVOptions);
+        status &= options_allow_split_region(config.clspv_options);
 #endif
         return status;
     }

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -14,6 +14,7 @@
 
 #include <unordered_set>
 
+#include "config.hpp"
 #include "init.hpp"
 #include "memory.hpp"
 #include "queue.hpp"
@@ -36,12 +37,6 @@ cvk_command_queue::cvk_command_queue(
 
     if (properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE) {
         cvk_warn_fn("out-of-order execution enabled, will be ignored");
-    }
-
-    char* max_batch_size_env = getenv("CLVK_MAX_BATCH_SIZE");
-    m_max_batch_size = 10000;
-    if (max_batch_size_env) {
-        m_max_batch_size = atoi(max_batch_size_env);
     }
 }
 
@@ -123,7 +118,7 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
         }
 
         // End command batch when size limit reached
-        if (m_command_batch->batch_size() >= m_max_batch_size) {
+        if (m_command_batch->batch_size() >= config.max_batch_size) {
             if ((err = end_current_command_batch()) != CL_SUCCESS) {
                 return err;
             }

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -17,6 +17,7 @@
 #include <array>
 #include <memory>
 
+#include "config.hpp"
 #include "event.hpp"
 #include "init.hpp"
 #include "kernel.hpp"
@@ -148,7 +149,7 @@ struct cvk_command_queue : public _cl_command_queue,
     CHECK_RETURN cl_int finish();
     bool profiling_on_device() const {
         return m_device->has_timer_support() ||
-               gQueueProfilingUsesTimestampQueries;
+               config.queue_profiling_use_timestamp_queries;
     }
 
     CHECK_RETURN bool allocate_command_buffer(VkCommandBuffer* cmdbuf) {
@@ -187,7 +188,6 @@ private:
     std::mutex m_lock;
     std::deque<std::unique_ptr<cvk_command_group>> m_groups;
 
-    cl_uint m_max_batch_size;
     cvk_command_batch* m_command_batch;
 
     cvk_vulkan_queue_wrapper& m_vulkan_queue;
@@ -563,7 +563,7 @@ struct cvk_command_batchable : public cvk_command {
 
     bool is_profiled_by_executor() const override final {
         return !m_queue->device()->has_timer_support() &&
-               !gQueueProfilingUsesTimestampQueries;
+               !config.queue_profiling_use_timestamp_queries;
     }
 
     CHECK_RETURN cl_int get_timestamp_query_results(cl_ulong* start,


### PR DESCRIPTION
Keep it really simple, stupid for now. Going forward we should:
- Add support to load the configuration from a file (environment variables would still be usable and would take precedence).
- Generate documentation for all config options from the option definitions.
- Better validate inputs and support error handlers.
- Support enumerated types.
- And probably more ...

Signed-off-by: Kévin Petit <kpet@free.fr>