### PR TITLE
allow to disable support for sampler with linear filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ variables. Here's a quick guide:
     * `0x00c00000`: meaning `CL3.0` (default)
     * `0x00402000`: meaning `CL1.2`
 
-* `CLVK_SUPPORTS_LINEAR_FILTER` specifies if using sampler with
+* `CLVK_SUPPORTS_LINEAR_FILTER` specifies whether using samplers with
   `CL_FILTER_LINEAR` is supported (default: `true`). Note that this is not
   required by the OpenCL-CTS, thus can be switch to false to have a conformant
   implementation on some platform.

--- a/README.md
+++ b/README.md
@@ -430,6 +430,11 @@ variables. Here's a quick guide:
     * `0x00c00000`: meaning `CL3.0` (default)
     * `0x00402000`: meaning `CL1.2`
 
+* `CLVK_SUPPORTS_LINEAR_FILTER` specifies if using sampler with
+  `CL_FILTER_LINEAR` is supported (default: `true`). Note that this is not
+  required by the OpenCL-CTS, thus can be switch to false to have a conformant
+  implementation on some platform.
+
 # Limitations
 
 * Only one device per CL context

--- a/README.md
+++ b/README.md
@@ -432,8 +432,9 @@ variables. Here's a quick guide:
 
 * `CLVK_SUPPORTS_LINEAR_FILTER` specifies whether using samplers with
   `CL_FILTER_LINEAR` is supported (default: `true`). Note that this is not
-  required by the OpenCL-CTS, thus can be switch to false to have a conformant
-  implementation on some platform.
+  required for OpenCL conformance on GPU devices and thus can be disabled to pass
+  conformance on devices that do not support linear filtering with all the image formats
+  required for conformance.
 
 # Limitations
 

--- a/src/config.def
+++ b/src/config.def
@@ -49,6 +49,8 @@ OPTION(uint32_t, max_first_cmd_group_size, UINT32_MAX)
 
 OPTION(uint32_t, max_entry_points_instances, 2*1024u) // FIXME find a better definition
 
+OPTION(bool, supports_filter_linear, true)
+
 //
 // Logging
 //

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -183,6 +183,11 @@ bool cvk_sampler::init(bool force_normalized_coordinates) {
         break;
     }
 
+    if (!config.supports_filter_linear && m_filter_mode == CL_FILTER_LINEAR) {
+        cvk_error_fn("linear filter is not supported");
+        return false;
+    }
+
     // Translate filtering
     VkFilter filter;
     VkSamplerMipmapMode mipmap_mode;
@@ -263,9 +268,11 @@ cvk_image::required_format_feature_flags_for(cl_mem_object_type type,
     if (type == CL_MEM_OBJECT_IMAGE1D_BUFFER) {
         format_feature_flags_RO = VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT;
     } else {
-        format_feature_flags_RO =
-            VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT |
-            VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
+        format_feature_flags_RO = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
+        if (config.supports_filter_linear()) {
+            format_feature_flags_RO |=
+                VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
+        }
     }
     VkFormatFeatureFlags format_feature_flags_WO;
     if (type == CL_MEM_OBJECT_IMAGE1D_BUFFER) {


### PR DESCRIPTION
This is needing for some platform to pass CTS as linear filtering is not required.