### PR TITLE
Implement clGetKernelInfo with CL_KERNEL_ATTRIBUTES

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -2826,6 +2826,7 @@ cl_int CLVK_API_CALL clGetKernelInfo(cl_kernel kern, cl_kernel_info param_name,
     cl_int ret = CL_SUCCESS;
     size_t ret_size = 0;
     const void* copy_ptr = nullptr;
+    // TODO could this be a union
     cl_uint val_uint;
     cl_context val_context;
     cl_program val_program;
@@ -2861,7 +2862,12 @@ cl_int CLVK_API_CALL clGetKernelInfo(cl_kernel kern, cl_kernel_info param_name,
         copy_ptr = &val_program;
         ret_size = sizeof(val_program);
         break;
-    case CL_KERNEL_ATTRIBUTES: // TODO implement
+    case CL_KERNEL_ATTRIBUTES: {
+        const auto& attrs = kernel->attributes();
+        copy_ptr = attrs.c_str();
+        ret_size = attrs.size() + 1;
+        break;
+    }
     default:
         ret = CL_INVALID_VALUE;
     }

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -34,9 +34,7 @@ struct cvk_kernel : public _cl_kernel, api_object<object_magic::kernel> {
     CHECK_RETURN cl_int init();
     std::unique_ptr<cvk_kernel> clone(cl_int* errcode_ret) const;
 
-    virtual ~cvk_kernel() {
-        m_argument_values.reset();
-    }
+    virtual ~cvk_kernel() { m_argument_values.reset(); }
 
     std::shared_ptr<cvk_kernel_argument_values> argument_values() const {
         return m_argument_values;
@@ -61,6 +59,9 @@ struct cvk_kernel : public _cl_kernel, api_object<object_magic::kernel> {
     }
 
     const std::string& name() const { return m_name; }
+    const std::string& attributes() const {
+        return m_program->kernel_attributes(m_name);
+    }
     uint32_t num_args() const { return m_args.size(); }
     uint32_t num_set_layouts() const {
         return m_entry_point->num_set_layouts();

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -172,8 +172,9 @@ spv_result_t parse_reflection(void* user_data,
             case NonSemanticClspvReflectionKernel: {
                 // Record the kernel name.
                 const auto& name = parse_data->strings[inst->words[6]];
+                const auto& attributes = parse_data->strings[inst->words[9]];
                 parse_data->strings[inst->result_id] = name;
-                parse_data->binary->add_kernel(name);
+                parse_data->binary->add_kernel(name, attributes);
                 break;
             }
             case NonSemanticClspvReflectionArgumentInfo: {

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -216,9 +216,15 @@ public:
         }
     }
 
-    void add_kernel(const std::string& name) {
+    const std::unordered_map<std::string, std::string>&
+    kernels_attributes() const {
+        return m_kernels_attributes;
+    }
+
+    void add_kernel(const std::string& name, const std::string& attributes) {
         m_dmaps[name] = {};
         m_reqd_work_group_sizes[name] = {0, 0, 0};
+        m_kernels_attributes[name] = attributes;
     }
 
     void add_kernel_argument(const std::string& name, kernel_argument&& arg) {
@@ -272,6 +278,7 @@ private:
     std::unique_ptr<constant_data_buffer_info> m_constant_data_buffer;
     kernels_arguments_map m_dmaps;
     kernels_reqd_work_group_size_map m_reqd_work_group_sizes;
+    std::unordered_map<std::string, std::string> m_kernels_attributes;
     bool m_loaded_from_binary;
     spv_target_env m_target_env;
 };
@@ -629,6 +636,10 @@ public:
         status &= options_allow_split_region(config.clspv_options);
 #endif
         return status;
+    }
+
+    const std::string& kernel_attributes(const std::string& kernel_name) const {
+        return m_binary.kernels_attributes().at(kernel_name);
     }
 
 private:


### PR DESCRIPTION
This depends on this change to CLSPV - https://github.com/google/clspv/pull/990, which itself depends on changes to SPIRV-Headers - https://github.com/KhronosGroup/SPIRV-Headers/pull/308.

This contribution is being made by Codeplay on behalf of Samsung.

