### PR TITLE
Revert LLVM CMake Workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,13 +93,10 @@ if (CLVK_BUILD_SPIRV_TOOLS)
 endif()
 
 # clspv
-# FIXME remove the defintion of LLVM_TARGETS_TO_BUILD when LLVM supports an
-# empty list again
 if(MSVC)
     add_compile_options(/wd4574)
 endif()
-set(LLVM_TARGETS_TO_BUILD AArch64 CACHE STRING
-    "Semicolon-separated list of targets to build, or \"all\".")
+
 if (CLVK_COMPILER_AVAILABLE)
   # clang used to test simple_test_from_il_binary in CI
   set(LLVM_ENABLE_PROJECTS clang CACHE STRING


### PR DESCRIPTION
Building with LLVM_TARGETS_TO_BUILD set to an empty string works now