### PR TITLE
llvmpipe: compile with hack-convert-to-float

### DIFF
--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -202,6 +202,9 @@ struct cvk_device_properties_llvmpipe : public cvk_device_properties {
             "half_sin", "half_sqrt",   "half_tan",
         });
     }
+    std::string get_compile_options() const override final {
+        return "-hack-convert-to-float";
+    }
 };
 
 static bool isllvmpipeDevice(const uint32_t vendorID) {


### PR DESCRIPTION
llvmpipe optimize conversions, failing on our implementation of rounding conversions.

Compiling with hack-convert-to-float fixes the issue