### PR TITLE
Add support for using buffer device addresses

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -179,6 +179,14 @@ jobs:
         run: ${{ env.testbindir }}/api_tests${{ env.exe-ext }}
         env:
           CLVK_LOG: 2
+      # TODO #477 - enable these tests
+      # - name: API tests (physical addressing)
+      #   if: ${{ matrix.compiler-available && matrix.android-abi == '' }}
+      #   run: ${{ env.testbindir }}/api_tests${{ env.exe-ext }}
+      #   env:
+      #     CLVK_LOG: 2
+      #     CLVK_SPIRV_ARCH: spir64
+      #     CLVK_PHYSICAL_ADDRESSING: 1
       - name: Offline compilation simple tests
         if: ${{ matrix.android-abi == '' }}
         run: |

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -488,7 +488,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         size_ret = sizeof(val_fpconfig);
         break;
     case CL_DEVICE_ADDRESS_BITS:
-        val_uint = 32; // FIXME
+        val_uint = (config.spirv_arch() == "spir64") ? 64 : 32;
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;

--- a/src/config.def
+++ b/src/config.def
@@ -26,6 +26,8 @@ OPTION(uint32_t, log, 0u)
 OPTION(bool, log_colour, false)
 OPTION(std::string, log_dest, "")
 OPTION(uint32_t, spirv_validation, 2u)
