### PR TITLE
Add -hack-mul-extended option for intel devices

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -777,6 +777,9 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
     if (device->supports_ubo_stdlayout()) {
         options += " -std430-ubo-layout ";
     }
+    if (strstr(device->name(), "Intel") != nullptr) {
+        options += " -hack-mul-extended ";
+    }
 
     // Select target SPIR-V version
     options += " -spv-version=";


### PR DESCRIPTION
Intel devices fail with `OpUMulExtended` instruction. So, we should use `-hack-mul-extended` to avoid failures on Intel devices. This fixes `integer_ops/integer_mul_hi`, `integer_ops/integer_mad_hi` and `integer_ops/integer_mad_sat` CTS tests on Intel devices.  