### PR TITLE
Support multiple image mappings with the same pointer for images with CL_MEM_USE_HOST_PTR

### DIFF
--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -291,7 +291,8 @@ void cvk_executor_thread::executor() {
         while (group->commands.size() > 0) {
 
             cvk_command* cmd = group->commands.front();
-            cvk_debug_fn("executing command %p, event %p", cmd, cmd->event());
+            cvk_debug_fn("executing command %p (%s), event %p", cmd,
+                         cl_command_type_to_string(cmd->type()), cmd->event());
 
             if (m_profiling && cmd->is_profiled_by_executor()) {
                 cmd->event()->set_profiling_info_from_monotonic_clock(


### PR DESCRIPTION
The spec does not really specify what the behaviour should be here (see https://github.com/KhronosGroup/OpenCL-Docs/issues/165).

Assume that mappings are always removed in the order they were created.

Also log the command type for commands about to be executed.

Fixes #404.