### PR TITLE
fix subgroup support & add partial support of cl_intel_subgroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ variables. Here's a quick guide:
   conformance on devices that do not support linear filtering with all the image formats
   required for conformance.
 
-* `CLVK_PREFERED_SUBGROUP_SIZE` specifies the subgroup size to use if nothing
+* `CLVK_PREFERRED_SUBGROUP_SIZE` specifies the subgroup size to use if nothing
   is specified in the kernel. When not set use the default value reported by
   the Vulkan driver.
 

--- a/README.md
+++ b/README.md
@@ -436,6 +436,13 @@ variables. Here's a quick guide:
   conformance on devices that do not support linear filtering with all the image formats
   required for conformance.
 
+* `CLVK_PREFERED_SUBGROUP_SIZE` specifies the subgroup size to use if nothing
+  is specified in the kernel. When not set use the default value reported by
+  the Vulkan driver.
+
+* `CLVK_FORCE_SUBGROUP_SIZE` specifies the subgroup size to use, overriding
+  everything.
+
 # Limitations
 
 * Only one device per CL context

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -430,7 +430,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
     cl_device_device_enqueue_capabilities val_dev_enqueue_caps;
     cl_device_pci_bus_info_khr val_pci_bus_info;
     cl_device_atomic_capabilities val_atomic_capabilities;
-    std::vector<size_t> subgroup_sizes;
+    std::vector<size_t> val_subgroup_sizes;
 
     auto device = icd_downcast(dev);
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -906,7 +906,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         size_ret = sizeof(val_pci_bus_info);
         break;
     case CL_DEVICE_SUB_GROUP_SIZES_INTEL:
