### PR TITLE
Used vulkan memory model to query atomic capabilities

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -780,17 +780,28 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         break;
     case CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES:
         val_atomic_capabilities =
-            CL_DEVICE_ATOMIC_ORDER_RELAXED | CL_DEVICE_ATOMIC_ORDER_ACQ_REL |
-            CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM |
-            CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP | CL_DEVICE_ATOMIC_SCOPE_DEVICE;
+            CL_DEVICE_ATOMIC_ORDER_RELAXED | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP;
+        if (device->vulkan_memory_model_features().vulkanMemoryModel) {
+            val_atomic_capabilities |= CL_DEVICE_ATOMIC_ORDER_ACQ_REL;
+        }
+        if (device->vulkan_memory_model_features()
+                .vulkanMemoryModelDeviceScope) {
+            val_atomic_capabilities |= CL_DEVICE_ATOMIC_SCOPE_DEVICE;
+        }
         copy_ptr = &val_atomic_capabilities;
         size_ret = sizeof(val_atomic_capabilities);
         break;
     case CL_DEVICE_ATOMIC_FENCE_CAPABILITIES:
-        val_atomic_capabilities =
-            CL_DEVICE_ATOMIC_ORDER_RELAXED | CL_DEVICE_ATOMIC_ORDER_ACQ_REL |
-            CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM |
-            CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP | CL_DEVICE_ATOMIC_SCOPE_DEVICE;
+        val_atomic_capabilities = CL_DEVICE_ATOMIC_ORDER_RELAXED |
+                                  CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM |
+                                  CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP;
+        if (device->vulkan_memory_model_features().vulkanMemoryModel) {
+            val_atomic_capabilities |= CL_DEVICE_ATOMIC_ORDER_ACQ_REL;
+        }
+        if (device->vulkan_memory_model_features()
+                .vulkanMemoryModelDeviceScope) {
+            val_atomic_capabilities |= CL_DEVICE_ATOMIC_SCOPE_DEVICE;
+        }
         copy_ptr = &val_atomic_capabilities;
         size_ret = sizeof(val_atomic_capabilities);
         break;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -277,6 +277,7 @@ bool cvk_device::init_extensions() {
         VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
         VK_EXT_PCI_BUS_INFO_EXTENSION_NAME,
         VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME,
+        VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME,
     };
 
     if (m_properties.apiVersion < VK_MAKE_VERSION(1, 2, 0)) {
@@ -326,6 +327,8 @@ void cvk_device::init_features(VkInstance instance) {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES_KHR;
     m_features_shader_subgroup_extended_types.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES_KHR;
+    m_features_vulkan_memory_model.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES;
 
     std::vector<std::pair<const char*, VkBaseOutStructure*>>
         extension_features = {
@@ -342,6 +345,8 @@ void cvk_device::init_features(VkInstance instance) {
                     &m_features_16bit_storage),
             EXTFEAT(VK_KHR_SHADER_SUBGROUP_EXTENDED_TYPES_EXTENSION_NAME,
                     &m_features_shader_subgroup_extended_types),
+            EXTFEAT(VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME,
+                    &m_features_vulkan_memory_model),
 #undef EXTFEAT
         };
 

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -376,6 +376,10 @@ struct cvk_device : public _cl_device_id,
     device_16bit_storage_features() const {
         return m_features_16bit_storage;
     }
+    const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR&
+    vulkan_memory_model_features() const {
+        return m_features_vulkan_memory_model;
+    }
 
     uint32_t vulkan_max_push_constants_size() const {
         return m_properties.limits.maxPushConstantsSize;
@@ -519,6 +523,8 @@ private:
     VkPhysicalDevice16BitStorageFeaturesKHR m_features_16bit_storage{};
     VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
         m_features_shader_subgroup_extended_types{};
+    VkPhysicalDeviceVulkanMemoryModelFeaturesKHR
+        m_features_vulkan_memory_model{};
 
     VkDevice m_dev;
     std::vector<const char*> m_vulkan_device_extensions;


### PR DESCRIPTION
I've added a query to the Vulkan physical device to check if atomics are actually supported on the device. Atomic semantics like Acquire and Release are described as part of the Vulkan memory model so I believe that this is the best way to test that.

This contribution is being made by Codeplay on behalf of Samsung.