### PR TITLE
rework thread naming to avoid requiring native_handle_type

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1515,7 +1515,7 @@ bool cvk_program::check_capabilities(const cvk_device* device) const {
 }
 
 void cvk_program::do_build() {
-    cvk_set_thread_name_if_supported(m_thread->native_handle(), "clvk-build");
+    cvk_set_current_thread_name_if_supported("clvk-build");
 
     // Destroy entry points from previous build
     m_entry_points.clear();

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -383,8 +383,7 @@ cvk_executor_thread::extract_cmds_required_by(bool only_non_batch_cmds,
 }
 
 void cvk_executor_thread::executor() {
-    cvk_set_thread_name_if_supported(m_thread->native_handle(),
-                                     "clvk-executor");
+    cvk_set_current_thread_name_if_supported("clvk-executor");
 
     std::unique_lock<std::mutex> lock(m_lock);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -81,10 +81,8 @@ int cvk_exec(const std::string& cmd, std::string* output) {
 #endif
 }
 
-void cvk_set_thread_name_if_supported(
-    const std::thread::native_handle_type& target_thread,
-    const std::string& name) {
+void cvk_set_current_thread_name_if_supported(const std::string& name) {
 #if !defined(WIN32) && !defined(__APPLE__)
-    pthread_setname_np(target_thread, name.c_str());
+    pthread_setname_np(pthread_self(), name.c_str());
 #endif
 }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -29,8 +29,7 @@
 
 char* cvk_mkdtemp(std::string& tmpl);
 int cvk_exec(const std::string& cmd, std::string* output = nullptr);
-void cvk_set_thread_name_if_supported(const std::thread::native_handle_type&,
-                                      const std::string&);
+void cvk_set_current_thread_name_if_supported(const std::string&);
 
 #define CVK_VK_CHECK_INTERNAL(logfn, res, msg)                                 \
     do {                                                                       \


### PR DESCRIPTION
We are having issue in google infra with native_handle_type which is
not supported.