### PR TITLE
Take advantage of clspv's --use-native-builtins flag

### DIFF
--- a/src/device.hpp
+++ b/src/device.hpp
@@ -73,6 +73,7 @@ struct cvk_device : public _cl_device_id,
 
         m_clvk_properties =
             create_cvk_device_properties(m_properties.deviceName);
+        m_device_name = m_properties.deviceName;
     }
 
     static cvk_device* create(cvk_platform* platform, VkInstance instance,
@@ -102,7 +103,7 @@ struct cvk_device : public _cl_device_id,
         return m_properties.limits;
     }
     cvk_platform* platform() const { return m_platform; }
-    const char* name() const { return m_properties.deviceName; }
+    const std::string& name() const { return m_device_name; }
     uint32_t vendor_id() const { return m_properties.vendorID; }
 
     CHECK_RETURN uint32_t memory_type_index_for_resource(
@@ -543,6 +544,7 @@ private:
     std::vector<cvk_vulkan_queue_wrapper> m_vulkan_queues;
     uint32_t m_vulkan_queue_alloc_index;
 
+    std::string m_device_name;
     std::string m_extension_string;
     std::vector<cl_name_version> m_extensions;
     std::string m_ils_string;

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -73,7 +73,6 @@ struct cvk_device : public _cl_device_id,
 
         m_clvk_properties =
             create_cvk_device_properties(m_properties.deviceName);
-        m_device_name = m_properties.deviceName;
     }
 
     static cvk_device* create(cvk_platform* platform, VkInstance instance,
@@ -103,7 +102,7 @@ struct cvk_device : public _cl_device_id,
         return m_properties.limits;
     }
     cvk_platform* platform() const { return m_platform; }
-    const std::string& name() const { return m_device_name; }
+    const char* name() const { return m_properties.deviceName; }
     uint32_t vendor_id() const { return m_properties.vendorID; }
 
     CHECK_RETURN uint32_t memory_type_index_for_resource(
@@ -487,8 +486,8 @@ struct cvk_device : public _cl_device_id,
         return m_max_first_cmd_group_size;
     }
 
-    std::string get_device_specific_compile_options() const {
-        return m_clvk_properties->get_compile_options();
+    const std::string& get_device_specific_compile_options() const {
+        return m_device_compiler_options;
     }
 
 private:
@@ -505,6 +504,7 @@ private:
     void init_vulkan_properties(VkInstance instance);
     void init_driver_behaviors();
     void init_features(VkInstance instance);
+    void init_compiler_options();
     void build_extension_ils_list();
     CHECK_RETURN bool create_vulkan_queues_and_device(uint32_t num_queues,
                                                       uint32_t queue_family);
@@ -544,13 +544,13 @@ private:
     std::vector<cvk_vulkan_queue_wrapper> m_vulkan_queues;
     uint32_t m_vulkan_queue_alloc_index;
 
-    std::string m_device_name;
     std::string m_extension_string;
     std::vector<cl_name_version> m_extensions;
     std::string m_ils_string;
     std::vector<cl_name_version> m_ils;
     std::vector<cl_name_version> m_opencl_c_versions;
     std::vector<cl_name_version> m_opencl_c_features;
+    std::string m_device_compiler_options;
 
     uint32_t m_driver_behaviors;
 

--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -64,6 +64,13 @@ struct cvk_device_properties_amd : public cvk_device_properties {
     cl_uint get_max_cmd_group_size() const override final { return 1; }
 };
 
+struct cvk_device_properties_samsung_xclipse_920
+    : public cvk_device_properties {
+    const std::vector<std::string> get_native_builtins() const override final {
+        return std::vector<std::string>({"fma"});
+    }
+};
+
 #define RETURN(x)                                                              \
     cvk_info_fn(#x);                                                           \
     return std::make_unique<x>();
@@ -103,6 +110,8 @@ create_cvk_device_properties(const char* name) {
         RETURN(cvk_device_properties_intel);
     } else if (strncmp(name, "AMD", 3) == 0) {
         RETURN(cvk_device_properties_amd);
+    } else if (strcmp(name, "Samsung Xclipse 920") == 0) {
+        RETURN(cvk_device_properties_samsung_xclipse_920);
     } else {
         cvk_warn("Unrecognized device '%s', some device properties will be "
                  "incorrect.",

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "cl_headers.hpp"
 #include "config.hpp"
@@ -38,6 +39,10 @@ struct cvk_device_properties {
     }
 
     virtual std::string get_compile_options() const { return ""; }
+
+    virtual const std::vector<std::string> get_native_builtins() const {
+        return std::vector<std::string>();
+    }
 
     virtual ~cvk_device_properties() {}
 };

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -922,6 +922,19 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
         }
     }
 
+    // Device specific builtins options
+    std::vector<std::string> native_builtins;
+    if(device->name() == "Samsung Xclipse 920") {
+        native_builtins.push_back("fma");
+    }
+    if(!native_builtins.empty()){
+        std::string builtin_list = "";
+        for(const auto& builtin : native_builtins) {
+            builtin_list += builtin + ",";
+        }
+        options += " --use-native-builtins=" + builtin_list;
+    }
+
     // Select target SPIR-V version
     options += " -spv-version=";
     switch (device->vulkan_spirv_env()) {


### PR DESCRIPTION
Also refactor build option handling so that options which don't vary per program are only set up once in the device rather than for each program built.

Depends on https://github.com/kpet/clvk/pull/474 (I'll pull the fixes soon)

This contribution is being made by Codeplay on behalf of Samsung.