### PR TITLE
fix memory leak with command image init

### DIFF
--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -102,7 +102,13 @@ cl_int cvk_command_queue::satisfy_data_dependencies(cvk_command* cmd) {
         if (err != CL_SUCCESS) {
             return err;
         }
-        tracker.set_event(icd_downcast(initev));
+        auto downcastev = icd_downcast(initev);
+        tracker.set_event(downcastev);
+
+        // the event has been retained by `enqueue_command` thinking it is a
+        // userspace event. But as it will not be given to the user, it needs to
+        // be released here to avoid a memory leak.
+        downcastev->release();
     }
 
     return CL_SUCCESS;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -105,9 +105,9 @@ cl_int cvk_command_queue::satisfy_data_dependencies(cvk_command* cmd) {
         auto downcastev = icd_downcast(initev);
         tracker.set_event(downcastev);
 
-        // the event has been retained by `enqueue_command` thinking it is a
-        // userspace event. But as it will not be given to the user, it needs to
-        // be released here to avoid a memory leak.
+        // The event has been retained by `enqueue_command` to give its user
+        // a refcount on the event. The tracker will request a refcount so we need
+        // to give up the one we got from `enqueue_command`.
         downcastev->release();
     }
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -106,8 +106,8 @@ cl_int cvk_command_queue::satisfy_data_dependencies(cvk_command* cmd) {
         tracker.set_event(downcastev);
 
         // The event has been retained by `enqueue_command` to give its user
-        // a refcount on the event. The tracker will request a refcount so we need
-        // to give up the one we got from `enqueue_command`.
+        // a refcount on the event. The tracker will request a refcount so we
+        // need to give up the one we got from `enqueue_command`.
         downcastev->release();
     }
 


### PR DESCRIPTION
During command image init construction, we call enqueue_command with a _cl_event in parameter.
We will retain this event in enqueue_command because we associate this pattern as an event from userspace that needs to be retained automatically.
But we have no release associated with this.

Fix #480