### PR TITLE
Add case for memory model SPIR-V capability

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -901,6 +901,8 @@ bool cvk_device::supports_capability(spv::Capability capability) const {
     case spv::CapabilityGroupNonUniformBallot:
         return m_subgroup_properties.supportedOperations &
                VK_SUBGROUP_FEATURE_BALLOT_BIT;
+    case spv::CapabilityVulkanMemoryModel:
+        return m_features_vulkan_memory_model.vulkanMemoryModel;
     // Capabilities that have not yet been mapped to Vulkan features:
     default:
         cvk_warn_fn("Capability %d not yet mapped to a feature.", capability);


### PR DESCRIPTION
Since we query the memory model device properties we should probably wire it up to the SPIR-V capabilities check as well.

This contribution is being made by Codeplay on behalf of Samsung.