### PR TITLE
Preserve arg set status when cloning a kernel

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -44,9 +44,6 @@ cl_int cvk_kernel::init() {
         m_image_metadata = md;
     }
 
-    // Mark all arguments as unset
-    m_args_set.resize(m_args.size(), false);
-
     // Init argument values
     m_argument_values = cvk_kernel_argument_values::create(m_entry_point);
     if (m_argument_values == nullptr) {
@@ -119,11 +116,6 @@ cl_int cvk_kernel::set_arg(cl_uint index, size_t size, const void* value) {
 
     cl_int ret = m_argument_values->set_arg(arg, size, value);
 
-    if (ret == CL_SUCCESS) {
-        // Mark argument as set
-        m_args_set[index] = true;
-    }
-
     // if the argument is an image, we need to set its metadata
     // (channel_order/channel_data_type).
     if (arg.kind == kernel_argument_kind::ro_image ||
@@ -133,6 +125,8 @@ cl_int cvk_kernel::set_arg(cl_uint index, size_t size, const void* value) {
 
     return ret;
 }
+
+bool cvk_kernel::args_valid() const { return m_argument_values->args_valid(); }
 
 bool cvk_kernel_argument_values::setup_descriptor_sets() {
     std::lock_guard<std::mutex> lock(m_lock);


### PR DESCRIPTION
This fixes test_api/clone_kernel from the CTS

This contribution is being made by Codeplay on behalf of Samsung.
