### PR TITLE
only report read-write images if we have theright spirv capability

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -730,6 +730,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
             val_uint = 0;
             copy_ptr = &val_uint;
             size_ret = sizeof(val_uint);
+            break;
         }
         [[fallthrough]];
     case CL_DEVICE_MAX_WRITE_IMAGE_ARGS:

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -731,7 +731,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
             copy_ptr = &val_uint;
             size_ret = sizeof(val_uint);
         }
-        // fallthrough
+        [[fallthrough]];
     case CL_DEVICE_MAX_WRITE_IMAGE_ARGS:
         val_uint = device->vulkan_limits().maxPerStageDescriptorStorageImages;
         copy_ptr = &val_uint;

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -726,6 +726,12 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         size_ret = sizeof(val_uint);
         break;
     case CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS:
+        if (!device->supports_read_write_images()) {
+            val_uint = 0;
+            copy_ptr = &val_uint;
+            size_ret = sizeof(val_uint);
+        }
+        // fallthrough
     case CL_DEVICE_MAX_WRITE_IMAGE_ARGS:
         val_uint = device->vulkan_limits().maxPerStageDescriptorStorageImages;
         copy_ptr = &val_uint;
@@ -4664,6 +4670,14 @@ cl_int CLVK_API_CALL clGetSupportedImageFormats(cl_context context,
 
     auto dev = icd_downcast(context)->device();
     auto pdev = dev->vulkan_physical_device();
+
+    if (!dev->supports_read_write_images() &&
+        (flags & CL_MEM_KERNEL_READ_AND_WRITE)) {
+        if (num_image_formats != nullptr) {
+            *num_image_formats = 0;
+        }
+        return CL_SUCCESS;
+    }
 
     const VkFormatFeatureFlags required_format_feature_flags =
         cvk_image::required_format_feature_flags_for(image_type, flags);

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -300,7 +300,9 @@ struct cvk_device : public _cl_device_id,
 
     bool supports_read_write_images() const {
         return supports_capability(
-            spv::CapabilityStorageImageReadWithoutFormat);
+                   spv::CapabilityStorageImageReadWithoutFormat) &&
+               supports_capability(
+                   spv::CapabilityStorageImageWriteWithoutFormat);
     }
 
     bool supports_fp16() const { return m_has_fp16_support; }

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -298,6 +298,11 @@ struct cvk_device : public _cl_device_id,
         return devices_support_images() ? CL_TRUE : CL_FALSE;
     }
 
+    bool supports_read_write_images() const {
+        return supports_capability(
+            spv::CapabilityStorageImageReadWithoutFormat);
+    }
+
     bool supports_fp16() const { return m_has_fp16_support; }
 
     bool supports_fp64() const { return m_has_fp64_support; }


### PR DESCRIPTION
We need at least StorageImageReadWithoutFormat to support read write images.