### PR TITLE
Rename image kernel arg kind enums.

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -126,8 +126,8 @@ cl_int cvk_kernel::set_arg(cl_uint index, size_t size, const void* value) {
 
     // if the argument is an image, we need to set its metadata
     // (channel_order/channel_data_type).
-    if (arg.kind == kernel_argument_kind::ro_image ||
-        arg.kind == kernel_argument_kind::wo_image) {
+    if (arg.kind == kernel_argument_kind::sampled_image ||
+        arg.kind == kernel_argument_kind::storage_image) {
         set_image_metadata(index, value);
     }
 
@@ -294,10 +294,10 @@ bool cvk_kernel_argument_values::setup_descriptor_sets() {
             descriptor_writes.push_back(writeDescriptorSet);
             break;
         }
-        case kernel_argument_kind::ro_image:
-        case kernel_argument_kind::wo_image: {
+        case kernel_argument_kind::sampled_image:
+        case kernel_argument_kind::storage_image: {
             auto image = static_cast<cvk_image*>(get_arg_value(arg));
-            bool sampled = arg.kind == kernel_argument_kind::ro_image;
+            bool sampled = arg.kind == kernel_argument_kind::sampled_image;
             auto view = sampled ? image->vulkan_sampled_view()
                                 : image->vulkan_storage_view();
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -108,9 +108,9 @@ spv_result_t parse_reflection(void* user_data,
         case NonSemanticClspvReflectionArgumentPodPushConstant:
             return kernel_argument_kind::pod_pushconstant;
         case NonSemanticClspvReflectionArgumentSampledImage:
-            return kernel_argument_kind::ro_image;
+            return kernel_argument_kind::sampled_image;
         case NonSemanticClspvReflectionArgumentStorageImage:
-            return kernel_argument_kind::wo_image;
+            return kernel_argument_kind::storage_image;
         case NonSemanticClspvReflectionArgumentSampler:
             return kernel_argument_kind::sampler;
         case NonSemanticClspvReflectionArgumentWorkgroup:
@@ -1375,10 +1375,10 @@ bool cvk_entry_point::build_descriptor_sets_layout_bindings_for_arguments(
         case kernel_argument_kind::buffer_ubo:
             dt = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
             break;
-        case kernel_argument_kind::ro_image:
+        case kernel_argument_kind::sampled_image:
             dt = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
             break;
-        case kernel_argument_kind::wo_image:
+        case kernel_argument_kind::storage_image:
             dt = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             break;
         case kernel_argument_kind::sampler:

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -42,8 +42,8 @@ enum class kernel_argument_kind
     pod,
     pod_ubo,
     pod_pushconstant,
-    ro_image,
-    wo_image,
+    sampled_image,
+    storage_image,
     sampler,
     local,
 };
@@ -88,8 +88,8 @@ struct kernel_argument {
     bool is_mem_object_backed() const {
         return (kind == kernel_argument_kind::buffer) ||
                (kind == kernel_argument_kind::buffer_ubo) ||
-               (kind == kernel_argument_kind::ro_image) ||
-               (kind == kernel_argument_kind::wo_image);
+               (kind == kernel_argument_kind::sampled_image) ||
+               (kind == kernel_argument_kind::storage_image);
     }
 };
 


### PR DESCRIPTION
I think this makes it clearer that the enum is used for both read_write
and write_only (and that both are represented with a vulkan read/write
capable type) while adhering to the existing convention.

This contribution is being made by Codeplay on behalf of Samsung.