### PR TITLE
Basic implementation for CL_DEVICE_VENDOR

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -453,7 +453,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         size_ret = val_string.size_with_null();
         break;
     case CL_DEVICE_VENDOR:
-        val_string = "FIXME";
+        val_string = device->vendor();
         copy_ptr = val_string.c_str();
         size_ret = val_string.size_with_null();
         break;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -965,6 +965,19 @@ bool cvk_device::init(VkInstance instance) {
     return true;
 }
 
+std::string cvk_device::vendor() const {
+    // Is this a Khronos vendor ID?
+    if (m_properties.vendorID > 0xFFFF) {
+        return vulkan_vendor_id_string(
+            static_cast<VkVendorId>(m_properties.vendorID));
+    }
+
+    // If not, we are looking at a PCI Vendor ID.
+    // TODO support looking it up in the PCI DB.
+
+    return m_clvk_properties->vendor();
+}
+
 bool cvk_device::supports_capability(spv::Capability capability) const {
     switch (capability) {
     // Capabilities required by all Vulkan implementations:

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -106,6 +106,7 @@ struct cvk_device : public _cl_device_id,
     cvk_platform* platform() const { return m_platform; }
     const char* name() const { return m_properties.deviceName; }
     uint32_t vendor_id() const { return m_properties.vendorID; }
+    std::string vendor() const;
 
     CHECK_RETURN uint32_t memory_type_index_for_resource(
         uint32_t valid_memory_type_bits,

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -22,6 +22,7 @@
 #include "config.hpp"
 
 struct cvk_device_properties {
+    virtual std::string vendor() const { return "Unknown vendor"; }
     virtual cl_ulong get_global_mem_cache_size() const { return 0; }
     virtual cl_ulong get_num_compute_units() const { return 1; }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -377,6 +377,27 @@ std::string vulkan_format_features_string(VkFormatFeatureFlags flags) {
     return str;
 }
 
+std::string vulkan_vendor_id_string(VkVendorId vid) {
+    switch (vid) {
+    case VK_VENDOR_ID_VIV:
+        return "Vivante";
+    case VK_VENDOR_ID_VSI:
+        return "VeriSilicon";
+    case VK_VENDOR_ID_KAZAN:
+        return "Kazan Software Renderer";
+    case VK_VENDOR_ID_CODEPLAY:
+        return "Codeplay Software Ltd.";
+    case VK_VENDOR_ID_MESA:
+        return "Mesa";
+    case VK_VENDOR_ID_POCL:
+        return "PoCL";
+    case VK_VENDOR_ID_MOBILEYE:
+        return "Mobileye";
+    default:
+        return "Unknown Khronos Vendor ID";
+    }
+}
+
 std::string cl_channel_order_to_string(cl_channel_order order) {
     switch (order) {
         CASE(CL_R)

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -97,6 +97,7 @@ std::string vulkan_queue_flags_string(VkQueueFlags flags);
 std::string vulkan_physical_device_type_string(VkPhysicalDeviceType type);
 std::string vulkan_calibrateable_time_domain_string(VkTimeDomainEXT td);
 std::string vulkan_format_features_string(VkFormatFeatureFlags flags);
+std::string vulkan_vendor_id_string(VkVendorId vid);
 
 static inline std::string vulkan_version_string(uint32_t version) {
     std::string ret = std::to_string(VK_VERSION_MAJOR(version));


### PR DESCRIPTION
I've used the name from the PCI DB in cases where the selection is made using a PCI Vendor ID.

Contributes to #10

Change-Id: I9ca4aaccfa05738d25268738b61b8c9ee8bc56ad