### PR TITLE
fix support for read of 3D images with unnormalised sampler

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -158,7 +158,7 @@ cvk_sampler::create(cvk_context* context, bool normalized_coords,
     return sampler.release();
 }
 
-bool cvk_sampler::init() {
+bool cvk_sampler::init(bool force_normalized_coordinates) {
     auto vkdev = context()->device()->vulkan_device();
 
     // Translate addressing mode
@@ -199,7 +199,7 @@ bool cvk_sampler::init() {
 
     // Translate coordinate type
     VkBool32 unnormalized_coordinates;
-    if (m_normalized_coords) {
+    if (m_normalized_coords || force_normalized_coordinates) {
         unnormalized_coordinates = VK_FALSE;
     } else {
         unnormalized_coordinates = VK_TRUE;
@@ -235,7 +235,9 @@ bool cvk_sampler::init() {
         unnormalized_coordinates,              // unnormalizedCoordinates
     };
 
-    auto res = vkCreateSampler(vkdev, &create_info, nullptr, &m_sampler);
+    VkSampler* sampler =
+        force_normalized_coordinates ? &m_sampler_norm : &m_sampler;
+    auto res = vkCreateSampler(vkdev, &create_info, nullptr, sampler);
 
     return (res == VK_SUCCESS);
 }

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -428,12 +428,16 @@ struct cvk_sampler : public _cl_sampler, api_object<object_magic::sampler> {
                 std::vector<cl_sampler_properties>&& properties)
         : api_object(context), m_normalized_coords(normalized_coords),
           m_addressing_mode(addressing_mode), m_filter_mode(filter_mode),
-          m_properties(std::move(properties)), m_sampler(VK_NULL_HANDLE) {}
+          m_properties(std::move(properties)), m_sampler(VK_NULL_HANDLE),
+          m_sampler_norm(VK_NULL_HANDLE) {}
 
     ~cvk_sampler() {
+        auto vkdev = context()->device()->vulkan_device();
         if (m_sampler != VK_NULL_HANDLE) {
-            auto vkdev = context()->device()->vulkan_device();
             vkDestroySampler(vkdev, m_sampler, nullptr);
+        }
+        if (m_sampler_norm != VK_NULL_HANDLE) {
+            vkDestroySampler(vkdev, m_sampler_norm, nullptr);
         }
     }
 
@@ -453,17 +457,26 @@ struct cvk_sampler : public _cl_sampler, api_object<object_magic::sampler> {
     cl_addressing_mode addressing_mode() const { return m_addressing_mode; }
     cl_filter_mode filter_mode() const { return m_filter_mode; }
     VkSampler vulkan_sampler() const { return m_sampler; }
+    VkSampler get_or_create_vulkan_sampler_with_normalized_coords() {
+        if (m_sampler_norm == VK_NULL_HANDLE) {
+            if (!init(true)) {
+                return VK_NULL_HANDLE;
+            }
+        }
+        return m_sampler_norm;
+    }
     const std::vector<cl_sampler_properties>& properties() const {
         return m_properties;
     }
 
 private:
-    bool init();
+    bool init(bool force_normalized_coordinates = false);
     bool m_normalized_coords;
     cl_addressing_mode m_addressing_mode;
     cl_filter_mode m_filter_mode;
     const std::vector<cl_sampler_properties> m_properties;
     VkSampler m_sampler;
+    VkSampler m_sampler_norm;
 };
 
 static inline cvk_sampler* icd_downcast(cl_sampler sampler) {

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -631,6 +631,14 @@ cl_int cvk_command_kernel::update_global_push_constants(
             }
         }
     }
+    if (const auto* md = m_kernel->get_sampler_metadata()) {
+        for (const auto& md : *md) {
+            auto offset = md.second;
+            image_metadata_pc_start = std::min(image_metadata_pc_start, offset);
+            image_metadata_pc_end = std::max(
+                image_metadata_pc_end, offset + (uint32_t)sizeof(uint32_t));
+        }
+    }
     if (image_metadata_pc_start < image_metadata_pc_end) {
         uint32_t offset = image_metadata_pc_start & ~0x3U;
         uint32_t size = round_up(image_metadata_pc_end - offset, 4);

--- a/tests/api/images.cpp
+++ b/tests/api/images.cpp
@@ -594,3 +594,53 @@ kernel void test(global uint* dst, uint magic, image2d_t read_only image, uint o
                     (dst[2] == (offset + magic)));
     }
 }
+
+TEST_F(WithCommandQueue, ReadImage3DWithUnormSampler) {
+    const size_t sizes[3] = {7, 7, 7};
+    const unsigned nb_elem = sizes[0] * sizes[1] * sizes[2];
+    cl_uint input[nb_elem];
+    cl_uint output[nb_elem];
+    srand(nb_elem);
+    for (unsigned i = 0; i < nb_elem; i++) {
+        input[i] = rand();
+    }
+
+    const cl_image_desc desc = {CL_MEM_OBJECT_IMAGE3D,
+                                sizes[0],
+                                sizes[1],
+                                sizes[2],
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                nullptr};
+    const cl_image_format format = {CL_R, CL_UNSIGNED_INT32};
+    auto image = CreateImage(CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, &format,
+                             &desc, input);
+    auto dst_buffer = CreateBuffer(CL_MEM_WRITE_ONLY, sizeof(output), nullptr);
+    auto sampler = CreateSampler(CL_FALSE, CL_ADDRESS_NONE, CL_FILTER_NEAREST);
+
+    const char* source = R"(
+kernel void test(global uint* dst, read_only image3d_t img, sampler_t sampler)
+{
+  unsigned x = get_global_id(0);
+  unsigned y = get_global_id(1);
+  unsigned z = get_global_id(2);
+  unsigned offset = x + get_image_width(img) * (y + get_image_height(img) * z);
+  dst[offset] = read_imageui(img, sampler, (int4)(x, y, z, 0))[0];
+}
+)";
+
+    auto kernel = CreateKernel(source, "test");
+    SetKernelArg(kernel, 0, dst_buffer);
+    SetKernelArg(kernel, 1, image);
+    SetKernelArg(kernel, 2, sampler);
+
+    EnqueueNDRangeKernel(kernel, 3, nullptr, sizes, nullptr);
+    EnqueueReadBuffer(dst_buffer, CL_TRUE, 0, sizeof(output), output);
+
+    for (unsigned i = 0; i < nb_elem; i++) {
+        EXPECT_TRUE(input[i] == output[i]);
+    }
+}


### PR DESCRIPTION
This PR depends on google/clspv#1234

We parse the new NormalizedSamplerMaskPushConstant non-semantic instruction from KhronosGroup/SPIRV-Headers#377.

Set the sampler mask in the push constant, but also create a new sampler with normalised coordinate if not already the case or already created.