### PR TITLE
Add support to use a percentage of total memory 

### DIFF
--- a/src/config.def
+++ b/src/config.def
@@ -24,6 +24,7 @@ OPTION(bool, keep_temporaries, false)
 OPTION(uint32_t, log, 0u)
 OPTION(bool, log_colour, false)
 OPTION(std::string, log_dest, "")
+OPTION(uint32_t, percentage_of_available_memory_reported, 100u)
 OPTION(uint32_t, spirv_validation, 2u)
 
 #if COMPILER_AVAILABLE

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -205,7 +205,14 @@ struct cvk_device : public _cl_device_id,
         heap_index = m_mem_properties.memoryTypes[type_index].heapIndex;
         size = std::min(size, m_mem_properties.memoryHeaps[heap_index].size);
 
-        return size;
+        double percentage_of_available_memory_reported =
+            static_cast<double>(
+                config.percentage_of_available_memory_reported()) /
+            100;
+        cvk_info("Using %u%% of total memory size",
+                 config.percentage_of_available_memory_reported());
+
+        return size * percentage_of_available_memory_reported;
     }
 
     uint64_t memory_size() const {


### PR DESCRIPTION
Add an option so that users could control the amount of total memory used by clvk on allocations.

This contribution is being made by Codeplay on behalf of Samsung.