### PR TITLE
Check format feature flags before reporting an image format as supported

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,5 +1,9 @@
 name: Presubmit
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   format:

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -278,6 +278,48 @@ std::string vulkan_calibrateable_time_domain_string(VkTimeDomainEXT td) {
     }
 }
 
+std::string vulkan_format_features_string(VkFormatFeatureFlags flags) {
+    std::string str;
+
+    if (flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT) {
+        str += "SAMPLED_IMAGE ";
+    }
+
+    if (flags & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT) {
+        str += "STORAGE_IMAGE ";
+    }
+
+    if (flags & VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT) {
+        str += "STORAGE_IMAGE_ATOMIC ";
+    }
+
+    if (flags & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT) {
+        str += "UNIFORM_TEXEL_BUFFER ";
+    }
+
+    if (flags & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT) {
+        str += "STORAGE_TEXEL_BUFFER ";
+    }
+
+    if (flags & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT) {
+        str += "STORAGE_TEXEL_BUFFER_ATOMIC ";
+    }
+
+    if (flags & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT) {
+        str += "SAMPLED_IMAGE_FILTER_LINEAR ";
+    }
+
+    if (flags & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) {
+        str += "TRANSFER_SRC ";
+    }
+
+    if (flags & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) {
+        str += "TRANSFER_DST ";
+    }
+
+    return str;
+}
+
 std::string cl_channel_order_to_string(cl_channel_order order) {
     switch (order) {
         CASE(CL_R)

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -57,6 +57,7 @@ std::string vulkan_memory_property_flags_string(VkMemoryPropertyFlags flags);
 std::string vulkan_queue_flags_string(VkQueueFlags flags);
 std::string vulkan_physical_device_type_string(VkPhysicalDeviceType type);
 std::string vulkan_calibrateable_time_domain_string(VkTimeDomainEXT td);
+std::string vulkan_format_features_string(VkFormatFeatureFlags flags);
 
 static inline std::string vulkan_version_string(uint32_t version) {
     std::string ret = std::to_string(VK_VERSION_MAJOR(version));

--- a/tests/conformance/results-kpet.json
+++ b/tests/conformance/results-kpet.json
@@ -57,7 +57,7 @@
       "load_two_kernels_manually": "pass",
       "mem_object_destructor_callback": "pass",
       "min_data_type_align_size_alignment": "pass",
-      "min_image_formats": "pass",
+      "min_image_formats": "fail",
       "min_max_address_bits": "pass",
       "min_max_compute_units": "pass",
       "min_max_constant_args": "pass",


### PR DESCRIPTION
Prepare dedicated usage flags for each buffer/image.

Also restrict CI push trigger to the main branch by default.

Contributes to #122

Signed-off-by: Kévin Petit <kpet@free.fr>