### PR TITLE
force flush fatal and error logs

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install packages
-        run: sudo apt-get install -y clang-format clang-format-15
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format clang-format-15
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -199,6 +199,11 @@ void cvk_log(uint64_t group_mask, loglevel level, const char* fmt, ...) {
         fprintf(gLoggingFile, "%s", colourReset);
     }
 
+    // Force to flush error and fatal logs
+    if (level <= loglevel::error) {
+        fflush(gLoggingFile);
+    }
+
     if (level == loglevel::fatal) {
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
While stdout is line buffered and stderr is unbuffered, file are just buffered by default.
Which means that fatal and error logs might not be printed (or completely printed) in some scenario.