### PR TITLE
remove unneeded build in satisfy_data_dependencies

### DIFF
--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -94,9 +94,6 @@ cl_int cvk_command_queue::satisfy_data_dependencies(cvk_command* cmd) {
         CVK_ASSERT(mem->is_image_type());
         auto initcmd =
             new cvk_command_image_init(this, static_cast<cvk_image*>(mem));
-        if (initcmd->build() != CL_SUCCESS) {
-            return CL_OUT_OF_RESOURCES;
-        }
         _cl_event* initev;
         cl_int err = enqueue_command(initcmd, &initev);
         if (err != CL_SUCCESS) {


### PR DESCRIPTION
building the command in satisfy_data_dependencies is not needed.

The command is enqueued just after. During the enqueue the command will be either built as a batchable command (in
`cvk_command_queue::enqueue_command`), or built when it will be added to a batch (in `cvk_command_batch::add_command`).