### PR TITLE
allow main thread to exec instead of executor

### DIFF
--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -220,6 +220,8 @@ cl_int cvk_command_queue::enqueue_command_with_deps(
 
 cl_int cvk_command_queue::end_current_command_batch() {
     if (m_command_batch) {
+        TRACE_FUNCTION("queue", (uintptr_t)this);
+
         if (!m_command_batch->end()) {
             return CL_OUT_OF_RESOURCES;
         }
@@ -253,6 +255,14 @@ cl_int cvk_command_queue::wait_for_events(cl_uint num_events,
         }
     }
 
+    if (queues_to_flush.size() == 1) {
+        for (auto q : queues_to_flush) {
+            auto status = q->execute_cmds_dominated_by(num_events, event_list);
+            if (status != CL_SUCCESS)
+                return status;
+        }
+    }
+
     // Now wait for all the events
     for (cl_uint i = 0; i < num_events; i++) {
         cvk_event* event = icd_downcast(event_list[i]);
@@ -264,15 +274,102 @@ cl_int cvk_command_queue::wait_for_events(cl_uint num_events,
     return ret;
 }
 
+static cl_int execute_cmds(std::deque<cvk_command*>& cmds) {
+    TRACE_FUNCTION();
+    cl_int global_status = CL_SUCCESS;
+    while (!cmds.empty()) {
+        cvk_command* cmd = cmds.front();
+        cvk_debug_fn("executing command %p, event %p", cmd, cmd->event());
+
+        cl_int status = cmd->execute();
+        if (status != CL_COMPLETE && global_status == CL_SUCCESS)
+            global_status = status;
+        cvk_debug_fn("command returned %d", status);
+
+        cmds.pop_front();
+
+        delete cmd;
+    }
+    return global_status;
+}
+
+cl_int cvk_command_queue::execute_cmds_dominated_by_no_lock(
+    cl_uint num_events, _cl_event* const* event_list) {
+    auto* exec = m_executor;
+    if (exec == nullptr) {
+        return CL_SUCCESS;
+    }
+
+    m_lock.unlock();
+    auto cmds = exec->extract_cmds_dominated_by(false, num_events, event_list);
+    auto ret = execute_cmds(cmds);
+    m_lock.lock();
+
+    return ret;
+}
+
+cl_int
+cvk_command_queue::execute_cmds_dominated_by(cl_uint num_events,
+                                             _cl_event* const* event_list) {
+    std::unique_lock<std::mutex> lock(m_lock);
+    return execute_cmds_dominated_by_no_lock(num_events, event_list);
+}
+
+std::deque<cvk_command*>
+cvk_executor_thread::extract_cmds_dominated_by(bool only_non_batch_cmds,
+                                               cl_uint num_events,
+                                               _cl_event* const* event_list) {
+    std::lock_guard<std::mutex> lock(m_lock);
+    std::deque<cvk_command*> output_cmds;
+    if (m_groups.empty()) {
+        return output_cmds;
+    }
+
+    cvk_command_queue_holder queue = m_groups.back()->commands.front()->queue();
+    TRACE_FUNCTION("queue", (uintptr_t) & (*queue));
+
+    std::unique_ptr<cvk_command_group> executor_cmds =
+        std::make_unique<cvk_command_group>();
+    bool dominated = false;
+    while (!m_groups.empty()) {
+        auto group = std::move(m_groups.back());
+        m_groups.pop_back();
+        queue->group_completed();
+        while (!group->commands.empty()) {
+            auto cmd = group->commands.back();
+            group->commands.pop_back();
+            if (!dominated) {
+                for (unsigned each_event = 0; each_event < num_events;
+                     each_event++) {
+                    if (cmd->event() == icd_downcast(event_list[each_event])) {
+                        dominated = true;
+                        break;
+                    }
+                }
+            }
+            if (!dominated ||
+                (cmd->type() == CLVK_COMMAND_BATCH && only_non_batch_cmds)) {
+                executor_cmds->commands.push_front(cmd);
+            } else {
+                output_cmds.push_front(cmd);
+            }
+        }
+    }
+    if (executor_cmds->commands.size() > 0) {
+        m_groups.push_back(std::move(executor_cmds));
+        queue->group_sent();
+    }
+    return output_cmds;
+}
+
 void cvk_executor_thread::executor() {
 
     std::unique_lock<std::mutex> lock(m_lock);
 
     while (!m_shutdown) {
 
-        if (m_groups.size() == 0) {
+        while (m_groups.size() == 0 && !m_shutdown) {
             m_running = false;
-            m_running_cv.notify_all();
             TRACE_BEGIN("executor_wait");
             m_cv.wait(lock);
             TRACE_END();
@@ -292,19 +389,7 @@ void cvk_executor_thread::executor() {
         CVK_ASSERT(group->commands.size() > 0);
         cvk_command_queue_holder queue = group->commands.front()->queue();
 
-        while (group->commands.size() > 0) {
-
-            cvk_command* cmd = group->commands.front();
-            cvk_debug_fn("executing command %p (%s), event %p", cmd,
-                         cl_command_type_to_string(cmd->type()), cmd->event());
-
-            cl_int status = cmd->execute();
-            cvk_debug_fn("command returned %d", status);
-
-            group->commands.pop_front();
-
-            delete cmd;
-        }
+        execute_cmds(group->commands);
 
         queue->group_completed();
 
@@ -349,6 +434,10 @@ cl_int cvk_command_queue::flush_no_lock() {
         m_executor = get_thread_pool()->get_executor();
     }
 
+    auto ev = group->commands.back()->event();
+    m_finish_event.reset(ev);
+    cvk_debug_fn("stored event %p", ev);
+
     // Submit command group to executor
     m_executor->send_group(std::move(group));
     group_sent();
@@ -369,8 +458,10 @@ cl_int cvk_command_queue::finish() {
         return status;
     }
 
-    if (m_executor != nullptr) {
-        m_executor->wait_idle();
+    if (m_finish_event != nullptr) {
+        _cl_event* evt_list = (_cl_event*)&*m_finish_event;
+        execute_cmds_dominated_by_no_lock(1, &evt_list);
+        m_finish_event->wait();
     }
 
     return CL_SUCCESS;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -310,7 +310,7 @@ cl_int cvk_command_queue::execute_cmds_required_by_no_lock(
 
 cl_int
 cvk_command_queue::execute_cmds_required_by(cl_uint num_events,
-                                             _cl_event* const* event_list) {
+                                            _cl_event* const* event_list) {
     std::unique_lock<std::mutex> lock(m_lock);
     return execute_cmds_required_by_no_lock(num_events, event_list);
 }

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -31,6 +31,7 @@ using cvk_command_queue_holder = refcounted_holder<cvk_command_queue>;
 
 struct cvk_command_group {
     std::deque<cvk_command*> commands;
+    cl_int execute_cmds();
 };
 
 struct cvk_executor_thread {
@@ -68,9 +69,9 @@ struct cvk_executor_thread {
         }
     }
 
-    std::deque<cvk_command*>
-    extract_cmds_dominated_by(bool only_non_batch_cmds, cl_uint num_events,
-                              _cl_event* const* event_list);
+    cvk_command_group extract_cmds_required_by(bool only_non_batch_cmds,
+                                               cl_uint num_events,
+                                               _cl_event* const* event_list);
 
 private:
     void executor();
@@ -200,9 +201,9 @@ struct cvk_command_queue : public _cl_command_queue,
         TRACE_CNT(group_in_flight_counter, group - 1);
     }
 
-    cl_int execute_cmds_dominated_by(cl_uint num_events,
+    cl_int execute_cmds_required_by(cl_uint num_events,
                                      _cl_event* const* event_list);
-    cl_int execute_cmds_dominated_by_no_lock(cl_uint num_events,
+    cl_int execute_cmds_required_by_no_lock(cl_uint num_events,
                                              _cl_event* const* event_list);
 
 private:

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -208,6 +208,7 @@ struct cvk_command_queue : public _cl_command_queue,
 
 private:
     CHECK_RETURN cl_int satisfy_data_dependencies(cvk_command* cmd);
+    void enqueue_command(cvk_command *cmd);
     CHECK_RETURN cl_int enqueue_command(cvk_command* cmd, _cl_event** event);
     CHECK_RETURN cl_int end_current_command_batch();
     void executor();

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -54,15 +54,6 @@ struct cvk_executor_thread {
         return !m_running;
     }
 
-    void wait_idle() {
-        std::unique_lock<std::mutex> lock(m_lock);
-        while (m_running) {
-            TRACE_BEGIN("wait_idle");
-            m_running_cv.wait(lock);
-            TRACE_END();
-        }
-    }
-
     void shutdown() {
 
         // Tell the executor to shutdown
@@ -77,6 +68,10 @@ struct cvk_executor_thread {
         }
     }
 
+    std::deque<cvk_command*>
+    extract_cmds_dominated_by(bool only_non_batch_cmds, cl_uint num_events,
+                              _cl_event* const* event_list);
+
 private:
     void executor();
 
@@ -87,7 +82,6 @@ private:
     std::deque<std::unique_ptr<cvk_command_group>> m_groups;
 
     bool m_running;
-    std::condition_variable m_running_cv;
 };
 
 struct cvk_command_pool {
@@ -206,6 +200,11 @@ struct cvk_command_queue : public _cl_command_queue,
         TRACE_CNT(group_in_flight_counter, group - 1);
     }
 
+    cl_int execute_cmds_dominated_by(cl_uint num_events,
+                                     _cl_event* const* event_list);
+    cl_int execute_cmds_dominated_by_no_lock(cl_uint num_events,
+                                             _cl_event* const* event_list);
+
 private:
     CHECK_RETURN cl_int satisfy_data_dependencies(cvk_command* cmd);
     CHECK_RETURN cl_int enqueue_command(cvk_command* cmd, _cl_event** event);
@@ -217,6 +216,7 @@ private:
     std::vector<cl_queue_properties> m_properties_array;
 
     cvk_executor_thread* m_executor;
+    cvk_event_holder m_finish_event;
 
     std::mutex m_lock;
     std::deque<std::unique_ptr<cvk_command_group>> m_groups;

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -202,9 +202,9 @@ struct cvk_command_queue : public _cl_command_queue,
     }
 
     cl_int execute_cmds_required_by(cl_uint num_events,
-                                     _cl_event* const* event_list);
+                                    _cl_event* const* event_list);
     cl_int execute_cmds_required_by_no_lock(cl_uint num_events,
-                                             _cl_event* const* event_list);
+                                            _cl_event* const* event_list);
 
 private:
     CHECK_RETURN cl_int satisfy_data_dependencies(cvk_command* cmd);

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -208,7 +208,7 @@ struct cvk_command_queue : public _cl_command_queue,
 
 private:
     CHECK_RETURN cl_int satisfy_data_dependencies(cvk_command* cmd);
-    void enqueue_command(cvk_command *cmd);
+    void enqueue_command(cvk_command* cmd);
     CHECK_RETURN cl_int enqueue_command(cvk_command* cmd, _cl_event** event);
     CHECK_RETURN cl_int end_current_command_batch();
     void executor();

--- a/tests/api/dependencies.cpp
+++ b/tests/api/dependencies.cpp
@@ -60,12 +60,14 @@ TEST_F(WithCommandQueue, InOrderQueueStopsExecutionAfterFailedCommand) {
     cl_int err;
     std::vector<cl_event> dependencies = {uevent};
     clEnqueueMapBuffer(m_queue, buffer, CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION,
-                       0, BUFFER_SIZE, dependencies.size(), dependencies.data(), nullptr, &err);
+                       0, BUFFER_SIZE, dependencies.size(), dependencies.data(),
+                       nullptr, &err);
 
     // Check the enqueue fails
     ASSERT_EQ(err, CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST);
 
-    // Enqueue another command with no dependencies to the same queue. The queue is in-order
+    // Enqueue another command with no dependencies to the same queue. The queue
+    // is in-order
     cl_event mapev;
     clEnqueueMapBuffer(m_queue, buffer, CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION,
                        0, BUFFER_SIZE, 0, nullptr, &mapev, &err);

--- a/tests/api/dependencies.cpp
+++ b/tests/api/dependencies.cpp
@@ -47,3 +47,29 @@ TEST_F(WithCommandQueue, FailedAndCompleteDependencies) {
 
     ASSERT_EQ(err, CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST);
 }
+
+TEST_F(WithCommandQueue, InOrderQueueStopsExecutionAfterFailedCommand) {
+    auto buffer = CreateBuffer(CL_MEM_WRITE_ONLY | CL_MEM_ALLOC_HOST_PTR,
+                               BUFFER_SIZE, nullptr);
+
+    // Create a user event in a terminated status
+    auto uevent = CreateUserEvent();
+    SetUserEventStatus(uevent, CL_INVALID_OPERATION);
+
+    // Enqueue a command that depends on it
+    cl_int err;
+    std::vector<cl_event> dependencies = {uevent};
+    clEnqueueMapBuffer(m_queue, buffer, CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION,
+                       0, BUFFER_SIZE, dependencies.size(), dependencies.data(), nullptr, &err);
+
+    // Check the enqueue fails
+    ASSERT_EQ(err, CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST);
+
+    // Enqueue another command with no dependencies to the same queue. The queue is in-order
+    cl_event mapev;
+    clEnqueueMapBuffer(m_queue, buffer, CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION,
+                       0, BUFFER_SIZE, 0, nullptr, &mapev, &err);
+    cl_int status;
+    GetEventInfo(mapev, CL_EVENT_COMMAND_EXECUTION_STATUS, &status);
+    ASSERT_NE(status, CL_COMPLETE);
+}


### PR DESCRIPTION
Allow main thread to steal commands from the executor when main thread reaches a clFinish call, a clWaitForEvents call or a blocking enqueue command.

For clWaitForEvents, execute instead of executor only if all events are associated to one unique queue.

extract_cmds_dominated_by has a boolean to extract only non-batch commands. It will be very important when clvk will be able to use timeline semaphore.