### PR TITLE
remove fabs from native_builtins for intel and AMD

### DIFF
--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -92,16 +92,15 @@ struct cvk_device_properties_intel : public cvk_device_properties {
     cl_uint get_max_cmd_group_size() const override final { return 1; }
     const std::set<std::string> get_native_builtins() const override final {
         return std::set<std::string>({
-            "ceil",           "copysign",    "exp2",      "fabs",
-            "floor",          "fma",         "fmax",      "fmin",
-            "half_exp",       "half_exp10",  "half_exp2", "half_log",
-            "half_log10",     "half_log2",   "half_powr", "half_rsqrt",
-            "half_sqrt",      "isequal",     "isfinite",  "isgreater",
-            "isgreaterequal", "isinf",       "isless",    "islessequal",
-            "islessgreater",  "isnan",       "isnormal",  "isnotequal",
-            "isordered",      "isunordered", "mad",       "rint",
-            "round",          "rsqrt",       "signbit",   "sqrt",
-            "trunc",
+            "ceil",        "copysign",  "exp2",        "floor",
+            "fma",         "fmax",      "fmin",        "half_exp",
+            "half_exp10",  "half_exp2", "half_log",    "half_log10",
+            "half_log2",   "half_powr", "half_rsqrt",  "half_sqrt",
+            "isequal",     "isfinite",  "isgreater",   "isgreaterequal",
+            "isinf",       "isless",    "islessequal", "islessgreater",
+            "isnan",       "isnormal",  "isnotequal",  "isordered",
+            "isunordered", "mad",       "rint",        "round",
+            "rsqrt",       "signbit",   "sqrt",        "trunc",
         });
     }
     std::string get_compile_options() const override final {
@@ -122,17 +121,17 @@ struct cvk_device_properties_amd : public cvk_device_properties {
     cl_uint get_max_cmd_group_size() const override final { return 1; }
     const std::set<std::string> get_native_builtins() const override final {
         return std::set<std::string>({
-            "ceil",        "copysign",       "exp2",        "fabs",
-            "fdim",        "floor",          "fmax",        "fmin",
-            "frexp",       "half_exp",       "half_exp10",  "half_exp2",
-            "half_log",    "half_log10",     "half_log2",   "half_powr",
-            "half_rsqrt",  "half_sqrt",      "isequal",     "isfinite",
-            "isgreater",   "isgreaterequal", "isinf",       "isless",
-            "islessequal", "islessgreater",  "isnan",       "isnormal",
-            "isnotequal",  "isordered",      "isunordered", "ldexp",
-            "log",         "log10",          "log2",        "mad",
-            "rint",        "round",          "rsqrt",       "signbit",
-            "sqrt",        "trunc",
+            "ceil",           "copysign",    "exp2",      "fdim",
+            "floor",          "fmax",        "fmin",      "frexp",
+            "half_exp",       "half_exp10",  "half_exp2", "half_log",
+            "half_log10",     "half_log2",   "half_powr", "half_rsqrt",
+            "half_sqrt",      "isequal",     "isfinite",  "isgreater",
+            "isgreaterequal", "isinf",       "isless",    "islessequal",
+            "islessgreater",  "isnan",       "isnormal",  "isnotequal",
+            "isordered",      "isunordered", "ldexp",     "log",
+            "log10",          "log2",        "mad",       "rint",
+            "round",          "rsqrt",       "signbit",   "sqrt",
+            "trunc",
         });
     }
     std::string get_compile_options() const override final {


### PR DESCRIPTION
Both Intel and AMD GLSL fabs version flush denormalized numbers to zero.
This will prevent OpenCL compliance when clspv will be updated with google/clspv#1252 as functions like cbrt from libclc requires denormalized numbers not to be flushed to zero to be compliant.