### PR TITLE
improve descriptor set reuse

### DIFF
--- a/src/config.def
+++ b/src/config.def
@@ -47,8 +47,6 @@ OPTION(uint32_t, max_first_cmd_batch_size, 10000u)
 OPTION(uint32_t, max_cmd_group_size, UINT32_MAX)
 OPTION(uint32_t, max_first_cmd_group_size, UINT32_MAX)
 
-OPTION(uint32_t, max_entry_points_instances, 2*1024u) // FIXME find a better definition
-
 //
 // Logging
 //

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -408,6 +408,8 @@ struct cvk_device : public _cl_device_id,
         return queue;
     }
 
+    uint32_t num_queues() const { return m_vulkan_queues.size(); }
+
     cl_device_fp_config fp_config(cl_device_info fptype) const {
         if ((fptype == CL_DEVICE_HALF_FP_CONFIG) && supports_fp16()) {
             return CL_FP_ROUND_TO_NEAREST | CL_FP_INF_NAN | CL_FP_FMA;

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -179,7 +179,8 @@ cl_int cvk_kernel::set_arg(cl_uint index, size_t size, const void* value) {
 
 bool cvk_kernel::args_valid() const { return m_argument_values->args_valid(); }
 
-bool cvk_kernel_argument_values::setup_descriptor_sets() {
+bool cvk_kernel_argument_values::setup_descriptor_sets(
+    cvk_vulkan_queue_wrapper* queue) {
     std::lock_guard<std::mutex> lock(m_lock);
 
     auto program = m_entry_point->program();
@@ -193,7 +194,10 @@ bool cvk_kernel_argument_values::setup_descriptor_sets() {
     m_is_enqueued = true;
 
     // Get descriptor sets
-    VkDescriptorSet* ds = descriptor_sets();
+    VkDescriptorSet* ds = descriptor_sets(queue);
+    if (ds == nullptr) {
+        return false;
+    }
 
     // Make enough space to store all descriptor write structures
     size_t max_descriptor_writes =

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -192,10 +192,7 @@ bool cvk_kernel_argument_values::setup_descriptor_sets() {
 
     m_is_enqueued = true;
 
-    // Allocate descriptor sets
-    if (!m_entry_point->allocate_descriptor_sets(descriptor_sets())) {
-        return false;
-    }
+    // Get descriptor sets
     VkDescriptorSet* ds = descriptor_sets();
 
     // Make enough space to store all descriptor write structures

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -342,10 +342,11 @@ struct cvk_kernel_argument_values {
         return m_specialization_constants;
     }
 
-    CHECK_RETURN bool setup_descriptor_sets();
+    CHECK_RETURN bool
+    setup_descriptor_sets(cvk_vulkan_queue_wrapper* queue_index);
 
-    VkDescriptorSet* descriptor_sets() {
-        return m_entry_point->get_descriptor_sets();
+    VkDescriptorSet* descriptor_sets(cvk_vulkan_queue_wrapper* queue) {
+        return m_entry_point->get_descriptor_sets(queue);
     }
 
     // Take ownership of resources and retain them.

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -346,7 +346,7 @@ struct cvk_kernel_argument_values {
     setup_descriptor_sets(cvk_vulkan_queue_wrapper* queue_index);
 
     VkDescriptorSet* descriptor_sets(cvk_vulkan_queue_wrapper* queue) {
-        return m_entry_point->get_descriptor_sets(queue);
+        return m_entry_point->get_or_allocate_descriptor_sets(queue);
     }
 
     // Take ownership of resources and retain them.

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -2193,8 +2193,8 @@ cvk_entry_point::create_pipeline(const cvk_spec_constant_map& spec_constants) {
     return pipeline;
 }
 
-VkDescriptorSet*
-cvk_entry_point::get_descriptor_sets(cvk_vulkan_queue_wrapper* queue) {
+VkDescriptorSet* cvk_entry_point::get_or_allocate_descriptor_sets(
+    cvk_vulkan_queue_wrapper* queue) {
     std::lock_guard<std::mutex> lock(m_descriptor_pool_lock);
     VkDescriptorSet* ds;
     if (m_descriptor_sets.count(queue) != 0) {

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -456,7 +456,8 @@ public:
     CHECK_RETURN VkPipeline
     create_pipeline(const cvk_spec_constant_map& spec_constants);
 
-    VkDescriptorSet* get_descriptor_sets(cvk_vulkan_queue_wrapper* queue);
+    VkDescriptorSet*
+    get_or_allocate_descriptor_sets(cvk_vulkan_queue_wrapper* queue);
 
     uint32_t num_set_layouts() const { return m_descriptor_set_layouts.size(); }
 

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -356,6 +356,10 @@ struct cvk_command_buffer {
 
     operator VkCommandBuffer() { return m_command_buffer; }
 
+    cvk_vulkan_queue_wrapper* vulkan_queue() const {
+        return &m_queue->vulkan_queue();
+    }
+
 protected:
     cvk_command_queue_holder m_queue;
     VkCommandBuffer m_command_buffer;


### PR DESCRIPTION
Only allocate one descriptor set per entry-point per queue. And always reuse it as we are not doing update after bind.

Fix #580