### PR TITLE
fix error with -Wnon-virtual-dtor

### DIFF
--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -38,6 +38,8 @@ struct cvk_device_properties {
     }
 
     virtual std::string get_compile_options() const { return ""; }
+
+    virtual ~cvk_device_properties() {}
 };
 
 cvk_device_properties create_cvk_device_properties(const char* name);


### PR DESCRIPTION
clvk/src/device_properties.hpp:42:5: error: 'cvk_device_properties' has virtual functions but non-virtual destructor