### PR TITLE
Set mipmap filtering to nearest for unnormalized coords

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -203,6 +203,8 @@ bool cvk_sampler::init() {
         unnormalized_coordinates = VK_FALSE;
     } else {
         unnormalized_coordinates = VK_TRUE;
+        // VUID-01073: unnormalized coords must use nearest mipmap filtering.
+        mipmap_mode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
     }
 
     // TODO this is a rough first pass, dig into the details


### PR DESCRIPTION
* VUID 01073 requires the sampler mipmapMode to be set to nearest if unnormalized coordinates are used

Unlikely to have any practical effect since the min and max LODs are set to 0 already, but avoids a validation error. See https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01073.