### PR TITLE
add option to disable dependency on LLVM-SPIRV-Translator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,8 +110,9 @@ add_subdirectory(${CLSPV_SOURCE_DIR} ${PROJECT_BINARY_DIR}/external/clspv
 set_target_properties(clspv PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                       ${CMAKE_BINARY_DIR})
 
+option(CLVK_ENABLE_SPIRV_IL "Enable SPIR-V as an intermediate language" ON)
 # SPIRV-LLVM-Translator
-if (CLVK_COMPILER_AVAILABLE)
+if (CLVK_COMPILER_AVAILABLE AND CLVK_ENABLE_SPIRV_IL)
   set(LLVM_DIR
       ${CMAKE_BINARY_DIR}/external/clspv/third_party/llvm/lib/cmake/llvm)
   set(LLVM_SPIRV_SOURCE ${PROJECT_SOURCE_DIR}/external/SPIRV-LLVM-Translator CACHE STRING

--- a/README.md
+++ b/README.md
@@ -273,6 +273,11 @@ variables. Here's a quick guide:
 
 * `CLVK_LLVMSPIRV_BIN` to provide a path to the llvm-spirv binary to use
 
+* `CLVK_ENABLE_SPIRV_IL` to enable support for SPIR-V as an intermediate language
+
+   * 0: disabled
+   * 1: enabled (default)
+
 * `CLVK_VALIDATION_LAYERS` allows to enable Vulkan validation layers
 
    * 0: disabled (default)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,9 @@ endif()
 
 if (CLVK_COMPILER_AVAILABLE)
     add_compile_options(-DCOMPILER_AVAILABLE=1)
+    if (CLVK_ENABLE_SPIRV_IL)
+        add_compile_options(-DENABLE_SPIRV_IL=1)
+    endif()
 endif()
 
 if (${CLVK_VULKAN_IMPLEMENTATION} STREQUAL swiftshader)
@@ -133,9 +136,12 @@ endif()
 target_include_directories(OpenCL-objects PRIVATE
   "${CLSPV_SOURCE_DIR}/include")
 if (CLVK_CLSPV_ONLINE_COMPILER)
-  set(OpenCL-dependencies ${OpenCL-dependencies} clspv_core LLVMSPIRVLib)
-  target_include_directories(OpenCL-objects PRIVATE
-    "${LLVM_SPIRV_SOURCE}/include")
+  set(OpenCL-dependencies ${OpenCL-dependencies} clspv_core)
+  if (CLVK_ENABLE_SPIRV_IL)
+    set(OpenCL-dependencies ${OpenCL-dependencies} LLVMSPIRVLib)
+    target_include_directories(OpenCL-objects PRIVATE
+      "${LLVM_SPIRV_SOURCE}/include")
+  endif()
 else()
   if (CLVK_COMPILER_AVAILABLE)
     add_dependencies(OpenCL-objects clspv)
@@ -146,7 +152,7 @@ endif()
 
 # llvm-spirv needed to test simple_test_from_il_binary in CI even when
 # not used in online compilation mode
-if (CLVK_COMPILER_AVAILABLE)
+if (CLVK_COMPILER_AVAILABLE AND CLVK_ENABLE_SPIRV_IL)
   add_dependencies(OpenCL-objects llvm-spirv)
   set_target_properties(llvm-spirv PROPERTIES RUNTIME_OUTPUT_DIRECTORY
     ${CMAKE_BINARY_DIR})

--- a/src/config.def
+++ b/src/config.def
@@ -28,7 +28,9 @@ OPTION(std::string, clspv_library_builtins, "")
 OPTION(std::string, clspv_options, "")
 #if !CLSPV_ONLINE_COMPILER
 OPTION(std::string, clspv_path, DEFAULT_CLSPV_BINARY_PATH)
+#if ENABLE_SPIRV_IL
 OPTION(std::string, llvmspirv_bin, DEFAULT_LLVMSPIRV_BINARY_PATH)
+#endif
 #endif // !CLSPV_ONLINE_COMPILER
 #endif // COMPILER_AVAILABLE
 

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -521,7 +521,9 @@ void cvk_device::build_extension_ils_list() {
         // Add always supported extensions
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_extended_versioning"),
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_create_command_queue"),
+#ifdef ENABLE_SPIRV_IL
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_il_program"),
+#endif
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_spirv_no_integer_wrap_decoration"),
         MAKE_NAME_VERSION(1, 0, 0, "cl_arm_non_uniform_work_group_size"),
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_suggested_local_work_size"),

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -575,7 +575,9 @@ void cvk_device::build_extension_ils_list() {
 
     // Build list of ILs
     m_ils = {
+#ifdef ENABLE_SPIRV_IL
         MAKE_NAME_VERSION(1, 0, 0, "SPIR-V"),
+#endif
     };
 
     for (auto& il : m_ils) {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1020,8 +1020,8 @@ cl_build_status cvk_program::do_build_inner_offline(bool build_to_ir,
     // Save input program to a file
     if (build_from_il) {
 #ifndef ENABLE_SPIRV_IL
-        cvk_error_fn(
-            "Trying to build SPIR-V IL while SPIR-V IL has been disabled");
+        cvk_error_fn("Could not build from il because clvk has been built with "
+                     "CLVK_ENABLE_SPIRV_IL=OFF");
         return CL_BUILD_ERROR;
 #else  // ENABLE_SPIRV_IL
         std::string llvmspirv_input_file{tmp_folder + "/source.spv"};
@@ -1184,8 +1184,8 @@ cl_build_status cvk_program::do_build_inner_online(bool build_to_ir,
                 build_to_ir);
     if (build_from_il) {
 #ifndef ENABLE_SPIRV_IL
-        cvk_error_fn(
-            "Trying to build SPIR-V IL while SPIR-V IL has been disabled");
+        cvk_error_fn("Could not build from il because clvk has been built with "
+                     "CLVK_ENABLE_SPIRV_IL=OFF");
         return CL_BUILD_ERROR;
 #else  // ENABLE_SPIRV_IL
         llvm::LLVMContext llvm_context;

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -995,7 +995,7 @@ bool cvk_program::parse_user_spec_constants() {
     return true;
 #endif // CLSPV_ONLINE_COMPILER
 #else
-#ifndef COMPILER_AVAILABLE
+#if !COMPILER_AVAILABLE
     cvk_error_fn("Could not parse user spec constants because clvk has been "
                  "built with CLVK_COMPILER_AVAILABLE=OFF");
 #elif !ENABLE_SPIRV_IL

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -914,7 +914,7 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
 }
 
 bool cvk_program::parse_user_spec_constants() {
-#if COMPILER_AVAILABLE
+#if COMPILER_AVAILABLE && ENABLE_SPIRV_IL
 #ifndef CLSPV_ONLINE_COMPILER
     // We'll need to go through the whole temp folder rigamarole to query the
     // spec constant info with the command line tool.
@@ -995,6 +995,13 @@ bool cvk_program::parse_user_spec_constants() {
     return true;
 #endif // CLSPV_ONLINE_COMPILER
 #else
+#ifndef COMPILER_AVAILABLE
+    cvk_error_fn("Could not parse user spec constants because clvk has been "
+                 "built with CLVK_COMPILER_AVAILABLE=OFF");
+#elif !ENABLE_SPIRV_IL
+    cvk_error_fn("Could not parse user spec constants because clvk has been "
+                 "built with CLVK_ENABLE_SPIRV_IL=OFF");
+#endif
     return false;
 #endif // COMPILER_AVAILABLE
 }
@@ -1012,6 +1019,11 @@ cl_build_status cvk_program::do_build_inner_offline(bool build_to_ir,
     std::string clspv_input_file{tmp_folder + "/source"};
     // Save input program to a file
     if (build_from_il) {
+#ifndef ENABLE_SPIRV_IL
+        cvk_error_fn(
+            "Trying to build SPIR-V IL while SPIR-V IL has been disabled");
+        return CL_BUILD_ERROR;
+#else  // ENABLE_SPIRV_IL
         std::string llvmspirv_input_file{tmp_folder + "/source.spv"};
         clspv_input_file += ".bc";
         if (!save_il_to_file(llvmspirv_input_file, m_il)) {
@@ -1081,6 +1093,7 @@ cl_build_status cvk_program::do_build_inner_offline(bool build_to_ir,
 
         cmd += clspv_input_file;
         cmd += " ";
+#endif // ENABLE_SPIRV_IL
     } else if (m_operation == build_operation::link) {
         for (auto input_program : m_input_programs) {
             if (input_program->m_binary_type !=
@@ -1170,6 +1183,11 @@ cl_build_status cvk_program::do_build_inner_online(bool build_to_ir,
     cvk_info_fn("build_from_il %u - build_to_ir %u", build_from_il,
                 build_to_ir);
     if (build_from_il) {
+#ifndef ENABLE_SPIRV_IL
+        cvk_error_fn(
+            "Trying to build SPIR-V IL while SPIR-V IL has been disabled");
+        return CL_BUILD_ERROR;
+#else  // ENABLE_SPIRV_IL
         llvm::LLVMContext llvm_context;
         llvm::Module* llvm_module;
         std::string err;
@@ -1224,6 +1242,7 @@ cl_build_status cvk_program::do_build_inner_online(bool build_to_ir,
         m_source.clear();
         llvm::raw_string_ostream spirv_stream(m_source);
         llvm::WriteBitcodeToFile(*llvm_module, spirv_stream);
+#endif // ENABLE_SPIRV_IL
     }
     cvk_info("About to compile \"%s\"", build_options.c_str());
     int status;


### PR DESCRIPTION
Keep it enabled by default
According to the OpenCL specification, just removing it from the list returned by CL_DEVICE_IL_VERSION should be enough.

This is useful for ChromeOS to remove dependency on LLVM-SPIRV-Translator as it is not strictly needed for OpenCL compliance and we do not have a use for it.