### PR TITLE
fix print when forgetting vector modifier

### DIFF
--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -217,6 +217,13 @@ void process_printf(char*& data, const printf_descriptor_map_t& descs,
             data += size;
         } else {
             // Vector argument
+            if (el_size == 0) {
+                // 'ele_size == 0' means that no modifier has been used.
+                // According to the spec, this is an undefined behavior. Let's
+                // use the size coming from clspv and the vec_len to figure out
+                // the element size then.
+                el_size = size / vec_len;
+            }
             auto* data_start = data;
             for (int i = 0; i < vec_len - 1; i++) {
                 printf_out << print_part(part_fmt, data, size / vec_len) << ",";

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -218,7 +218,7 @@ void process_printf(char*& data, const printf_descriptor_map_t& descs,
         } else {
             // Vector argument
             if (el_size == 0) {
-                // 'ele_size == 0' means that no modifier has been used.
+                // 'ele_size == 0' means that no length modifier has been used.
                 // According to the spec, this is an undefined behavior. Let's
                 // use the size coming from clspv and the vec_len to figure out
                 // the element size then.

--- a/tests/api/printf.cpp
+++ b/tests/api/printf.cpp
@@ -208,7 +208,9 @@ TEST_F(WithCommandQueue, PrintfMissingLengthModifier) {
 
     const char message[] = "1,2,3,4";
     char source[512];
-    sprintf(source, "kernel void test_printf() { printf(\"%%v4u\", (uint4)(%s));}", message);
+    sprintf(source,
+            "kernel void test_printf() { printf(\"%%v4u\", (uint4)(%s));}",
+            message);
     auto kernel = CreateKernel(source, "test_printf");
 
     size_t gws = 1;

--- a/tests/api/printf.cpp
+++ b/tests/api/printf.cpp
@@ -199,4 +199,28 @@ TEST_F(WithCommandQueue, TooLongPrintf2) {
     ASSERT_STREQ(printf_buffer, message);
 }
 
+TEST_F(WithCommandQueue, PrintfMissingLengthModifier) {
+    temp_folder_deletion temp;
+    stdoutFileName = getStdoutFileName(temp);
+
+    int fd;
+    ASSERT_TRUE(getStdout(fd));
+
+    const char message[] = "1,2,3,4";
+    char source[512];
+    sprintf(source, "kernel void test_printf() { printf(\"%%v4u\", (uint4)(%s));}", message);
+    auto kernel = CreateKernel(source, "test_printf");
+
+    size_t gws = 1;
+    size_t lws = 1;
+    EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, &lws, 0, nullptr, nullptr);
+    Finish();
+
+    releaseStdout(fd);
+    auto printf_buffer = getStdoutContent();
+    ASSERT_NE(printf_buffer, nullptr);
+
+    ASSERT_STREQ(printf_buffer, message);
+}
+
 #endif


### PR DESCRIPTION
According to the OpenCL specification, when printing a vector if the modifier is not used, it is an undefined behavior. The current implement prints the first element only: "%v4u", (1, 2, 3, 4) => '1, 1, 1, 1'

But in our case we can figure out the element size using information coming from clspv. Use it only when we are in this undefined behavior to print something making more sense:
"%v4u", (1, 2, 3, 4) => '1, 2, 3, 4'