### PR TITLE
Assert when a batchable command in built into a batch after being built as standalone

### DIFF
--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -998,7 +998,8 @@ cl_int cvk_command_batchable::build() {
 }
 
 cl_int cvk_command_batchable::build(cvk_command_buffer& command_buffer) {
-    CVK_ASSERT(m_command_buffer == nullptr || (*m_command_buffer == command_buffer));
+    CVK_ASSERT(m_command_buffer == nullptr ||
+               (*m_command_buffer == command_buffer));
     // Create query pool
     VkQueryPoolCreateInfo query_pool_create_info = {
         VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO,

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -998,6 +998,7 @@ cl_int cvk_command_batchable::build() {
 }
 
 cl_int cvk_command_batchable::build(cvk_command_buffer& command_buffer) {
+    CVK_ASSERT(m_command_buffer == nullptr || (*m_command_buffer == command_buffer));
     // Create query pool
     VkQueryPoolCreateInfo query_pool_create_info = {
         VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO,


### PR DESCRIPTION
Catching the opposite would require adding state to cvk_command_batchable but it's a much harder mistake to make so probably not worth it.

Change-Id: I2a010f1e157a4713ef6da907c9b45f4ff2defaf2