### PR TITLE
add config variable to manage native builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ variables. Here's a quick guide:
 
 * `CLVK_CLSPV_OPTIONS` to provide additional options to pass to clspv
 
+* `CLVK_CLSPV_NATIVE_BUILTINS` comma separated list of builtins that will use
+  the native implementation by default
+
+* `CLVK_CLSPV_LIBRARY_BUILTINS` comma separated list of builtins that will be
+  forced to use the libclc implementation
+
 * `CLVK_QUEUE_PROFILING_USE_TIMESTAMP_QUERIES` to use timestamp queries to
   measure the `CL_PROFILING_COMMAND_{START,END}` profiling infos on devices
   that do not support `VK_EXT_calibrated_timestamps`.

--- a/src/config.def
+++ b/src/config.def
@@ -29,6 +29,8 @@ OPTION(uint32_t, percentage_of_available_memory_reported, 100u)
 OPTION(uint32_t, spirv_validation, 2u)
 OPTION(std::string, spirv_arch, "spir")
 OPTION(bool, physical_addressing, false)
+OPTION(std::string, clspv_native_builtins, "")
+OPTION(std::string, clspv_library_builtins, "")
 
 #if COMPILER_AVAILABLE
 OPTION(std::string, clspv_options, "")

--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -54,8 +54,8 @@ struct cvk_device_properties_adreno_640 : public cvk_device_properties {
 struct cvk_device_properties_intel : public cvk_device_properties {
     cl_uint get_max_first_cmd_batch_size() const override final { return 10; }
     cl_uint get_max_cmd_group_size() const override final { return 1; }
-    const std::vector<std::string> get_native_builtins() const override final {
-        return std::vector<std::string>({
+    const std::set<std::string> get_native_builtins() const override final {
+        return std::set<std::string>({
             "ceil",           "copysign",    "exp2",      "fabs",
             "floor",          "fma",         "fmax",      "fmin",
             "half_exp",       "half_exp10",  "half_exp2", "half_log",
@@ -81,8 +81,8 @@ static bool isIntelDevice(const char* name, const uint32_t vendorID) {
 struct cvk_device_properties_amd : public cvk_device_properties {
     cl_uint get_max_first_cmd_batch_size() const override final { return 10; }
     cl_uint get_max_cmd_group_size() const override final { return 1; }
-    const std::vector<std::string> get_native_builtins() const override final {
-        return std::vector<std::string>({
+    const std::set<std::string> get_native_builtins() const override final {
+        return std::set<std::string>({
             "ceil",        "copysign",       "exp2",        "fabs",
             "fdim",        "floor",          "fmax",        "fmin",
             "frexp",       "half_exp",       "half_exp10",  "half_exp2",
@@ -105,14 +105,14 @@ static bool isAMDDevice(const char* name, const uint32_t vendorID) {
 
 struct cvk_device_properties_samsung_xclipse_920
     : public cvk_device_properties {
-    const std::vector<std::string> get_native_builtins() const override final {
-        return std::vector<std::string>({"fma"});
+    const std::set<std::string> get_native_builtins() const override final {
+        return std::set<std::string>({"fma"});
     }
 };
 
 struct cvk_device_properties_swiftshader : public cvk_device_properties {
-    const std::vector<std::string> get_native_builtins() const override final {
-        return std::vector<std::string>({
+    const std::set<std::string> get_native_builtins() const override final {
+        return std::set<std::string>({
             "asin",          "asinpi",     "atan",
             "atanpi",        "ceil",       "copysign",
             "fabs",          "fdim",       "floor",
@@ -139,8 +139,8 @@ static bool isSwiftShaderDevice(const char* name, const uint32_t vendorID,
 }
 
 struct cvk_device_properties_nvidia : public cvk_device_properties {
-    const std::vector<std::string> get_native_builtins() const override final {
-        return std::vector<std::string>({
+    const std::set<std::string> get_native_builtins() const override final {
+        return std::set<std::string>({
             "acos",        "acosh",          "acospi",      "asin",
             "asinh",       "asinpi",         "atan",        "atan2",
             "atan2pi",     "atanh",          "atanpi",      "ceil",

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -15,8 +15,8 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <string>
-#include <vector>
 
 #include "cl_headers.hpp"
 #include "config.hpp"
@@ -40,8 +40,8 @@ struct cvk_device_properties {
 
     virtual std::string get_compile_options() const { return ""; }
 
-    virtual const std::vector<std::string> get_native_builtins() const {
-        return std::vector<std::string>();
+    virtual const std::set<std::string> get_native_builtins() const {
+        return std::set<std::string>();
     }
 
     virtual ~cvk_device_properties() {}


### PR DESCRIPTION
CLVK_CLSPV_LIBRARY_BUILTINS: it allows to disable the use of native builtins coming from device properties

CLVK_CLSPV_NATIVE_BUILTINS: it allows to enable to use of native builtins that are not in device properties