### PR TITLE
Fix cyclical refcount between command queues and executors

### DIFF
--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -259,7 +259,6 @@ cl_int cvk_command_queue::wait_for_events(cl_uint num_events,
 }
 
 void cvk_executor_thread::set_queue(cvk_command_queue* queue) {
-    m_queue.reset(queue);
     m_profiling = queue->has_property(CL_QUEUE_PROFILING_ENABLE);
 }
 
@@ -286,6 +285,9 @@ void cvk_executor_thread::executor() {
 
         lock.unlock();
 
+        CVK_ASSERT(group->commands.size() > 0);
+        cvk_command_queue_holder queue = group->commands.front()->queue();
+
         while (group->commands.size() > 0) {
 
             cvk_command* cmd = group->commands.front();
@@ -311,8 +313,7 @@ void cvk_executor_thread::executor() {
             delete cmd;
         }
 
-        CVK_ASSERT(m_queue);
-        m_queue->group_completed();
+        queue->group_completed();
 
         lock.lock();
     }

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -36,8 +36,7 @@ struct cvk_command_group {
 struct cvk_executor_thread {
 
     cvk_executor_thread()
-        : m_thread(nullptr), m_shutdown(false), m_profiling(false),
-          m_queue(nullptr) {
+        : m_thread(nullptr), m_shutdown(false), m_profiling(false) {
         m_thread =
             std::make_unique<std::thread>(&cvk_executor_thread::executor, this);
     }
@@ -74,7 +73,6 @@ private:
     bool m_shutdown;
     std::deque<std::unique_ptr<cvk_command_group>> m_groups;
     bool m_profiling;
-    cvk_command_queue_holder m_queue;
 };
 
 struct cvk_command_pool {


### PR DESCRIPTION
Since #421, command queue executors hold a refcount on the last command queue they were associated with. Since executors are pooled and not destroyed until the context is destroyed, they keep all command queues that ever were created alive, which in turn means that executors are never returned to the pool.

After this change executors only hold that refcount temporarily during the execution of individual command groups.

Fixes #433

Signed-off-by: Kévin Petit <kpet@free.fr>