### PR TITLE
add list of unsupported image_format in device_properties

### DIFF
--- a/src/device.hpp
+++ b/src/device.hpp
@@ -560,6 +560,11 @@ struct cvk_device : public _cl_device_id,
             ->is_bgra_format_not_supported_for_image1d_buffer();
     }
 
+    bool is_image_format_disabled(cl_image_format format) const {
+        return m_clvk_properties->get_unsupported_image_format().count(
+                   format) != 0;
+    }
+
 private:
     std::string version_desc() const {
         std::string ret = "CLVK on Vulkan v";

--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -111,6 +111,10 @@ struct cvk_device_properties_intel : public cvk_device_properties {
     is_bgra_format_not_supported_for_image1d_buffer() const override final {
         return true;
     }
+
+    image_format_set get_unsupported_image_format() const override final {
+        return image_format_set({{CL_RGB, CL_UNORM_SHORT_565}});
+    }
 };
 
 static bool isIntelDevice(const char* name, const uint32_t vendorID) {

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -56,6 +56,17 @@ struct cvk_device_properties {
         return false;
     }
 
+    struct ClFormatSetCompare {
+        int operator()(const cl_image_format& lhs,
+                       const cl_image_format& rhs) const {
+            return lhs.image_channel_order > rhs.image_channel_order ||
+                   (lhs.image_channel_order == rhs.image_channel_order &&
+                    lhs.image_channel_data_type > rhs.image_channel_data_type);
+        }
+    };
+    using image_format_set = std::set<cl_image_format, ClFormatSetCompare>;
+    virtual image_format_set get_unsupported_image_format() const { return {}; }
+
     virtual ~cvk_device_properties() {}
 };
 

--- a/src/image_format.cpp
+++ b/src/image_format.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "image_format.hpp"
-#include "CL/cl.h"
-#include <unordered_map>
+#include "cl_headers.hpp"
+#include "device.hpp"
 
 format_mapping_map FormatMaps = {
     // R formats
@@ -180,13 +180,15 @@ bool cl_image_format_to_vulkan_format(cl_image_format clformat,
                                       image_format_support* fmt_support,
                                       VkComponentMapping* components_sampled,
                                       VkComponentMapping* components_storage) {
-    auto m = FormatMaps.find(clformat);
-    bool success = false;
-
-    if (m != FormatMaps.end()) {
-        *fmt_support = (*m).second;
-        success = true;
+    if (device->is_image_format_disabled(clformat)) {
+        return false;
     }
+
+    auto m = FormatMaps.find(clformat);
+    if (m == FormatMaps.end()) {
+        return false;
+    }
+    *fmt_support = (*m).second;
 
     get_component_mappings_for_channel_order(
         clformat.image_channel_order, components_sampled, components_storage);
@@ -198,5 +200,5 @@ bool cl_image_format_to_vulkan_format(cl_image_format clformat,
             fmt_support->vkfmt, components_sampled, components_storage);
     }
 
-    return success;
+    return true;
 }

--- a/src/image_format.hpp
+++ b/src/image_format.hpp
@@ -15,9 +15,12 @@
 #pragma once
 
 #include "cl_headers.hpp"
-#include "device.hpp"
+
+#include <unordered_map>
 
 #include <vulkan/vulkan.h>
+
+struct cvk_device;
 
 struct ClFormatMapHash {
     size_t operator()(const cl_image_format& format) const {


### PR DESCRIPTION
Some Intel drivers have bug with CL_UNORM_SHORT_565. As it is not mandatory for OpenCL, just report it as unsupported for Intel.