### PR TITLE
Populate list of enabled feature macros from the devices list.

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -513,9 +513,15 @@ void cvk_device::build_extension_ils_list() {
     // Build list of supported OpenCL C features
     m_opencl_c_features = {
         MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_images"),
+        MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_read_write_images"),
         MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_atomic_order_acq_rel"),
         MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_atomic_scope_device"),
+        MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_3d_image_writes"),
     };
+    if (supports_subgroups()) {
+        m_opencl_c_features.push_back(
+            MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_subgroups"));
+    }
     if (m_features.features.shaderInt64) {
         m_opencl_c_features.push_back(
             MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_int64"));

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -788,9 +788,17 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
     }
 
     // Features
-    options += " -enable-feature-macros=";
-    options += "__opencl_c_read_write_images";
-    options += " ";
+    if (options.find("-cl-std=CL3.0") != std::string::npos) {
+        auto features = device->opencl_c_features();
+        if (!features.empty()) {
+            options += "-enable-feature-macros=";
+            for (auto& feature : features) {
+                options += feature.name;
+                options += ',';
+            }
+            options.back() = ' '; // replace the final comma
+        }
+    }
 
     // Select target SPIR-V version
     options += " -spv-version=";


### PR DESCRIPTION
This contribution is being made by Codeplay on behalf of Samsung.

Use the device list of OpenCL C optional features to populate the "enable-feature-macros" clspv option.