### PR TITLE
Physical module constants

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -160,7 +160,9 @@ bool cvk_kernel_argument_values::setup_descriptor_sets() {
     image_info.reserve(max_descriptor_writes);
 
     // Setup module-scope variables
-    if (program->module_constant_data_buffer() != nullptr) {
+    if (program->module_constant_data_buffer() != nullptr &&
+        program->module_constant_data_buffer_info()->type ==
+            constant_data_buffer_type::storage_buffer) {
         auto buffer = program->module_constant_data_buffer();
         auto info = program->module_constant_data_buffer_info();
         cvk_debug_fn(

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -123,6 +123,7 @@ enum class pushconstant
     num_workgroups,
     region_group_offset,
     image_metadata,
+    module_constants_pointer,
 };
 
 struct pushconstant_desc {
@@ -142,9 +143,17 @@ enum class spec_constant
     subgroup_max_size,
 };
 
+enum class constant_data_buffer_type
+{
+    storage_buffer,
+    pointer_push_constant,
+};
+
 struct constant_data_buffer_info {
+    constant_data_buffer_type type;
     uint32_t set;
     uint32_t binding;
+    uint32_t pc_offset;
     std::vector<char> data;
 };
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -476,6 +476,18 @@ void cvk_command_kernel::update_global_push_constants(
                            &num_workgroups);
     }
 
+    if (auto pc =
+            program->push_constant(pushconstant::module_constants_pointer)) {
+        CVK_ASSERT(pc->size == 8);
+
+        auto buffer = program->module_constant_data_buffer();
+        auto dev_addr = buffer->device_address();
+
+        vkCmdPushConstants(command_buffer, m_kernel->pipeline_layout(),
+                           VK_SHADER_STAGE_COMPUTE_BIT, pc->offset, pc->size,
+                           &dev_addr);
+    }
+
     uint32_t image_metadata_pc_start = UINT32_MAX;
     uint32_t image_metadata_pc_end = 0;
     if (const auto* md = m_kernel->get_image_metadata()) {


### PR DESCRIPTION
Add support for passing the module constants buffer as a device address push constant, so it can be used as a physical storage buffer.

This depends on this clspv change: https://github.com/google/clspv/pull/974
And the following update to the ClspvReflection instructions:
https://github.com/KhronosGroup/SPIRV-Headers/pull/308
https://github.com/KhronosGroup/SPIRV-Registry/pull/178

**This change is complete, but is marked as a draft as it depends on #453 which isn't merged yet. Only the top commit is relevant to this PR. I'm putting it up now to give context to help with the review of the ClspvReflection change.**

This contribution is being made by Codeplay on behalf of Samsung.
