### PR TITLE
Protect changes to memory object mappings with a mutex

### DIFF
--- a/tests/conformance/results-amd-7950x.json
+++ b/tests/conformance/results-amd-7950x.json
@@ -759,16 +759,28 @@
       "retcode": 1
     },
     "Images (clFillImage max size)": {
-      "duration": "00:00:03.073710",
-      "has_results": false,
-      "results": {},
-      "retcode": -6
+      "duration": "00:00:12.015982",
+      "has_results": true,
+      "results": {
+        "1D": "pass",
+        "1Darray": "pass",
+        "2D": "pass",
+        "2Darray": "pass",
+        "3D": "pass"
+      },
+      "retcode": 0
     },
     "Images (clFillImage pitch)": {
-      "duration": "00:00:05.749350",
-      "has_results": false,
-      "results": {},
-      "retcode": -6
+      "duration": "00:00:11.917343",
+      "has_results": true,
+      "results": {
+        "1D": "pass",
+        "1Darray": "pass",
+        "2D": "pass",
+        "2Darray": "pass",
+        "3D": "pass"
+      },
+      "retcode": 0
     },
     "Images (clFillImage)": {
       "duration": "00:00:07.716860",

--- a/tests/conformance/results-intel-a750.json
+++ b/tests/conformance/results-intel-a750.json
@@ -759,22 +759,40 @@
       "retcode": 1
     },
     "Images (clFillImage max size)": {
-      "duration": "00:00:11.033466",
-      "has_results": false,
-      "results": {},
-      "retcode": -11
+      "duration": "00:00:34.566830",
+      "has_results": true,
+      "results": {
+        "1D": "pass",
+        "1Darray": "pass",
+        "2D": "pass",
+        "2Darray": "pass",
+        "3D": "pass"
+      },
+      "retcode": 0
     },
     "Images (clFillImage pitch)": {
-      "duration": "00:00:26.927571",
-      "has_results": false,
-      "results": {},
-      "retcode": -11
+      "duration": "00:00:32.019595",
+      "has_results": true,
+      "results": {
+        "1D": "pass",
+        "1Darray": "pass",
+        "2D": "pass",
+        "2Darray": "pass",
+        "3D": "pass"
+      },
+      "retcode": 0
     },
     "Images (clFillImage)": {
-      "duration": "00:00:13.602608",
-      "has_results": false,
-      "results": {},
-      "retcode": -6
+      "duration": "00:00:26.987112",
+      "has_results": true,
+      "results": {
+        "1D": "pass",
+        "1Darray": "pass",
+        "2D": "pass",
+        "2Darray": "pass",
+        "3D": "pass"
+      },
+      "retcode": 0
     },
     "Images (clReadWriteImage max size)": {
       "duration": "00:00:08.666396",


### PR DESCRIPTION
Both command enqueue and execution need to mutate mappings and they can be concurrent.

Change-Id: Ic94b2a4ddb6170e1ed1b74399d51e9f39df1d3b7