### PR TITLE
manage spirv_arch & physical_addressing in device/device_properties

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -529,7 +529,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         size_ret = sizeof(val_fpconfig);
         break;
     case CL_DEVICE_ADDRESS_BITS:
-        val_uint = (config.spirv_arch() == "spir64") ? 64 : 32;
+        val_uint = (device->get_spirv_arch() == "spir64") ? 64 : 32;
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -529,7 +529,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         size_ret = sizeof(val_fpconfig);
         break;
     case CL_DEVICE_ADDRESS_BITS:
-        val_uint = (device->get_spirv_arch() == "spir64") ? 64 : 32;
+        val_uint = device->address_bits();
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -107,20 +107,34 @@ void cvk_device::init_vulkan_properties(VkInstance instance) {
 }
 
 void cvk_device::init_clvk_runtime_behaviors() {
-#define SET_DEVICE_PROPERTY(option)                                            \
+#define SET_DEVICE_PROPERTY(option, print)                                     \
     do {                                                                       \
         if (config.option.set) {                                               \
             m_##option = config.option;                                        \
         } else {                                                               \
             m_##option = m_clvk_properties->get_##option();                    \
         }                                                                      \
-        cvk_info_fn(#option ": %u", m_##option);                               \
+        print(option);                                                         \
     } while (0)
 
-    SET_DEVICE_PROPERTY(max_cmd_batch_size);
-    SET_DEVICE_PROPERTY(max_first_cmd_batch_size);
-    SET_DEVICE_PROPERTY(max_cmd_group_size);
-    SET_DEVICE_PROPERTY(max_first_cmd_group_size);
+#define PRINT_U(option) cvk_info_fn(#option ": %u", m_##option);
+#define SET_DEVICE_PROPERTY_U(option) SET_DEVICE_PROPERTY(option, PRINT_U)
+
+#define PRINT_S(option) cvk_info_fn(#option ": %s", m_##option.c_str());
+#define SET_DEVICE_PROPERTY_S(option) SET_DEVICE_PROPERTY(option, PRINT_S)
+
+    SET_DEVICE_PROPERTY_U(max_cmd_batch_size);
+    SET_DEVICE_PROPERTY_U(max_first_cmd_batch_size);
+    SET_DEVICE_PROPERTY_U(max_cmd_group_size);
+    SET_DEVICE_PROPERTY_U(max_first_cmd_group_size);
+
+    SET_DEVICE_PROPERTY_U(physical_addressing);
+    SET_DEVICE_PROPERTY_S(spirv_arch);
+
+#undef PRINT_U
+#undef PRINT_S
+#undef SET_DEVICE_PROPERTY_U
+#undef SET_DEVICE_PROPERTY_S
 #undef SET_DEVICE_PROPERTY
 }
 
@@ -478,9 +492,9 @@ void cvk_device::init_compiler_options() {
     m_device_compiler_options +=
         " " + m_clvk_properties->get_compile_options() + " ";
 
-    m_device_compiler_options += " -arch=" + config.spirv_arch() + " ";
+    m_device_compiler_options += " -arch=" + m_spirv_arch + " ";
 
-    if (config.physical_addressing()) {
+    if (m_physical_addressing) {
         m_device_compiler_options += " -physical-storage-buffers ";
     }
 

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -528,6 +528,9 @@ struct cvk_device : public _cl_device_id,
         return m_max_first_cmd_group_size;
     }
 
+    const std::string get_spirv_arch() const { return m_spirv_arch; }
+    bool get_physical_addressing() const { return m_physical_addressing; }
+
     const std::string& get_device_specific_compile_options() const {
         return m_device_compiler_options;
     }
@@ -632,6 +635,9 @@ private:
     cl_uint m_max_first_cmd_batch_size;
     cl_uint m_max_cmd_group_size;
     cl_uint m_max_first_cmd_group_size;
+
+    std::string m_spirv_arch;
+    bool m_physical_addressing;
 
     spv_target_env m_vulkan_spirv_env;
 

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -528,8 +528,8 @@ struct cvk_device : public _cl_device_id,
         return m_max_first_cmd_group_size;
     }
 
-    const std::string get_spirv_arch() const { return m_spirv_arch; }
-    bool get_physical_addressing() const { return m_physical_addressing; }
+    cl_uint address_bits() const { return m_spirv_arch == "spir64" ? 64 : 32; }
+    bool uses_physical_addressing() const { return m_physical_addressing; }
 
     const std::string& get_device_specific_compile_options() const {
         return m_device_compiler_options;

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -39,6 +39,13 @@ struct cvk_device_properties {
         return config.max_first_cmd_group_size();
     }
 
+    virtual std::string get_spirv_arch() const {
+        return config.spirv_arch();
+    }
+    virtual bool get_physical_addressing() const {
+        return config.physical_addressing();
+    }
+
     virtual std::string get_compile_options() const { return ""; }
 
     virtual const std::set<std::string> get_native_builtins() const {

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -39,9 +39,7 @@ struct cvk_device_properties {
         return config.max_first_cmd_group_size();
     }
 
-    virtual std::string get_spirv_arch() const {
-        return config.spirv_arch();
-    }
+    virtual std::string get_spirv_arch() const { return config.spirv_arch(); }
     virtual bool get_physical_addressing() const {
         return config.physical_addressing();
     }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -110,7 +110,8 @@ bool cvk_buffer::init() {
 
     // Allocate memory
     m_memory = std::make_shared<cvk_memory_allocation>(
-        vkdev, params.size, params.memory_type_index);
+        vkdev, params.size, params.memory_type_index,
+        device->get_physical_addressing());
     res = m_memory->allocate();
 
     if (res != VK_SUCCESS) {
@@ -412,7 +413,8 @@ bool cvk_image::init() {
 
         // Allocate memory
         m_memory = std::make_unique<cvk_memory_allocation>(
-            vkdev, params.size, params.memory_type_index);
+            vkdev, params.size, params.memory_type_index,
+            device->get_physical_addressing());
 
         res = m_memory->allocate();
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -110,9 +110,8 @@ bool cvk_buffer::init() {
 
     // Allocate memory
     m_memory = std::make_shared<cvk_memory_allocation>(
-        vkdev, params.size, params.memory_type_index,
-        device->get_physical_addressing());
-    res = m_memory->allocate();
+        vkdev, params.size, params.memory_type_index);
+    res = m_memory->allocate(device->uses_physical_addressing());
 
     if (res != VK_SUCCESS) {
         return false;
@@ -413,10 +412,9 @@ bool cvk_image::init() {
 
         // Allocate memory
         m_memory = std::make_unique<cvk_memory_allocation>(
-            vkdev, params.size, params.memory_type_index,
-            device->get_physical_addressing());
+            vkdev, params.size, params.memory_type_index);
 
-        res = m_memory->allocate();
+        res = m_memory->allocate(device->uses_physical_addressing());
 
         if (res != VK_SUCCESS) {
             cvk_error_fn("Could not allocate memory!");

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -24,11 +24,9 @@
 
 struct cvk_memory_allocation {
 
-    cvk_memory_allocation(VkDevice dev, VkDeviceSize size, uint32_t type_index,
-                          bool physical_addressing)
+    cvk_memory_allocation(VkDevice dev, VkDeviceSize size, uint32_t type_index)
         : m_device(dev), m_size(size), m_memory(VK_NULL_HANDLE),
-          m_memory_type_index(type_index),
-          m_physical_addressing(physical_addressing) {}
+          m_memory_type_index(type_index) {}
 
     ~cvk_memory_allocation() {
         if (m_memory != VK_NULL_HANDLE) {
@@ -36,14 +34,14 @@ struct cvk_memory_allocation {
         }
     }
 
-    VkResult allocate() {
+    VkResult allocate(bool physical_addressing) {
         const VkMemoryAllocateFlagsInfo flagsInfo = {
             VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO, nullptr,
             VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT, 0};
 
         const VkMemoryAllocateInfo memoryAllocateInfo = {
             VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
-            m_physical_addressing ? &flagsInfo : nullptr,
+            physical_addressing ? &flagsInfo : nullptr,
             m_size,
             m_memory_type_index,
         };
@@ -64,7 +62,6 @@ private:
     VkDeviceSize m_size;
     VkDeviceMemory m_memory;
     uint32_t m_memory_type_index;
-    bool m_physical_addressing;
 };
 
 using cvk_mem_callback_pointer_type = void(CL_CALLBACK*)(cl_mem mem,
@@ -321,7 +318,7 @@ struct cvk_buffer : public cvk_mem {
                                          VK_BUFFER_USAGE_TRANSFER_DST_BIT |
                                          VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT |
                                          VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-        if (m_context->device()->get_physical_addressing()) {
+        if (m_context->device()->uses_physical_addressing()) {
             usage_flags |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
         }
         return usage_flags;

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -24,9 +24,11 @@
 
 struct cvk_memory_allocation {
 
-    cvk_memory_allocation(VkDevice dev, VkDeviceSize size, uint32_t type_index)
+    cvk_memory_allocation(VkDevice dev, VkDeviceSize size, uint32_t type_index,
+                          bool physical_addressing)
         : m_device(dev), m_size(size), m_memory(VK_NULL_HANDLE),
-          m_memory_type_index(type_index) {}
+          m_memory_type_index(type_index),
+          m_physical_addressing(physical_addressing) {}
 
     ~cvk_memory_allocation() {
         if (m_memory != VK_NULL_HANDLE) {
@@ -41,7 +43,7 @@ struct cvk_memory_allocation {
 
         const VkMemoryAllocateInfo memoryAllocateInfo = {
             VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
-            config.physical_addressing() ? &flagsInfo : nullptr,
+            m_physical_addressing ? &flagsInfo : nullptr,
             m_size,
             m_memory_type_index,
         };
@@ -62,6 +64,7 @@ private:
     VkDeviceSize m_size;
     VkDeviceMemory m_memory;
     uint32_t m_memory_type_index;
+    bool m_physical_addressing;
 };
 
 using cvk_mem_callback_pointer_type = void(CL_CALLBACK*)(cl_mem mem,
@@ -318,7 +321,7 @@ struct cvk_buffer : public cvk_mem {
                                          VK_BUFFER_USAGE_TRANSFER_DST_BIT |
                                          VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT |
                                          VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-        if (config.physical_addressing()) {
+        if (m_context->device()->get_physical_addressing()) {
             usage_flags |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
         }
         return usage_flags;


### PR DESCRIPTION
This will help once we have something detected whether or not to use physical addressing.
It will also help force some device to not use physical addressing if the feature is bugged.