### PR TITLE
clang-format: InsertBraces = true

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -79,6 +79,7 @@ IndentCaseLabels: false
 IndentPPDirectives: None
 IndentWidth:     4
 IndentWrappedFunctionNames: false
+InsertBraces: true
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true


### PR DESCRIPTION
Since clang-format-15 InsertBraces can be used to force brace around single line control statement.