### PR TITLE
add missing header in config.hpp

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <string>


### PR DESCRIPTION
compiling on arch-linux with gcc-13 failed on this missing header