### PR TITLE
fix device_properties + add amd

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -96,7 +96,7 @@ void cvk_device::init_clvk_runtime_behaviors() {
         if (config.option.set) {                                               \
             m_##option = config.option;                                        \
         } else {                                                               \
-            m_##option = m_clvk_properties.get_##option();                     \
+            m_##option = m_clvk_properties->get_##option();                    \
         }                                                                      \
         cvk_info_fn(#option ": %u", m_##option);                               \
     } while (0)

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -225,11 +225,11 @@ struct cvk_device : public _cl_device_id,
     }
 
     cl_ulong global_mem_cache_size() const {
-        return m_clvk_properties.get_global_mem_cache_size();
+        return m_clvk_properties->get_global_mem_cache_size();
     }
 
     cl_uint num_compute_units() const {
-        return m_clvk_properties.get_num_compute_units();
+        return m_clvk_properties->get_num_compute_units();
     }
 
     cl_uint max_samplers() const {
@@ -487,7 +487,7 @@ struct cvk_device : public _cl_device_id,
     }
 
     std::string get_device_specific_compile_options() const {
-        return m_clvk_properties.get_compile_options();
+        return m_clvk_properties->get_compile_options();
     }
 
 private:
@@ -584,7 +584,7 @@ private:
 
     spv_target_env m_vulkan_spirv_env;
 
-    cvk_device_properties m_clvk_properties;
+    std::unique_ptr<cvk_device_properties> m_clvk_properties;
 };
 
 static inline cvk_device* icd_downcast(cl_device_id device) {

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -40,4 +40,5 @@ struct cvk_device_properties {
     virtual std::string get_compile_options() const { return ""; }
 };
 
-cvk_device_properties create_cvk_device_properties(const char* name);
+std::unique_ptr<cvk_device_properties>
+create_cvk_device_properties(const char* name);


### PR DESCRIPTION
strcmp if statement was incorrectly moved by previous commit use explicit comparison for strcmp
use strncmp instead of strstr for Intel

overriden functions were not used because of copy of struct. Use a unique_ptr instead.