### PR TITLE
remove cvk_command_combine in favor of cvk_event_combine

### DIFF
--- a/src/event.cpp
+++ b/src/event.cpp
@@ -22,9 +22,9 @@ static const cl_profiling_info status_to_profiling_info[4] = {
     CL_PROFILING_COMMAND_QUEUED,
 };
 
-cvk_event::cvk_event(cvk_context* ctx, cvk_command* cmd,
-                     cvk_command_queue* queue)
-    : api_object(ctx), m_cmd(cmd), m_queue(queue) {
+cvk_event_command::cvk_event_command(cvk_context* ctx, cvk_command* cmd,
+                                     cvk_command_queue* queue)
+    : cvk_event(ctx, queue), m_cmd(cmd) {
     if (cmd == nullptr) {
         m_status = CL_SUBMITTED;
         m_command_type = CL_COMMAND_USER;
@@ -34,7 +34,7 @@ cvk_event::cvk_event(cvk_context* ctx, cvk_command* cmd,
     }
 }
 
-void cvk_event::set_status(cl_int status) {
+void cvk_event_command::set_status(cl_int status) {
     cvk_debug_group(loggroup::event,
                     "cvk_event::set_status: event = %p, status = %d", this,
                     status);

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -37,17 +37,49 @@ struct cvk_event_callback {
 
 struct cvk_event : public _cl_event, api_object<object_magic::event> {
 
-    cvk_event(cvk_context* ctx, cvk_command* cmd, cvk_command_queue* queue);
+    cvk_event(cvk_context* ctx, cvk_command_queue* queue)
+        : api_object(ctx), m_command_type(0), m_queue(queue) {}
 
-    bool completed() { return m_status == CL_COMPLETE; }
+    virtual cl_int get_status() const = 0;
 
-    bool terminated() { return m_status < 0; }
+    bool completed() { return get_status() == CL_COMPLETE; }
 
-    void set_status(cl_int status);
+    bool terminated() { return get_status() < 0; }
+
+    virtual void set_status(cl_int status) = 0;
+
+    virtual void register_callback(cl_int callback_type,
+                                   cvk_event_callback_pointer_type ptr,
+                                   void* user_data) = 0;
+
+    cl_command_type command_type() const { return m_command_type; }
+
+    bool is_user_event() const { return m_command_type == CL_COMMAND_USER; }
+
+    cvk_command_queue* queue() const {
+        CVK_ASSERT(!is_user_event());
+        return m_queue;
+    }
+
+    virtual cl_int wait() = 0;
+
+    virtual uint64_t get_profiling_info(cl_profiling_info pinfo) const = 0;
+
+protected:
+    cl_command_type m_command_type;
+    cvk_command_queue* m_queue;
+};
+
+struct cvk_event_command : public cvk_event {
+
+    cvk_event_command(cvk_context* ctx, cvk_command* cmd,
+                      cvk_command_queue* queue);
+
+    void set_status(cl_int status) override final;
 
     void register_callback(cl_int callback_type,
                            cvk_event_callback_pointer_type ptr,
-                           void* user_data) {
+                           void* user_data) override final {
         std::lock_guard<std::mutex> lock(m_lock);
 
         cvk_event_callback cb = {ptr, user_data};
@@ -59,17 +91,9 @@ struct cvk_event : public _cl_event, api_object<object_magic::event> {
         }
     }
 
-    cl_int get_status() const { return m_status; }
-    cl_command_type command_type() const { return m_command_type; }
+    cl_int get_status() const override final { return m_status; }
 
-    bool is_user_event() const { return m_command_type == CL_COMMAND_USER; }
-
-    cvk_command_queue* queue() const {
-        CVK_ASSERT(!is_user_event());
-        return m_queue;
-    }
-
-    cl_int wait() {
+    cl_int wait() override final {
         std::unique_lock<std::mutex> lock(m_lock);
         cvk_debug_group(loggroup::event,
                         "cvk_event::wait: event = %p, status = %d", this,
@@ -93,7 +117,7 @@ struct cvk_event : public _cl_event, api_object<object_magic::event> {
         set_profiling_info(info, val);
     }
 
-    uint64_t get_profiling_info(cl_profiling_info pinfo) const {
+    uint64_t get_profiling_info(cl_profiling_info pinfo) const override final {
         return m_profiling_data[pinfo - CL_PROFILING_COMMAND_QUEUED];
     }
 
@@ -117,13 +141,63 @@ private:
     std::condition_variable m_cv;
     cl_int m_status;
     cl_ulong m_profiling_data[4]{};
-    cl_command_type m_command_type;
     cvk_command* m_cmd;
-    cvk_command_queue* m_queue;
     std::unordered_map<cl_int, std::vector<cvk_event_callback>> m_callbacks;
 };
 
 using cvk_event_holder = refcounted_holder<cvk_event>;
+
+struct cvk_event_combine : public cvk_event {
+
+    cvk_event_combine(cvk_context* ctx, cl_command_type command_type,
+                      cvk_command_queue* queue, cvk_event* start_event,
+                      cvk_event* end_event)
+        : cvk_event(ctx, queue), m_start_event(start_event),
+          m_end_event(end_event) {
+        m_command_type = command_type;
+    }
+
+    void set_status(cl_int status) override final {
+        UNUSED(status);
+        CVK_ASSERT(false && "Should never be called");
+    }
+
+    void register_callback(cl_int callback_type,
+                           cvk_event_callback_pointer_type ptr,
+                           void* user_data) override final {
+        if (callback_type == CL_COMPLETE) {
+            m_end_event->register_callback(callback_type, ptr, user_data);
+        } else {
+            m_start_event->register_callback(callback_type, ptr, user_data);
+        }
+    }
+
+    cl_int get_status() const override final {
+        auto start_status = m_start_event->get_status();
+        auto end_status = m_end_event->get_status();
+        if (start_status < 0) {
+            return start_status;
+        }
+        if (end_status <= 0) {
+            return end_status;
+        }
+        return start_status;
+    }
+
+    cl_int wait() override final { return m_end_event->wait(); }
+
+    uint64_t get_profiling_info(cl_profiling_info pinfo) const override final {
+        if (pinfo == CL_PROFILING_COMMAND_END) {
+            return m_end_event->get_profiling_info(pinfo);
+        } else {
+            return m_start_event->get_profiling_info(pinfo);
+        }
+    }
+
+private:
+    cvk_event_holder m_start_event;
+    cvk_event_holder m_end_event;
+};
 
 static inline cvk_event* icd_downcast(cl_event event) {
     return static_cast<cvk_event*>(event);

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1538,20 +1538,6 @@ cl_int cvk_command_unmap_image::do_action() {
     // TODO flush caches on non-coherent memory
     m_image->remove_mapping(m_mapped_ptr);
 
-    if (m_needs_copy) {
-        cl_int err;
-        if (m_update_host_ptr) {
-            err = m_cmd_host_ptr_update->do_action();
-            if (err != CL_COMPLETE) {
-                return err;
-            }
-        }
-        err = m_cmd_copy.do_action();
-        if (err != CL_COMPLETE) {
-            return err;
-        }
-    }
-
     return CL_COMPLETE;
 }
 
@@ -1646,65 +1632,6 @@ VkBufferImageCopy prepare_buffer_image_copy(const cvk_image* image,
         extent,       // imageExtent
     };
     return ret;
-}
-
-cl_int cvk_command_map_image::build(void** map_ptr) {
-    // Get a mapping
-    if (!m_image->find_or_create_mapping(m_mapping, m_origin, m_region, m_flags,
-                                         m_update_host_ptr)) {
-        cvk_error("cannot find or create a mapping");
-        return CL_OUT_OF_RESOURCES;
-    }
-    m_mapping_needs_releasing_on_destruction = true;
-
-    *map_ptr = m_mapping.ptr;
-
-    if (needs_copy()) {
-        m_cmd_copy = std::make_unique<cvk_command_buffer_image_copy>(
-            CL_COMMAND_MAP_IMAGE, m_queue, m_mapping.buffer, m_image, 0,
-            m_origin, m_region);
-
-        cl_int err = m_cmd_copy->build();
-        if (err != CL_SUCCESS) {
-            return err;
-        }
-
-        if (m_update_host_ptr && m_image->has_flags(CL_MEM_USE_HOST_PTR)) {
-            size_t zero_origin[3] = {0, 0, 0};
-            m_cmd_host_ptr_update =
-                std::make_unique<cvk_command_copy_host_buffer_rect>(
-                    m_queue, CL_COMMAND_READ_BUFFER_RECT, m_mapping.buffer,
-                    m_image->host_ptr(), m_origin.data(), zero_origin,
-                    m_region.data(), m_image->row_pitch(),
-                    m_image->slice_pitch(),
-                    m_image->map_buffer_row_pitch(m_region),
-                    m_image->map_buffer_slice_pitch(m_region),
-                    m_image->element_size());
-        }
-    }
-
-    return CL_SUCCESS;
-}
-
-cl_int cvk_command_map_image::do_action() {
-    if (needs_copy()) {
-        auto err = m_cmd_copy->do_action();
-        if (err != CL_COMPLETE) {
-            return CL_OUT_OF_RESOURCES;
-        }
-
-        if (m_update_host_ptr) {
-            if (m_cmd_host_ptr_update->do_action() != CL_COMPLETE) {
-                return CL_OUT_OF_RESOURCES;
-            }
-        }
-    }
-
-    m_mapping_needs_releasing_on_destruction = false;
-
-    // TODO invalidate buffer if the memory isn't coherent
-
-    return CL_COMPLETE;
 }
 
 void cvk_command_buffer_image_copy::build_inner_image_to_buffer(

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -391,7 +391,7 @@ struct cvk_command {
 
     cvk_command(cl_command_type type, cvk_command_queue* queue)
         : m_type(type), m_queue(queue),
-          m_event(new cvk_event(m_queue->context(), this, queue)) {}
+          m_event(new cvk_event_command(m_queue->context(), this, queue)) {}
 
     virtual ~cvk_command() { m_event->release(); }
 
@@ -458,9 +458,7 @@ struct cvk_command {
         return status;
     }
 
-    CHECK_RETURN virtual cl_int do_action() = 0;
-
-    cvk_event* event() const { return m_event; }
+    cvk_event_command* event() const { return m_event; }
 
     cl_command_type type() const { return m_type; }
 
@@ -485,9 +483,11 @@ struct cvk_command {
 protected:
     cl_command_type m_type;
     cvk_command_queue_holder m_queue;
-    cvk_event* m_event;
+    cvk_event_command* m_event;
 
 private:
+    CHECK_RETURN virtual cl_int do_action() = 0;
+
     std::vector<cvk_event*> m_event_deps;
 };
 
@@ -523,13 +523,13 @@ struct cvk_command_buffer_host_copy final
         : cvk_command_buffer_base_region(q, type, buffer, offset, size),
           m_ptr(const_cast<void*>(ptr)) {}
 
-    CHECK_RETURN cl_int do_action() override final;
-
     const std::vector<cvk_mem*> memory_objects() const override {
         return {m_buffer};
     }
 
 private:
+    CHECK_RETURN cl_int do_action() override final;
+
     void* m_ptr;
 };
 
@@ -601,13 +601,13 @@ struct cvk_command_copy_host_buffer_rect final : public cvk_command {
                    elem_size),
           m_buffer(buffer), m_hostptr(hostptr) {}
 
-    CHECK_RETURN cl_int do_action() override final;
-
     const std::vector<cvk_mem*> memory_objects() const override final {
         return {m_buffer};
     }
 
 private:
+    CHECK_RETURN cl_int do_action() override final;
+
     cvk_rectangle_copier m_copier;
     cvk_buffer_holder m_buffer;
     void* m_hostptr;
@@ -621,13 +621,13 @@ struct cvk_command_copy_buffer final : public cvk_command {
         : cvk_command(type, q), m_src_buffer(src), m_dst_buffer(dst),
           m_src_offset(src_offset), m_dst_offset(dst_offset), m_size(size) {}
 
-    CHECK_RETURN cl_int do_action() override final;
-
     const std::vector<cvk_mem*> memory_objects() const override {
         return {m_src_buffer, m_dst_buffer};
     }
 
 private:
+    CHECK_RETURN cl_int do_action() override final;
+
     cvk_buffer_holder m_src_buffer;
     cvk_buffer_holder m_dst_buffer;
     size_t m_src_offset;
@@ -647,13 +647,13 @@ struct cvk_command_copy_buffer_rect final : public cvk_command {
                    src_slice_pitch, dst_row_pitch, dst_slice_pitch, 1),
           m_src_buffer(src_buffer), m_dst_buffer(dst_buffer) {}
 
-    CHECK_RETURN cl_int do_action() override final;
-
     const std::vector<cvk_mem*> memory_objects() const override {
         return {m_src_buffer, m_dst_buffer};
     }
 
 private:
+    CHECK_RETURN cl_int do_action() override final;
+
     cvk_rectangle_copier m_copier;
     cvk_buffer_holder m_src_buffer;
     cvk_buffer_holder m_dst_buffer;
@@ -669,13 +669,13 @@ struct cvk_command_fill_buffer final : public cvk_command_buffer_base_region {
         memcpy(m_pattern.data(), pattern, pattern_size);
     }
 
-    CHECK_RETURN cl_int do_action() override final;
-
     const std::vector<cvk_mem*> memory_objects() const override {
         return {m_buffer};
     }
 
 private:
+    CHECK_RETURN cl_int do_action() override final;
+
     static constexpr int MAX_PATTERN_SIZE = 128;
     std::array<char, MAX_PATTERN_SIZE> m_pattern;
     size_t m_pattern_size;
@@ -702,8 +702,6 @@ struct cvk_command_batchable : public cvk_command {
     CHECK_RETURN cl_int build(cvk_command_buffer& cmdbuf);
     CHECK_RETURN virtual cl_int
     build_batchable_inner(cvk_command_buffer& cmdbuf) = 0;
-    CHECK_RETURN cl_int do_action() override;
-    CHECK_RETURN virtual cl_int do_post_action() { return CL_SUCCESS; }
 
     CHECK_RETURN cl_int set_profiling_info_end() {
         // If it has already been set, don't override it
@@ -747,6 +745,9 @@ struct cvk_command_batchable : public cvk_command {
     }
 
 private:
+    CHECK_RETURN virtual cl_int do_post_action() { return CL_SUCCESS; }
+    CHECK_RETURN cl_int do_action() override;
+
     std::unique_ptr<cvk_command_buffer> m_command_buffer;
     VkQueryPool m_query_pool;
 
@@ -804,8 +805,6 @@ struct cvk_command_kernel final : public cvk_command_batchable {
     CHECK_RETURN cl_int
     build_batchable_inner(cvk_command_buffer& cmdbuf) override final;
 
-    CHECK_RETURN cl_int do_post_action() override final;
-
     bool can_be_batched() const override final {
         return !m_kernel->uses_printf() &&
                cvk_command_batchable::can_be_batched();
@@ -821,6 +820,8 @@ struct cvk_command_kernel final : public cvk_command_batchable {
     }
 
 private:
+    CHECK_RETURN cl_int do_post_action() override final;
+
     CHECK_RETURN cl_int
     build_and_dispatch_regions(cvk_command_buffer& command_buffer);
     CHECK_RETURN cl_int
@@ -845,7 +846,6 @@ struct cvk_command_batch : public cvk_command {
     cvk_command_batch(cvk_command_queue* queue)
         : cvk_command(CLVK_COMMAND_BATCH, queue) {}
 
-    cl_int do_action() override final;
     cl_int add_command(cvk_command_batchable* cmd) {
         if (!m_command_buffer) {
             // Create command buffer and start recording on first call
@@ -911,6 +911,8 @@ struct cvk_command_batch : public cvk_command {
     }
 
 private:
+    CHECK_RETURN cl_int do_action() override final;
+
     std::vector<std::unique_ptr<cvk_command_batchable>> m_commands;
     std::unique_ptr<cvk_command_buffer> m_command_buffer;
 };
@@ -929,13 +931,14 @@ struct cvk_command_map_buffer final : public cvk_command_buffer_base_region {
         }
     }
     CHECK_RETURN cl_int build(void** map_ptr);
-    CHECK_RETURN cl_int do_action() override final;
 
     const std::vector<cvk_mem*> memory_objects() const override {
         return {m_buffer};
     }
 
 private:
+    CHECK_RETURN cl_int do_action() override final;
+
     cl_map_flags m_flags;
     cvk_buffer_mapping m_mapping;
     bool m_mapping_needs_releasing_on_destruction;
@@ -948,13 +951,14 @@ struct cvk_command_unmap_buffer final : public cvk_command_buffer_base {
                              void* map_ptr)
         : cvk_command_buffer_base(queue, CL_COMMAND_UNMAP_MEM_OBJECT, buffer),
           m_mapped_ptr(map_ptr) {}
-    CHECK_RETURN cl_int do_action() override final;
 
     const std::vector<cvk_mem*> memory_objects() const override {
         return {m_buffer};
     }
 
 private:
+    CHECK_RETURN cl_int do_action() override final;
+
     void* m_mapped_ptr;
 };
 
@@ -962,9 +966,10 @@ struct cvk_command_dep : public cvk_command {
     cvk_command_dep(cvk_command_queue* q, cl_command_type type)
         : cvk_command(type, q) {}
 
-    CHECK_RETURN cl_int do_action() override final { return CL_COMPLETE; }
-
     const std::vector<cvk_mem*> memory_objects() const override { return {}; }
+
+private:
+    CHECK_RETURN cl_int do_action() override final { return CL_COMPLETE; }
 };
 
 struct cvk_command_buffer_image_copy final : public cvk_command_batchable {
@@ -1008,143 +1013,39 @@ private:
     cl_command_type m_copy_type;
 };
 
-struct cvk_command_combine final : public cvk_command {
-    cvk_command_combine(cvk_command_queue* queue, cl_command_type type,
-                        std::vector<std::unique_ptr<cvk_command>>&& commands)
-        : cvk_command(type, queue), m_commands(std::move(commands)) {}
-
-    CHECK_RETURN cl_int do_action() override final {
-        for (auto& cmd : m_commands) {
-            cl_int ret = cmd->do_action();
-            if (ret != CL_COMPLETE) {
-                return ret;
-            }
-        }
-
-        return CL_COMPLETE;
-    }
-    const std::vector<cvk_mem*> memory_objects() const override {
-        std::vector<cvk_mem*> ret;
-        // Reduce the number of reallocations
-        ret.reserve(m_commands.size() * 2);
-        for (auto& cmd : m_commands) {
-            auto const mems = cmd->memory_objects();
-            ret.insert(std::end(ret), std::begin(mems), std::end(mems));
-        }
-        return ret;
-    }
-
-private:
-    std::vector<std::unique_ptr<cvk_command>> m_commands;
-};
-
 struct cvk_command_map_image final : public cvk_command {
-    cvk_command_map_image(cvk_command_queue* q, cvk_image* img,
-                          const std::array<size_t, 3>& origin,
-                          const std::array<size_t, 3>& region,
-                          cl_map_flags flags, bool update_host_ptr = false)
-        : cvk_command(CL_COMMAND_MAP_IMAGE, q), m_image(img),
-          m_mapping_needs_releasing_on_destruction(false), m_origin(origin),
-          m_region(region), m_flags(flags),
-          m_update_host_ptr(update_host_ptr &&
-                            m_image->has_flags(CL_MEM_USE_HOST_PTR)) {}
-    ~cvk_command_map_image() {
-        if (m_mapping_needs_releasing_on_destruction) {
-            m_image->cleanup_mapping(m_mapping);
-        }
-    }
-    CHECK_RETURN cl_int build(void** map_ptr);
-    CHECK_RETURN cl_int do_action() override final;
-    cvk_buffer* map_buffer() { return m_mapping.buffer; }
-    size_t row_pitch() const {
-        if (m_update_host_ptr) {
-            return m_image->row_pitch();
-        } else {
-            return m_image->map_buffer_row_pitch(m_mapping);
-        }
-    }
-    size_t slice_pitch() const {
-        if (m_update_host_ptr) {
-            return m_image->slice_pitch();
-        } else {
-            return m_image->map_buffer_slice_pitch(m_mapping);
-        }
-    }
+    // This command intend to manage the dependency with m_image initialization
+    cvk_command_map_image(cvk_command_queue* q, cvk_image* img)
+        : cvk_command(CL_COMMAND_MAP_IMAGE, q), m_image(img) {}
 
     const std::vector<cvk_mem*> memory_objects() const override {
         return {m_image};
     }
 
 private:
-    bool needs_copy() const {
-        return (m_flags & CL_MAP_WRITE_INVALIDATE_REGION) == 0;
-    }
+    CHECK_RETURN cl_int do_action() override final { return CL_COMPLETE; };
 
     cvk_image_holder m_image;
-    cvk_image_mapping m_mapping;
-    bool m_mapping_needs_releasing_on_destruction;
-    std::array<size_t, 3> m_origin;
-    std::array<size_t, 3> m_region;
-    cl_map_flags m_flags;
-    std::unique_ptr<cvk_command_buffer_image_copy> m_cmd_copy;
-    std::unique_ptr<cvk_command_copy_host_buffer_rect> m_cmd_host_ptr_update;
-    bool m_update_host_ptr;
 };
 
 struct cvk_command_unmap_image final : public cvk_command {
 
-    cvk_command_unmap_image(cvk_command_queue* q, cvk_image* image,
-                            void* mapptr, bool update_host_ptr = false)
-        : cvk_command_unmap_image(q, image, mapptr, image->mapping_for(mapptr),
-                                  update_host_ptr) {
-    } // FIXME crashes when the mapping doesn't exist
-
     cvk_command_unmap_image(cvk_command_queue* queue, cvk_image* image,
-                            void* mapped_ptr, const cvk_image_mapping& mapping,
-                            bool update_host_ptr)
+                            void* mapped_ptr)
         : cvk_command(CL_COMMAND_UNMAP_MEM_OBJECT, queue),
-          m_needs_copy((mapping.flags &
-                        (CL_MAP_WRITE | CL_MAP_WRITE_INVALIDATE_REGION)) != 0),
-          m_mapped_ptr(mapped_ptr), m_image(image),
-          m_cmd_copy(CL_COMMAND_UNMAP_MEM_OBJECT, queue, mapping.buffer, image,
-                     0, mapping.origin, mapping.region),
-          m_update_host_ptr(update_host_ptr &&
-                            m_image->has_flags(CL_MEM_USE_HOST_PTR)) {}
-    cl_int build() {
-        if (m_needs_copy) {
-            auto err = m_cmd_copy.build();
-            if (err != CL_SUCCESS) {
-                return err;
-            }
-            if (m_update_host_ptr) {
-                size_t zero_origin[3] = {0, 0, 0};
-                auto const& mapping = m_image->mapping_for(m_mapped_ptr);
-                m_cmd_host_ptr_update =
-                    std::make_unique<cvk_command_copy_host_buffer_rect>(
-                        m_queue, CL_COMMAND_WRITE_BUFFER_RECT, mapping.buffer,
-                        m_image->host_ptr(), mapping.origin.data(), zero_origin,
-                        mapping.region.data(), m_image->row_pitch(),
-                        m_image->slice_pitch(),
-                        m_image->map_buffer_row_pitch(mapping),
-                        m_image->map_buffer_slice_pitch(mapping),
-                        m_image->element_size());
-            }
-        }
-        return CL_SUCCESS;
+          m_mapped_ptr(mapped_ptr),
+          m_image(image) { // FIXME crashes when the mapping doesn't exist
     }
-    CHECK_RETURN cl_int do_action() override final;
 
     const std::vector<cvk_mem*> memory_objects() const override final {
         return {m_image};
     }
 
 private:
-    bool m_needs_copy;
+    CHECK_RETURN cl_int do_action() override final;
+
     void* m_mapped_ptr;
     cvk_image_holder m_image;
-    cvk_command_buffer_image_copy m_cmd_copy;
-    std::unique_ptr<cvk_command_copy_host_buffer_rect> m_cmd_host_ptr_update;
-    bool m_update_host_ptr;
 };
 
 struct cvk_command_image_image_copy final : public cvk_command_batchable {
@@ -1181,11 +1082,12 @@ struct cvk_command_fill_image final : public cvk_command {
                            const std::array<size_t, 3>& region)
         : cvk_command(CL_COMMAND_FILL_IMAGE, queue), m_ptr(ptr),
           m_pattern(pattern), m_pattern_size(pattern_size), m_region(region) {}
-    CHECK_RETURN cl_int do_action() override final;
 
     const std::vector<cvk_mem*> memory_objects() const override { return {}; }
 
 private:
+    CHECK_RETURN cl_int do_action() override final;
+
     void* m_ptr;
     cvk_image::fill_pattern_array m_pattern;
     size_t m_pattern_size;


### PR DESCRIPTION
cvk_command_combine prevents optimization where commands could be batch.
It is needed to have a single event representing the execution of the group of commands. This PR creates a new event (cvk_event_combine) which allows to have a single event grouping several events, thus keeping the single event for the group of commands.

It also allows to make do_action a private function, thus having it called only in one place. This is very convenient to implement future optimization (using VkSemaphore).