-        if (device->supports_controled_subgroups()) {
+        if (device->supports_subgroup_size_selection()) {
             uint32_t size = device->min_sub_group_size();
             while (size <= device->max_sub_group_size()) {
                 subgroup_sizes.push_back((size_t)size);

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -909,11 +909,11 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         if (device->supports_subgroup_size_selection()) {
             uint32_t size = device->min_sub_group_size();
             while (size <= device->max_sub_group_size()) {
-                subgroup_sizes.push_back((size_t)size);
+                val_subgroup_sizes.push_back((size_t)size);
                 size *= 2;
             }
-            copy_ptr = subgroup_sizes.data();
-            size_ret = sizeof(size_t) * subgroup_sizes.size();
+            copy_ptr = val_subgroup_sizes.data();
+            size_ret = sizeof(size_t) * val_subgroup_sizes.size();
             break;
         }
         [[fallthrough]];

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -430,6 +430,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
     cl_device_device_enqueue_capabilities val_dev_enqueue_caps;
     cl_device_pci_bus_info_khr val_pci_bus_info;
     cl_device_atomic_capabilities val_atomic_capabilities;
+    std::vector<size_t> subgroup_sizes;
 
     auto device = icd_downcast(dev);
 
@@ -904,6 +905,18 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         copy_ptr = &val_pci_bus_info;
         size_ret = sizeof(val_pci_bus_info);
         break;
+    case CL_DEVICE_SUB_GROUP_SIZES_INTEL:
+        if (device->supports_controled_subgroups()) {
+            uint32_t size = device->min_sub_group_size();
+            while (size <= device->max_sub_group_size()) {
+                subgroup_sizes.push_back((size_t)size);
+                size *= 2;
+            }
+            copy_ptr = subgroup_sizes.data();
+            size_ret = sizeof(size_t) * subgroup_sizes.size();
+            break;
+        }
+        [[fallthrough]];
     default:
         ret = CL_INVALID_VALUE;
         break;

--- a/src/config.def
+++ b/src/config.def
@@ -39,6 +39,9 @@ OPTION(std::string, llvmspirv_bin, DEFAULT_LLVMSPIRV_BINARY_PATH)
 #endif // !CLSPV_ONLINE_COMPILER
 #endif // COMPILER_AVAILABLE
 
+OPTION(uint32_t, force_subgroup_size, 0u) // 0 meaning not forced
+OPTION(uint32_t, prefered_subgroup_size, 0u) // 0 meaning no preference
+
 //
 // Command execution
 //

--- a/src/config.def
+++ b/src/config.def
@@ -40,7 +40,7 @@ OPTION(std::string, llvmspirv_bin, DEFAULT_LLVMSPIRV_BINARY_PATH)
 #endif // COMPILER_AVAILABLE
 
 OPTION(uint32_t, force_subgroup_size, 0u) // 0 meaning not forced
-OPTION(uint32_t, prefered_subgroup_size, 0u) // 0 meaning no preference
+OPTION(uint32_t, preferred_subgroup_size, 0u) // 0 meaning no preference
 
 //
 // Command execution

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -135,7 +135,7 @@ void cvk_device::init_clvk_runtime_behaviors() {
     SET_DEVICE_PROPERTY_U(physical_addressing);
     SET_DEVICE_PROPERTY_S(spirv_arch);
 
-    SET_DEVICE_PROPERTY_U(prefered_subgroup_size);
+    SET_DEVICE_PROPERTY_U(preferred_subgroup_size);
 
 #undef PRINT_U
 #undef PRINT_S
@@ -636,7 +636,7 @@ void cvk_device::build_extension_ils_list() {
             MAKE_NAME_VERSION(1, 0, 0, "cl_khr_pci_bus_info"));
     }
 
-    if (supports_controled_subgroups()) {
+    if (supports_subgroup_size_selection()) {
         m_extensions.push_back(
             MAKE_NAME_VERSION(1, 0, 0, "cl_intel_required_subgroup_size"));
     }

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -49,6 +49,8 @@ void cvk_device::init_vulkan_properties(VkInstance instance) {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT;
     m_subgroup_properties.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES;
+    m_subgroup_size_control_properties.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES;
     m_float_controls_properties.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES;
 
@@ -73,6 +75,8 @@ void cvk_device::init_vulkan_properties(VkInstance instance) {
                          m_pci_bus_info_properties),
             VER_EXT_PROP(VK_MAKE_VERSION(1, 1, 0), nullptr,
                          m_subgroup_properties),
+            VER_EXT_PROP(VK_MAKE_VERSION(1, 3, 0), nullptr,
+                         m_subgroup_size_control_properties),
             VER_EXT_PROP(VK_MAKE_VERSION(1, 1, 0), nullptr,
                          m_maintenance3_properties),
             VER_EXT_PROP(VK_MAKE_VERSION(1, 2, 0), nullptr,
@@ -130,6 +134,8 @@ void cvk_device::init_clvk_runtime_behaviors() {
 
     SET_DEVICE_PROPERTY_U(physical_addressing);
     SET_DEVICE_PROPERTY_S(spirv_arch);
+
+    SET_DEVICE_PROPERTY_U(prefered_subgroup_size);
 
 #undef PRINT_U
 #undef PRINT_S
@@ -305,6 +311,8 @@ void cvk_device::init_features(VkInstance instance) {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES;
     m_features_buffer_device_address.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR;
+    m_features_subgroup_size_control.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES;
 
     std::vector<std::tuple<uint32_t, const char*, VkBaseOutStructure*>>
         coreversion_extension_features = {
@@ -328,6 +336,9 @@ void cvk_device::init_features(VkInstance instance) {
             VER_EXT_FEAT(VK_MAKE_VERSION(1, 2, 0),
                          VK_KHR_SHADER_SUBGROUP_EXTENDED_TYPES_EXTENSION_NAME,
                          m_features_shader_subgroup_extended_types),
+            VER_EXT_FEAT(VK_MAKE_VERSION(1, 3, 0),
+                         VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME,
+                         m_features_subgroup_size_control),
             VER_EXT_FEAT(VK_MAKE_VERSION(1, 2, 0),
                          VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME,
                          m_features_vulkan_memory_model),
@@ -623,6 +634,11 @@ void cvk_device::build_extension_ils_list() {
     if (is_vulkan_extension_enabled(VK_EXT_PCI_BUS_INFO_EXTENSION_NAME)) {
         m_extensions.push_back(
             MAKE_NAME_VERSION(1, 0, 0, "cl_khr_pci_bus_info"));
+    }
+
+    if (supports_controled_subgroups()) {
+        m_extensions.push_back(
+            MAKE_NAME_VERSION(1, 0, 0, "cl_intel_required_subgroup_size"));
     }
 
     // Build extension string

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -636,9 +636,15 @@ void cvk_device::build_extension_ils_list() {
             MAKE_NAME_VERSION(1, 0, 0, "cl_khr_pci_bus_info"));
     }
 
-    if (supports_subgroup_size_selection()) {
+    if ((m_properties.apiVersion >= VK_MAKE_VERSION(1, 3, 0) ||
+         is_vulkan_extension_enabled(
+             VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME)) &&
+        m_features_subgroup_size_control.subgroupSizeControl &&
+        (m_subgroup_size_control_properties.requiredSubgroupSizeStages &
+         VK_SHADER_STAGE_COMPUTE_BIT)) {
         m_extensions.push_back(
             MAKE_NAME_VERSION(1, 0, 0, "cl_intel_required_subgroup_size"));
+        m_has_subgroup_size_selection = true;
     }
 
     // Build extension string

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -344,12 +344,7 @@ struct cvk_device : public _cl_device_id,
     bool supports_subgroups() const { return m_has_subgroups_support; }
 
     bool supports_subgroup_size_selection() const {
-        return (m_properties.apiVersion >= VK_MAKE_VERSION(1, 3, 0) ||
-                is_vulkan_extension_enabled(
-                    VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME)) &&
-               m_features_subgroup_size_control.subgroupSizeControl &&
-               (m_subgroup_size_control_properties.requiredSubgroupSizeStages &
-                VK_SHADER_STAGE_COMPUTE_BIT);
+        return m_has_subgroup_size_selection;
     }
 
     bool supports_non_uniform_decoration() const {
@@ -701,6 +696,7 @@ private:
     bool m_has_fp64_support{};
     bool m_has_int8_support{};
     bool m_has_subgroups_support{};
+    bool m_has_subgroup_size_selection{};
 
     cl_uint m_max_cmd_batch_size;
     cl_uint m_max_first_cmd_batch_size;

--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -107,6 +107,7 @@ struct cvk_device_properties_intel : public cvk_device_properties {
         return "-hack-mul-extended -hack-convert-to-float "
                "-hack-image1d-buffer-bgra";
     }
+    uint32_t get_prefered_subgroup_size() const override final { return 16; }
     bool
     is_bgra_format_not_supported_for_image1d_buffer() const override final {
         return true;

--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -107,7 +107,7 @@ struct cvk_device_properties_intel : public cvk_device_properties {
         return "-hack-mul-extended -hack-convert-to-float "
                "-hack-image1d-buffer-bgra";
     }
-    uint32_t get_prefered_subgroup_size() const override final { return 16; }
+    uint32_t get_preferred_subgroup_size() const override final { return 16; }
     bool
     is_bgra_format_not_supported_for_image1d_buffer() const override final {
         return true;

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -52,6 +52,10 @@ struct cvk_device_properties {
         return std::set<std::string>();
     }
 
+    virtual uint32_t get_prefered_subgroup_size() const {
+        return config.prefered_subgroup_size();
+    }
+
     virtual bool is_non_uniform_decoration_broken() const { return false; }
 
     virtual bool is_bgra_format_not_supported_for_image1d_buffer() const {

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -52,8 +52,8 @@ struct cvk_device_properties {
         return std::set<std::string>();
     }
 
-    virtual uint32_t get_prefered_subgroup_size() const {
-        return config.prefered_subgroup_size();
+    virtual uint32_t get_preferred_subgroup_size() const {
+        return config.preferred_subgroup_size();
     }
 
     virtual bool is_non_uniform_decoration_broken() const { return false; }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -2165,10 +2165,18 @@ cvk_entry_point::create_pipeline(const cvk_spec_constant_map& spec_constants) {
     void* pipelineShaderStageCreateInfoPNext = nullptr;
     VkPipelineShaderStageRequiredSubgroupSizeCreateInfo
         reqdSubgroupSizeCreateInfo;
-    if (m_device->supports_controled_subgroups()) {
+    if (m_device->supports_subgroup_size_selection()) {
         auto reqdSubgroupSize = m_program->required_sub_group_size(m_name);
         if (reqdSubgroupSize > m_device->max_sub_group_size() ||
             reqdSubgroupSize < m_device->min_sub_group_size()) {
+            if (reqdSubgroupSize != 0) {
+                cvk_error_fn("required subgroup size '%u' for '%s' is out of "
+                             "the supported range [%u, %u]",
+                             reqdSubgroupSize, m_name.c_str(),
+                             m_device->min_sub_group_size(),
+                             m_device->max_sub_group_size());
+                return VK_NULL_HANDLE;
+            }
             reqdSubgroupSize = m_device->sub_group_size();
         }
         reqdSubgroupSizeCreateInfo.sType =

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -423,23 +423,20 @@ public:
                     const std::string& name);
 
     ~cvk_entry_point() {
+        VkDevice vkdev = m_device->vulkan_device();
         for (auto pipeline : m_pipelines) {
             cvk_info("destroying pipeline %p for kernel %s", pipeline.second,
                      m_name.c_str());
-            vkDestroyPipeline(m_device->vulkan_device(), pipeline.second,
-                              nullptr);
+            vkDestroyPipeline(vkdev, pipeline.second, nullptr);
         }
         if (m_descriptor_pool != VK_NULL_HANDLE) {
-            vkDestroyDescriptorPool(m_device->vulkan_device(),
-                                    m_descriptor_pool, nullptr);
+            vkDestroyDescriptorPool(vkdev, m_descriptor_pool, nullptr);
         }
         if (m_pipeline_layout != VK_NULL_HANDLE) {
-            vkDestroyPipelineLayout(m_device->vulkan_device(),
-                                    m_pipeline_layout, nullptr);
+            vkDestroyPipelineLayout(vkdev, m_pipeline_layout, nullptr);
         }
         for (auto layout : m_descriptor_set_layouts) {
-            vkDestroyDescriptorSetLayout(m_device->vulkan_device(), layout,
-                                         nullptr);
+            vkDestroyDescriptorSetLayout(vkdev, layout, nullptr);
         }
     }
 

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -26,6 +26,7 @@ add_gtest_executable(api_tests
     simple_image.cpp
     simple_ubo.cpp
     split_region.cpp
+    subgroup_size.cpp
     workgroup.cpp
 )
 

--- a/tests/api/subgroup_size.cpp
+++ b/tests/api/subgroup_size.cpp
@@ -1,0 +1,74 @@
+// Copyright 2024 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testcl.hpp"
+
+static const char* program_source = R"(
+#pragma OPENCL EXTENSION cl_khr_subgroups : enable
+%s__kernel void test(__global int *output)
+{
+    output[0] = get_num_sub_groups();
+}
+)";
+
+#ifdef CLVK_UNIT_TESTING_ENABLED
+TEST_F(WithCommandQueue, SubgroupSizes) {
+    std::vector<size_t> subgroup_sizes;
+    size_t raw_size;
+    GetDeviceInfo(CL_DEVICE_SUB_GROUP_SIZES_INTEL, 0, nullptr, &raw_size);
+    subgroup_sizes.resize(raw_size / sizeof(size_t));
+    GetDeviceInfo(CL_DEVICE_SUB_GROUP_SIZES_INTEL, raw_size,
+                  subgroup_sizes.data(), nullptr);
+
+    size_t max_work_group_size;
+    GetDeviceInfo(CL_DEVICE_MAX_WORK_GROUP_SIZE, sizeof(size_t),
+                  &max_work_group_size, nullptr);
+
+    auto buffer = CreateBuffer(0, sizeof(cl_int));
+
+    auto run = [this](const char* kernel_prefix, size_t subgroup_size,
+                      size_t max_work_group_size, cl_mem buffer) {
+        cl_int expected_num_sub_groups = max_work_group_size / subgroup_size;
+        size_t work_size = expected_num_sub_groups * subgroup_size;
+        char source[512];
+        sprintf(source, program_source, kernel_prefix);
+        auto kernel = CreateKernel(source, "test");
+        SetKernelArg(kernel, 0, buffer);
+        EnqueueNDRangeKernel(kernel, 1, nullptr, &work_size, &work_size);
+        Finish();
+        auto result =
+            EnqueueMapBuffer<cl_int>(buffer, true, 0, 0, sizeof(cl_int));
+#if 0
+        printf("\tkernel_prefix '%s' subgroup_size %lu max_work_group_size %lu "
+               "result %u expected %u\n",
+               kernel_prefix, subgroup_size, max_work_group_size, *result,
+               expected_num_sub_groups);
+#endif
+        ASSERT_EQ(expected_num_sub_groups, *result);
+        EnqueueUnmapMemObject(buffer, result);
+    };
+
+    for (auto subgroup_size : subgroup_sizes) {
+        char attribute[64];
+        sprintf(attribute, "__attribute__((intel_reqd_sub_group_size(%lu))) ",
+                subgroup_size);
+        run(attribute, subgroup_size, max_work_group_size, buffer);
+    }
+    for (auto subgroup_size : subgroup_sizes) {
+        auto cfg = CLVK_CONFIG_SCOPED_OVERRIDE(force_subgroup_size, uint32_t,
+                                               subgroup_size, true);
+        run("", subgroup_size, max_work_group_size, buffer);
+    }
+}
+#endif

--- a/tests/api/subgroup_size.cpp
+++ b/tests/api/subgroup_size.cpp
@@ -14,6 +14,8 @@
 
 #include "testcl.hpp"
 
+#ifdef CLVK_UNIT_TESTING_ENABLED
+
 static const char* program_source = R"(
 #pragma OPENCL EXTENSION cl_khr_subgroups : enable
 %s__kernel void test(__global int *output)
@@ -22,7 +24,6 @@ static const char* program_source = R"(
 }
 )";
 
-#ifdef CLVK_UNIT_TESTING_ENABLED
 TEST_F(WithCommandQueue, SubgroupSizes) {
     std::vector<size_t> subgroup_sizes;
     size_t raw_size;
@@ -42,7 +43,7 @@ TEST_F(WithCommandQueue, SubgroupSizes) {
         cl_int expected_num_sub_groups = max_work_group_size / subgroup_size;
         size_t work_size = expected_num_sub_groups * subgroup_size;
         char source[512];
-        sprintf(source, sizeof(source), program_source, kernel_prefix);
+        snprintf(source, sizeof(source), program_source, kernel_prefix);
         auto kernel = CreateKernel(source, "test");
         SetKernelArg(kernel, 0, buffer);
         EnqueueNDRangeKernel(kernel, 1, nullptr, &work_size, &work_size);
@@ -61,8 +62,9 @@ TEST_F(WithCommandQueue, SubgroupSizes) {
 
     for (auto subgroup_size : subgroup_sizes) {
         char attribute[64];
-        snprintf(attribute, sizeof(attribute), "__attribute__((intel_reqd_sub_group_size(%lu))) ",
-                subgroup_size);
+        snprintf(attribute, sizeof(attribute),
+                 "__attribute__((intel_reqd_sub_group_size(%lu))) ",
+                 subgroup_size);
         run(attribute, subgroup_size, max_work_group_size, buffer);
     }
     for (auto subgroup_size : subgroup_sizes) {

--- a/tests/api/subgroup_size.cpp
+++ b/tests/api/subgroup_size.cpp
@@ -42,7 +42,7 @@ TEST_F(WithCommandQueue, SubgroupSizes) {
         cl_int expected_num_sub_groups = max_work_group_size / subgroup_size;
         size_t work_size = expected_num_sub_groups * subgroup_size;
         char source[512];
-        sprintf(source, program_source, kernel_prefix);
+        sprintf(source, sizeof(source), program_source, kernel_prefix);
         auto kernel = CreateKernel(source, "test");
         SetKernelArg(kernel, 0, buffer);
         EnqueueNDRangeKernel(kernel, 1, nullptr, &work_size, &work_size);

--- a/tests/api/subgroup_size.cpp
+++ b/tests/api/subgroup_size.cpp
@@ -61,7 +61,7 @@ TEST_F(WithCommandQueue, SubgroupSizes) {
 
     for (auto subgroup_size : subgroup_sizes) {
         char attribute[64];
-        sprintf(attribute, "__attribute__((intel_reqd_sub_group_size(%lu))) ",
+        snprintf(attribute, sizeof(attribute), "__attribute__((intel_reqd_sub_group_size(%lu))) ",
                 subgroup_size);
         run(attribute, subgroup_size, max_work_group_size, buffer);
     }

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -744,6 +744,13 @@ protected:
         EnqueueFillImage(image, fill_color, origin, region, 0, nullptr,
                          nullptr);
     }
+
+    void GetDeviceInfo(cl_device_info param_name, size_t param_value_size,
+                       void* param_value, size_t* param_value_size_ret) {
+        auto err = clGetDeviceInfo(device(), param_name, param_value_size,
+                                   param_value, param_value_size_ret);
+        ASSERT_CL_SUCCESS(err);
+    }
 };
 
 class WithProfiledCommandQueue : public WithCommandQueue {


### PR DESCRIPTION
This PR fix an issue on Intel device where the subgroup size used by the compiler is not the default one exposed by the vulkan driver through `m_subgroup_properties.subgroupSize`. It leads to error when running CTS `test_api sub_group_dispatch` as the expected number of subgroup does not match the one seen during execution.

To fix that, this PR uses
`VkPipelineShaderStageRequiredSubgroupSizeCreateInfo` to force the subgroup size used by the compiler.

Doing so, it breaks TFLite because it assumes that the subgroup size is always 16. Which used to work by luck because it was the size used by the compiler for the kernel using subgroups on application I have tried.
But now the default size exposed by vulkan is 32, thus kernels are compiled with subgroup size of 32.

To avoid breaking TFLite, this PR implements a subpart of `cl_intel_subgroups` which is enough for TFLite to use this extension and specify the subgroup size inside the kernel using `__attribute__((intel_reqd_sub_group_size))`.

This PR also adds 2 config variable. One to set a prefered subgroup size to use if nothing is specified. Another to set a force subgroup size overriding everything. This aims at allowing easy debug if/when we will be facing other issues with subgroup size.