### PR TITLE
Only load SPIR-V reflection information once

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -497,7 +497,7 @@ bool spir_binary::load(std::istream& istream, uint32_t size) {
         return false;
     }
 
-    return load_descriptor_map();
+    return true;
 }
 
 bool spir_binary::read(const unsigned char* src, size_t size) {


### PR DESCRIPTION
Doing it multiple times leads to duplicated bindings for literal samplers.

Keep the call that is in the path common to online and offline compilation.

Caught by the Vulkan validation layers.

Change-Id: I8cc43d0d4f84931a85ea616ad3ba7487fcc1a8a4