+OPTION(std::string, spirv_arch, "spir")
+OPTION(bool, physical_addressing, false)
 
 #if COMPILER_AVAILABLE
 OPTION(std::string, clspv_options, "")

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -550,6 +550,8 @@ private:
         m_features_shader_subgroup_extended_types{};
     VkPhysicalDeviceVulkanMemoryModelFeaturesKHR
         m_features_vulkan_memory_model{};
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR
+        m_features_buffer_device_address{};
 
     VkDevice m_dev;
     std::vector<const char*> m_vulkan_device_extensions;

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -325,6 +325,8 @@ bool cvk_kernel_argument_values::setup_descriptor_sets() {
         case kernel_argument_kind::pod: // skip POD arguments
         case kernel_argument_kind::pod_ubo:
         case kernel_argument_kind::pod_pushconstant:
+        case kernel_argument_kind::pointer_ubo:
+        case kernel_argument_kind::pointer_pushconstant:
             break;
         case kernel_argument_kind::local: // nothing to do?
             break;

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -375,6 +375,16 @@ struct cvk_buffer : public cvk_mem {
         return mapping;
     }
 
+    uint64_t device_address() const {
+        VkBufferDeviceAddressInfo info{};
+        info.buffer = vulkan_buffer();
+        info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
+        info.pNext = NULL;
+        auto device_address = vkGetBufferDeviceAddress(
+            context()->device()->vulkan_device(), &info);
+        return device_address + vulkan_buffer_offset();
+    }
+
 private:
     bool init();
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -107,6 +107,10 @@ spv_result_t parse_reflection(void* user_data,
             return kernel_argument_kind::pod_ubo;
         case NonSemanticClspvReflectionArgumentPodPushConstant:
             return kernel_argument_kind::pod_pushconstant;
+        case NonSemanticClspvReflectionArgumentPointerUniform:
+            return kernel_argument_kind::pointer_ubo;
+        case NonSemanticClspvReflectionArgumentPointerPushConstant:
+            return kernel_argument_kind::pointer_pushconstant;
         case NonSemanticClspvReflectionArgumentSampledImage:
             return kernel_argument_kind::sampled_image;
         case NonSemanticClspvReflectionArgumentStorageImage:
@@ -239,7 +243,8 @@ spv_result_t parse_reflection(void* user_data,
                 break;
             }
             case NonSemanticClspvReflectionArgumentPodStorageBuffer:
-            case NonSemanticClspvReflectionArgumentPodUniform: {
+            case NonSemanticClspvReflectionArgumentPodUniform:
+            case NonSemanticClspvReflectionArgumentPointerUniform: {
                 // These arguments have descriptor set, binding, offset, size
                 // and an optional arg info.
                 auto kernel = parse_data->strings[inst->words[5]];
@@ -261,7 +266,8 @@ spv_result_t parse_reflection(void* user_data,
                 parse_data->binary->add_kernel_argument(kernel, std::move(arg));
                 break;
             }
-            case NonSemanticClspvReflectionArgumentPodPushConstant: {
+            case NonSemanticClspvReflectionArgumentPodPushConstant:
+            case NonSemanticClspvReflectionArgumentPointerPushConstant: {
                 // These arguments have offset, size and an optional arg info.
                 auto kernel = parse_data->strings[inst->words[5]];
                 auto ordinal = parse_data->constants[inst->words[6]];
@@ -1478,10 +1484,12 @@ bool cvk_entry_point::build_descriptor_sets_layout_bindings_for_arguments(
             continue;
         case kernel_argument_kind::pod:
         case kernel_argument_kind::pod_ubo:
+        case kernel_argument_kind::pointer_ubo:
             if (!pod_found) {
                 if (arg.kind == kernel_argument_kind::pod) {
                     dt = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                } else if (arg.kind == kernel_argument_kind::pod_ubo) {
+                } else if (arg.kind == kernel_argument_kind::pod_ubo ||
+                           arg.kind == kernel_argument_kind::pointer_ubo) {
                     dt = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
                 }
 
@@ -1493,6 +1501,7 @@ bool cvk_entry_point::build_descriptor_sets_layout_bindings_for_arguments(
             }
             break;
         case kernel_argument_kind::pod_pushconstant:
+        case kernel_argument_kind::pointer_pushconstant:
             continue;
         }
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -42,6 +42,8 @@ enum class kernel_argument_kind
     pod,
     pod_ubo,
     pod_pushconstant,
+    pointer_ubo,
+    pointer_pushconstant,
     sampled_image,
     storage_image,
     sampler,
@@ -75,12 +77,20 @@ struct kernel_argument {
     bool is_pod() const {
         return (kind == kernel_argument_kind::pod) ||
                (kind == kernel_argument_kind::pod_ubo) ||
-               (kind == kernel_argument_kind::pod_pushconstant);
+               (kind == kernel_argument_kind::pod_pushconstant) ||
+               (kind == kernel_argument_kind::pointer_ubo) ||
+               (kind == kernel_argument_kind::pointer_pushconstant);
     }
 
     bool is_pod_buffer() const {
         return (kind == kernel_argument_kind::pod) ||
-               (kind == kernel_argument_kind::pod_ubo);
+               (kind == kernel_argument_kind::pod_ubo) ||
+               (kind == kernel_argument_kind::pointer_ubo);
+    }
+
+    bool is_pod_pointer() const {
+        return (kind == kernel_argument_kind::pointer_pushconstant) ||
+               (kind == kernel_argument_kind::pointer_ubo);
     }
 
     bool is_vec3() const { return info.is_vec3(); }

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -503,7 +503,8 @@ void cvk_command_kernel::update_global_push_constants(
     if (m_kernel->has_pod_arguments() &&
         !m_kernel->has_pod_buffer_arguments()) {
         for (auto& arg : m_kernel->arguments()) {
-            if (arg.kind == kernel_argument_kind::pod_pushconstant) {
+            if (arg.kind == kernel_argument_kind::pod_pushconstant ||
+                arg.kind == kernel_argument_kind::pointer_pushconstant) {
                 CVK_ASSERT(arg.offset + arg.size <=
                            m_argument_values->pod_data().size());
 


### PR DESCRIPTION
This enables use of physical addressing for global memory.

Requires the relevant clspv change: https://github.com/google/clspv/pull/954

I wasn't sure whether we want this to be enabled by default at this stage, so for now it requires `CLVK_PHYSICAL_ADDRESSING=1` to enable

This contribution is being made by Codeplay on behalf of Samsung.
