### PR TITLE
Add tests for unused kernel arguments and handle error cases

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -2798,10 +2798,6 @@ cl_int CLVK_API_CALL clSetKernelArg(cl_kernel kern, cl_uint arg_index,
     }
 
     // TODO CL_INVALID_ARG_VALUE if arg_value specified is not a valid value.
-    // TODO CL_INVALID_MEM_OBJECT for an argument declared to be a memory object
-    // when the specified arg_value is not a valid memory object.
-    // TODO CL_INVALID_SAMPLER for an argument declared to be of type sampler_t
-    // when the specified arg_value is not a valid sampler object.
     // TODO CL_INVALID_ARG_SIZE if arg_size does not match the size of the data
     // type for an argument that is not a memory object or if the argument is a
     // memory object and arg_size != sizeof(cl_mem) or if arg_size is zero and
@@ -2812,15 +2808,14 @@ cl_int CLVK_API_CALL clSetKernelArg(cl_kernel kern, cl_uint arg_index,
     // cl_mem_flags of CL_MEM_WRITE or if the image argument is declared with
     // the write_only qualifier and arg_value refers to an image object created
     // with cl_mem_flags of CL_MEM_READ.
-    // TODO CL_OUT_OF_RESOURCES if there is a failure to allocate resources
-    // required by the OpenCL implementation on the device.
-    // TODO CL_OUT_OF_HOST_MEMORY if there is a failure to allocate resources
-    // required by the OpenCL implementation on the host.
 
     if (arg_index >= kernel->num_args()) {
         cvk_error_fn("the program has only %u arguments", kernel->num_args());
         return CL_INVALID_ARG_INDEX;
     }
+
+    // CL_INVALID_MEM_OBJECT and CL_INVALID_SAMPLER are handled in
+    // cvk_kernel_argument_values::set_arg.
 
     // With opaque pointers, clspv is unable to infer the type of an unused
     // kernel argument so allow nullptr for its value. It will not have an

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -288,11 +288,26 @@ struct cvk_kernel_argument_values {
                 return CL_INVALID_ARG_SIZE;
             }
             if (arg.kind == kernel_argument_kind::sampler) {
-                auto sampler = *reinterpret_cast<const cl_sampler*>(value);
-                m_kernel_resources[arg.binding] = icd_downcast(sampler);
+                auto apisampler = *reinterpret_cast<const cl_sampler*>(value);
+                if (apisampler == nullptr) {
+                    return CL_INVALID_SAMPLER;
+                }
+                auto sampler = icd_downcast(apisampler);
+                if (!sampler->is_valid()) {
+                    return CL_INVALID_SAMPLER;
+                }
+
+                m_kernel_resources[arg.binding] = sampler;
             } else {
-                auto mem = *reinterpret_cast<const cl_mem*>(value);
-                m_kernel_resources[arg.binding] = icd_downcast(mem);
+                auto apimem = *reinterpret_cast<const cl_mem*>(value);
+                if (apimem == nullptr) {
+                    return CL_INVALID_MEM_OBJECT;
+                }
+                auto mem = icd_downcast(apimem);
+                if (!mem->is_valid()) {
+                    return CL_INVALID_MEM_OBJECT;
+                }
+                m_kernel_resources[arg.binding] = mem;
             }
         }
 

--- a/tests/api/compiler.cpp
+++ b/tests/api/compiler.cpp
@@ -423,3 +423,59 @@ TEST_F(WithCommandQueue, LinkPrograms) {
     ASSERT_EQ(result[2], source[2]);
     ASSERT_EQ(result[3], source[3]);
 }
+
+TEST_F(WithContext, SetUnusedMemObjectArg) {
+    static const char* source = R"(
+      kernel void foo(global uint *dst) {}
+    )";
+
+    auto kernel = CreateKernel(source, "foo");
+
+    auto buffer = CreateBuffer(CL_MEM_READ_WRITE, 64);
+
+    SetKernelArg(kernel, 0, buffer);
+}
+
+TEST_F(WithContext, SetUnusedSamplerArg) {
+    static const char* source = R"(
+      kernel void foo(sampler_t smp) {}
+    )";
+
+    auto kernel = CreateKernel(source, "foo");
+
+    auto sampler = CreateSampler(CL_TRUE, CL_ADDRESS_NONE, CL_FILTER_NEAREST);
+
+    SetKernelArg(kernel, 0, sampler);
+}
+
+TEST_F(WithContext, SetUnusedLocalArg) {
+    static const char* source = R"(
+      kernel void foo(local int* ptr) {}
+    )";
+
+    auto kernel = CreateKernel(source, "foo");
+
+    SetKernelArg(kernel, 0, 64, nullptr);
+}
+
+TEST_F(WithContext, SetUnusedMemObjectArgWithInvalidObject) {
+    static const char* source = R"(
+      kernel void foo(global uint *dst) {}
+    )";
+
+    auto kernel = CreateKernel(source, "foo");
+    cl_kernel kern = kernel;
+    cl_int err = clSetKernelArg(kernel, 0, sizeof(cl_mem), &kern);
+    ASSERT_EQ(err, CL_INVALID_MEM_OBJECT);
+}
+
+TEST_F(WithContext, SetUnusedSamplerArgWithInvalidObject) {
+    static const char* source = R"(
+      kernel void foo(sampler_t smp) {}
+    )";
+
+    auto kernel = CreateKernel(source, "foo");
+    cl_kernel kern = kernel;
+    cl_int err = clSetKernelArg(kernel, 0, sizeof(cl_sampler), &kern);
+    ASSERT_EQ(err, CL_INVALID_SAMPLER);
+}


### PR DESCRIPTION
We rely on the arg info to provide the argument type information for unused arguments. This in turn is required to handle errors.

Change-Id: I44e5a532d06d256fcf114bc13ba52dcdd71a16e4