### PR TITLE
Add -rewrite-packed-structs option

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -403,6 +403,7 @@ void cvk_device::init_compiler_options() {
     }
     if (supports_int8()) {
         m_device_compiler_options += " -int8 ";
+        m_device_compiler_options += " -rewrite-packed-structs ";
     }
     if (supports_ubo_stdlayout()) {
         m_device_compiler_options += " -std430-ubo-layout ";


### PR DESCRIPTION
Fix spirv_new/cpacked-struct CTS test by passing -rewrite-packed-structs option

**This PR depends on [this clspv PR](https://github.com/google/clspv/pull/940)**

**This contribution is being made by Codeplay on behalf of Samsung.**