### PR TITLE
fix clang-format usage

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -11,13 +11,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install packages
-        run: sudo apt-get install -y clang-format
+        run: sudo apt-get install -y clang-format clang-format-15
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Check format
         run: |
           ./tests/check-format.sh
+        env:
+          CLANG_FORMAT_BINARY: clang-format-15
   build:
     name: Build ${{ matrix.os }} ${{ matrix.android }} ${{ matrix.android-abi }} compiler ${{ matrix.compiler-available }} online ${{ matrix.online-compiler }}
     needs: format

--- a/tests/check-format.sh
+++ b/tests/check-format.sh
@@ -2,9 +2,14 @@
 
 GIT_CLANG_FORMAT=${GIT_CLANG_FORMAT:-git-clang-format}
 
+if [ ${CLANG_FORMAT_BINARY} ]; then
+   GIT_CLANG_FORMAT_BINARY="--binary ${CLANG_FORMAT_BINARY}"
+fi
+GIT_CLANG_FORMAT_BINARY=${GIT_CLANG_FORMAT_BINARY:-}
+
 # Run git-clang-format to check for violations
 CLANG_FORMAT_OUTPUT=/tmp/clvk-clang-format-output.txt
-${GIT_CLANG_FORMAT} --diff origin/main --extensions cpp,hpp >$CLANG_FORMAT_OUTPUT
+${GIT_CLANG_FORMAT} ${GIT_CLANG_FORMAT_BINARY} --diff origin/main --extensions cpp,hpp >$CLANG_FORMAT_OUTPUT
 
 # Check for no-ops
 grep '^no modified files to format$' "$CLANG_FORMAT_OUTPUT" && exit 0


### PR DESCRIPTION
Since we use InsertBraces, we need to use at least clang-format-15. But only installing clang-format-15, does not pull git-clang-format with it.
So let's install both clang-format and clang-format-15, and force it to use clang-format-15 to ensure that InsertBraces is supported