### PR TITLE
free descriptor sets in cvk_kernel_argument_values earlier

### DIFF
--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -180,6 +180,14 @@ struct cvk_kernel_argument_values {
           m_args_set(other.m_args_set), m_descriptor_sets{VK_NULL_HANDLE},
           m_descriptor_sets_refcount(0) {}
 
+    ~cvk_kernel_argument_values() {
+        for (auto ds : m_descriptor_sets) {
+            if (ds != VK_NULL_HANDLE) {
+                m_entry_point->free_descriptor_set(ds);
+            }
+        }
+    }
+
     static std::shared_ptr<cvk_kernel_argument_values>
     create(cvk_entry_point* entry_point) {
         auto val = std::make_shared<cvk_kernel_argument_values>(entry_point);

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -349,7 +349,7 @@ struct cvk_kernel_argument_values {
         std::lock_guard<std::mutex> lock(m_lock);
         if (--m_descriptor_sets_refcount == 0) {
             m_is_enqueued = false;
-            for (auto ds : m_descriptor_sets) {
+            for (auto& ds : m_descriptor_sets) {
                 if (ds != VK_NULL_HANDLE) {
                     m_entry_point->free_descriptor_set(ds);
                     ds = VK_NULL_HANDLE;


### PR DESCRIPTION
We used to free descriptor sets when cvk_kernel_argument_values is destroyed. But as cvk_kernel has a ref on it, it is only freed when clReleaseKernel is called.

To be able to free them earlier, keep a refcount between retain_resources and release_resources. When the counter reach zero, free the descriptor sets, and set m_is_enqueued to false to make sure we reallocate the descriptor set if we need to use them once again.

As descriptor sets can be allocated after being freed, reset them to VK_NULL_HANDLE.