### PR TITLE
A few fixes to descriptor set allocation

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -442,6 +442,8 @@ spv_result_t parse_reflection(void* user_data,
                     NonSemanticClspvReflectionConstantDataStorageBuffer) {
                     binfo.type = constant_data_buffer_type::storage_buffer;
                     binfo.set = parse_data->constants[inst->words[5]];
+                    if (binfo.set >= spir_binary::MAX_DESCRIPTOR_SETS)
+                        return SPV_ERROR_INVALID_DATA;
                     binfo.binding = parse_data->constants[inst->words[6]];
 
                 } else {

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -249,7 +249,7 @@ public:
     }
     CHECK_RETURN bool
     get_capabilities(std::vector<spv::Capability>& capabilities) const;
-    static constexpr uint32_t MAX_DESCRIPTOR_SETS = 2;
+    static constexpr uint32_t MAX_DESCRIPTOR_SETS = 3;
 
     const std::unordered_map<pushconstant, pushconstant_desc>&
     push_constants() const {
@@ -416,7 +416,7 @@ public:
     cvk_program* program() const { return m_program; }
 
 private:
-    const uint32_t MAX_INSTANCES = 16 * 1024; // FIXME find a better definition
+    const uint32_t MAX_INSTANCES = 2 * 1024; // FIXME find a better definition
 
     VkDevice m_device;
     cvk_context* m_context;


### PR DESCRIPTION
- Check the descriptor set allocated by clspv for module constants.
- Fix the max number of descriptor sets that clspv is allowed to use and add a unit test.
- Reduce the max number of instances for an entry point. This significantly reduces memory usage in applications that use many different entry points. I'll raise an issue to look at alternative designs that don't suffer from the limitations of the current one.

Change-Id: Ib2e36e1ba723b89a1a85fe3711303ccfdad2a2a5