### PR TITLE
Stop reporting support for cl_khr_subgroups extension.

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -739,10 +739,6 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         size_ret = sizeof(val_svmcaps);
         break;
     case CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS:
-        val_bool = CL_TRUE;
-        copy_ptr = &val_bool;
-        size_ret = sizeof(val_bool);
-        break;
     case CL_DEVICE_PIPE_SUPPORT:
     case CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT:
     case CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT:

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -453,8 +453,6 @@ void cvk_device::build_extension_ils_list() {
              required_subgroup_ops) == required_subgroup_ops &&
             (m_features_shader_subgroup_extended_types
                  .shaderSubgroupExtendedTypes == VK_TRUE)) {
-            m_extensions.push_back(
-                MAKE_NAME_VERSION(1, 0, 0, "cl_khr_subgroups"));
             m_has_subgroups_support = true;
         }
     }


### PR DESCRIPTION
Removing this extension allows us to stop reporting CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS as true while still reporting support for core subgroup functionality. This is more in line with Vulkan subgroups, specifically Vulkan's lack of any such forward progress guarantees. See #451 for more detail.

This contribution is being made by Codeplay on behalf of Samsung.