### PR TITLE
align atomic feature macros to api query

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -788,11 +788,10 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
     case CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES:
         val_atomic_capabilities =
             CL_DEVICE_ATOMIC_ORDER_RELAXED | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP;
-        if (device->vulkan_memory_model_features().vulkanMemoryModel) {
+        if (device->supports_atomic_order_acq_rel()) {
             val_atomic_capabilities |= CL_DEVICE_ATOMIC_ORDER_ACQ_REL;
         }
-        if (device->vulkan_memory_model_features()
-                .vulkanMemoryModelDeviceScope) {
+        if (device->supports_atomic_scope_device()) {
             val_atomic_capabilities |= CL_DEVICE_ATOMIC_SCOPE_DEVICE;
         }
         copy_ptr = &val_atomic_capabilities;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -455,11 +455,11 @@ void cvk_device::build_extension_ils_list() {
         MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_read_write_images"),
         MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_3d_image_writes"),
     };
-    if (m_features_vulkan_memory_model.vulkanMemoryModel) {
+    if (supports_atomic_order_acq_rel()) {
         m_opencl_c_features.push_back(
             MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_atomic_order_acq_rel"));
     }
-    if (m_features_vulkan_memory_model.vulkanMemoryModelDeviceScope) {
+    if (supports_atomic_scope_device()) {
         m_opencl_c_features.push_back(
             MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_atomic_scope_device"));
     }

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -453,10 +453,16 @@ void cvk_device::build_extension_ils_list() {
     m_opencl_c_features = {
         MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_images"),
         MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_read_write_images"),
-        MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_atomic_order_acq_rel"),
-        MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_atomic_scope_device"),
         MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_3d_image_writes"),
     };
+    if (m_features_vulkan_memory_model.vulkanMemoryModel) {
+        m_opencl_c_features.push_back(
+            MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_atomic_order_acq_rel"));
+    }
+    if (m_features_vulkan_memory_model.vulkanMemoryModelDeviceScope) {
+        m_opencl_c_features.push_back(
+            MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_atomic_scope_device"));
+    }
     if (supports_subgroups()) {
         m_opencl_c_features.push_back(
             MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_subgroups"));

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -270,6 +270,14 @@ struct cvk_device : public _cl_device_id,
 
     bool supports_subgroups() const { return m_has_subgroups_support; }
 
+    bool supports_atomic_order_acq_rel() const {
+        return m_features_vulkan_memory_model.vulkanMemoryModel;
+    }
+
+    bool supports_atomic_scope_device() const {
+        return m_features_vulkan_memory_model.vulkanMemoryModelDeviceScope;
+    }
+
     bool compiler_available() const {
 #ifdef COMPILER_AVAILABLE
         return true;


### PR DESCRIPTION
This contribution is being made by Codeplay on behalf of Samsung.

Sorry I missed this when doing the previous PR. This change should make the feature macro list line up with more with the API query as seen here
https://github.com/kpet/clvk/blob/782818384cec4d09cc6b3a75396959475572e1af/src/api.cpp#L791-L797