### PR TITLE
use vendorID/deviceID to choose device properties

### DIFF
--- a/src/device.hpp
+++ b/src/device.hpp
@@ -71,8 +71,9 @@ struct cvk_device : public _cl_device_id,
             break;
         }
 
-        m_clvk_properties =
-            create_cvk_device_properties(m_properties.deviceName);
+        m_clvk_properties = create_cvk_device_properties(
+            m_properties.deviceName, m_properties.vendorID,
+            m_properties.deviceID);
     }
 
     static cvk_device* create(cvk_platform* platform, VkInstance instance,

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -48,4 +48,5 @@ struct cvk_device_properties {
 };
 
 std::unique_ptr<cvk_device_properties>
-create_cvk_device_properties(const char* name);
+create_cvk_device_properties(const char* name, const uint32_t vendorID,
+                             const uint32_t deviceID);


### PR DESCRIPTION
vendorID/deviceID are more reliable to identify which device properties to select.