### PR TITLE
Hashcat Kernel fails to compile

### DIFF
--- a/docs/supported-applications.md
+++ b/docs/supported-applications.md
@@ -36,7 +36,7 @@
 | [FAHBench](https://fahbench.github.io/) | Untested |
 | [Geekbench 5](https://www.geekbench.com/) | Partial support |
 | [Libreoffice](https://www.libreoffice.org/) | Untested |
-| [hashcat](https://github.com/hashcat/hashcat) | Untested |
+| [hashcat](https://github.com/hashcat/hashcat) | :x: Kernel build fails |
 | [DaVinci Resolve](https://www.blackmagicdesign.com/uk/products/davinciresolve) | Untested |
 | [TFLite](https://github.com/tensorflow/tensorflow.git) | :heavy_check_mark: Supported |
 


### PR DESCRIPTION
Hashcat information mode works

```
$ LD_LIBRARY_PATH=./build hashcat -I
hashcat (v6.2.6) starting in benchmark mode

...

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: clvk
  Name....: clvk
  Version.: OpenCL 3.0 clvk

  Backend Device ID #2
    Type...........: GPU
    Vendor.ID......: 32
    Vendor.........: NVIDIA Corporation
    Name...........: NVIDIA GeForce RTX 3070 Ti
    Version........: OpenCL 3.0 CLVK on Vulkan v1.3.242 driver 2245361984
    Processor(s)...: 1
    Clock..........: 0
    Memory.Total...: 8192 MB (limited to 1024 MB allocatable in one block)
    Memory.Free....: 8064 MB
    Local.Memory...: 48 KB
    OpenCL.Version.: OpenCL C 1.2 CLVK on Vulkan v1.3.242 driver 2245361984
    Driver.Version.: 3.0 CLVK on Vulkan v1.3.242 driver 2245361984

```

However, when attempting to run a benchmark, the kernel fails to build.

```
$ LD_LIBRARY_PATH=./build hashcat -d 2 -b

hashcat (v6.2.6) starting in benchmark mode

...

OpenCL API (OpenCL 3.0 clvk) - Platform #1 [clvk]
=================================================
* Device #2: NVIDIA GeForce RTX 3070 Ti, 8064/8192 MB (1024 MB allocatable), 1MCU

Benchmark relevant options:
===========================
* --backend-devices=2
* --optimized-kernel-enable

-------------------
* Hash-Mode 0 (MD5)
-------------------

sh: -c: line 1: syntax error near unexpected token `('
sh: -c: line 1: `/home/michael/Documents/clvk/build/clspv clvk-oyJEGw/source.cl  -D KERNEL_STATIC -D INCLUDE_PATH=/usr/share/hashcat/OpenCL -D XM2S(x)=#x -D M2S(x)=XM2S(x) -D LOCAL_MEM_TYPE=1 -D VENDOR_ID=2147483648 -D CUDA_ARCH=0 -D HAS_ADD=0 -D HAS_ADDC=0 -D HAS_SUB=0 -D HAS_SUBC=0 -D HAS_VADD=0 -D HAS_VADDC=0 -D HAS_VADD_CO=0 -D HAS_VADDC_CO=0 -D HAS_VSUB=0 -D HAS_VSUBB=0 -D HAS_VSUB_CO=0 -D HAS_VSUBB_CO=0 -D HAS_VPERM=0 -D HAS_VADD3=0 -D HAS_VBFE=0 -D HAS_BFE=0 -D HAS_LOP3=0 -D HAS_MOV64=0 -D HAS_PRMT=0 -D VECT_SIZE=8 -D DEVICE_TYPE=4 -D DGST_R0=0 -D DGST_R1=3 -D DGST_R2=2 -D DGST_R3=1 -D DGST_ELEM=4 -D KERN_TYPE=0 -D ATTACK_EXEC=11 -D ATTACK_KERN=3 -D ATTACK_MODE=3 -w  -cl-single-precision-constant  -cl-kernel-arg-info   -rounding-mode-rte=16,32,64  -rewrite-packed-structs  -std430-ubo-layout  -decorate-nonuniform    -arch=spir  --use-native-builtins=acos,acosh,acospi,asin,asinh,asinpi,atan,atan2,atan2pi,atanh,atanpi,ceil,copysign,fabs,fdim,floor,fma,fmax,fmin,frexp,half_rsqrt,half_sqrt,isequal,isfinite,isgreater,isgreaterequal,isinf,isless,islessequal,islessgreater,isnan,isnormal,isnotequal,isordered,isunordered,ldexp,mad,rint,round,rsqrt,signbit,sqrt,tanh,trunc,  -spv-version=1.6  -max-pushconstant-size=256  -max-ubo-size=65536  -global-offset  -long-vector  -module-constants-in-storage-buffer  -cl-arm-non-uniform-work-group-size   -enable-printf  -printf-buffer-size=1048576    --output-format=bc -Iclvk-oyJEGw -o clvk-oyJEGw/compiled.bc 2>&1'
clCompileProgram(): CL_BUILD_PROGRAM_FAILURE


* Device #2: Kernel /usr/share/hashcat/OpenCL/shared.cl build failed.

----------------------
* Hash-Mode 100 (SHA1)
----------------------

sh: -c: line 1: syntax error near unexpected token `('
sh: -c: line 1: `/home/michael/Documents/clvk/build/clspv clvk-3PHTVg/source.cl  -D KERNEL_STATIC -D INCLUDE_PATH=/usr/share/hashcat/OpenCL -D XM2S(x)=#x -D M2S(x)=XM2S(x) -D LOCAL_MEM_TYPE=1 -D VENDOR_ID=2147483648 -D CUDA_ARCH=0 -D HAS_ADD=0 -D HAS_ADDC=0 -D HAS_SUB=0 -D HAS_SUBC=0 -D HAS_VADD=0 -D HAS_VADDC=0 -D HAS_VADD_CO=0 -D HAS_VADDC_CO=0 -D HAS_VSUB=0 -D HAS_VSUBB=0 -D HAS_VSUB_CO=0 -D HAS_VSUBB_CO=0 -D HAS_VPERM=0 -D HAS_VADD3=0 -D HAS_VBFE=0 -D HAS_BFE=0 -D HAS_LOP3=0 -D HAS_MOV64=0 -D HAS_PRMT=0 -D VECT_SIZE=1 -D DEVICE_TYPE=4 -D DGST_R0=3 -D DGST_R1=4 -D DGST_R2=2 -D DGST_R3=1 -D DGST_ELEM=5 -D KERN_TYPE=100 -D ATTACK_EXEC=11 -D ATTACK_KERN=3 -D ATTACK_MODE=3 -w  -cl-single-precision-constant  -cl-kernel-arg-info   -rounding-mode-rte=16,32,64  -rewrite-packed-structs  -std430-ubo-layout  -decorate-nonuniform    -arch=spir  --use-native-builtins=acos,acosh,acospi,asin,asinh,asinpi,atan,atan2,atan2pi,atanh,atanpi,ceil,copysign,fabs,fdim,floor,fma,fmax,fmin,frexp,half_rsqrt,half_sqrt,isequal,isfinite,isgreater,isgreaterequal,isinf,isless,islessequal,islessgreater,isnan,isnormal,isnotequal,isordered,isunordered,ldexp,mad,rint,round,rsqrt,signbit,sqrt,tanh,trunc,  -spv-version=1.6  -max-pushconstant-size=256  -max-ubo-size=65536  -global-offset  -long-vector  -module-constants-in-storage-buffer  -cl-arm-non-uniform-work-group-size   -enable-printf  -printf-buffer-size=1048576    --output-format=bc -Iclvk-3PHTVg -o clvk-3PHTVg/compiled.bc 2>&1'
clCompileProgram(): CL_BUILD_PROGRAM_FAILURE


* Device #2: Kernel /usr/share/hashcat/OpenCL/shared.cl build failed.

...
```