### PR TITLE
fix set_arg with invalid pod pointer

### DIFF
--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -268,6 +268,8 @@ struct cvk_kernel_argument_values {
                 set_pod_data(arg.offset, arg.size, &null);
             } else {
                 auto mem_downcast = icd_downcast(mem);
+                if (!mem_downcast->is_valid())
+                    return CL_INVALID_MEM_OBJECT;
                 auto buff = reinterpret_cast<const cvk_buffer*>(mem_downcast);
                 auto dev_addr = buff->device_address();
                 set_pod_data(arg.offset, arg.size, &dev_addr);

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -268,8 +268,9 @@ struct cvk_kernel_argument_values {
                 set_pod_data(arg.offset, arg.size, &null);
             } else {
                 auto mem_downcast = icd_downcast(mem);
-                if (!mem_downcast->is_valid())
+                if (!mem_downcast->is_valid()) {
                     return CL_INVALID_MEM_OBJECT;
+                }
                 auto buff = reinterpret_cast<const cvk_buffer*>(mem_downcast);
                 auto dev_addr = buff->device_address();
                 set_pod_data(arg.offset, arg.size, &dev_addr);


### PR DESCRIPTION
I found this bug running api_tests on llvmpipe with physical addressing enabled.
api_tests: WithContext.SetUnusedMemeObjectArgWithInvalidObject failed