### PR TITLE
Add utilities to write tests that assume or require specific config options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ if (CLVK_ENABLE_UBSAN)
   add_link_options(-fsanitize=undefined)
 endif()
 
+if(WIN32)
+  add_compile_definitions(NOMINMAX)
+endif()
+
 # Options
 option(CLVK_CLSPV_ONLINE_COMPILER "Use the Clspv C++ API for compilation of kernels")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,6 @@ endif()
 
 # Options
 option(CLVK_CLSPV_ONLINE_COMPILER "Use the Clspv C++ API for compilation of kernels")
-if (CLVK_CLSPV_ONLINE_COMPILER)
-  add_compile_options(-DCLSPV_ONLINE_COMPILER)
-endif()
 
 option(CLVK_COMPILER_AVAILABLE "Enable compiler support" ON)
 if (NOT CLVK_COMPILER_AVAILABLE AND CLVK_CLSPV_ONLINE_COMPILER)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 add_library(clvk-config-definitions INTERFACE)
 
 if (CLVK_CLSPV_ONLINE_COMPILER)
-  target_compile_definitions(clvk-config-definitions CLSPV_ONLINE_COMPILER=1)
+  target_compile_definitions(clvk-config-definitions INTERFACE CLSPV_ONLINE_COMPILER=1)
 endif()
 
 if (CLVK_COMPILER_AVAILABLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -174,11 +174,6 @@ if (CLVK_COMPILER_AVAILABLE AND CLVK_ENABLE_SPIRV_IL)
     DEFAULT_LLVMSPIRV_BINARY_PATH="$<TARGET_FILE:llvm-spirv>")
 endif()
 
-if(WIN32)
-	target_compile_definitions(OpenCL-objects PRIVATE
-		NOMINMAX)
-endif()
-
 option(CLVK_ENABLE_TIMING "Enable timing of clvk internals" OFF)
 if (CLVK_ENABLE_TIMING)
 	target_compile_definitions(OpenCL-objects PRIVATE CVK_ENABLE_TIMING)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,17 +32,27 @@ if (UNIX AND NOT APPLE)
         "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
 endif()
 
-if (CLVK_COMPILER_AVAILABLE)
-    add_compile_options(-DCOMPILER_AVAILABLE=1)
-    if (CLVK_ENABLE_SPIRV_IL)
-        add_compile_options(-DENABLE_SPIRV_IL=1)
-    endif()
-endif()
-
 if (${CLVK_VULKAN_IMPLEMENTATION} STREQUAL swiftshader)
     add_compile_options(-DUSING_SWIFTSHADER=1)
 endif()
 
+# Config macros
+# These are made available to all targets linking against OpenCL so they can
+# correctly use the config in config.def
+add_library(clvk-config-definitions INTERFACE)
+
+if (CLVK_CLSPV_ONLINE_COMPILER)
+  target_compile_definitions(clvk-config-definitions CLSPV_ONLINE_COMPILER=1)
+endif()
+
+if (CLVK_COMPILER_AVAILABLE)
+    target_compile_definitions(clvk-config-definitions INTERFACE COMPILER_AVAILABLE=1)
+    if (CLVK_ENABLE_SPIRV_IL)
+        target_compile_definitions(clvk-config-definitions INTERFACE ENABLE_SPIRV_IL=1)
+    endif()
+endif()
+
+# Core objects
 add_library(OpenCL-objects OBJECT
   api.cpp
   config.cpp
@@ -64,6 +74,7 @@ add_library(OpenCL-objects OBJECT
   utils.cpp
   exports.map
 )
+target_link_libraries(OpenCL-objects clvk-config-definitions)
 
 if (CLVK_UNIT_TESTING)
    target_compile_definitions(OpenCL-objects PUBLIC CLVK_UNIT_TESTING_ENABLED)
@@ -107,7 +118,7 @@ if (CLVK_PERFETTO_ENABLE)
   )
   set_property(CACHE CLVK_PERFETTO_BACKEND PROPERTY STRINGS ${CLVK_PERFETTO_BACKEND_OPTIONS})
   if (${CLVK_PERFETTO_BACKEND} STREQUAL InProcess)
-    target_compile_definitions(OpenCL-objects PUBLIC CLVK_PERFETTO_BACKEND_INPROCESS)
+      target_compile_definitions(clvk-config-definitions INTERFACE CLVK_PERFETTO_BACKEND_INPROCESS)
   endif()
 
   target_compile_definitions(OpenCL-objects PUBLIC CLVK_PERFETTO_ENABLE)
@@ -133,6 +144,8 @@ if (CLVK_COMPILER_AVAILABLE)
   set(OpenCL-dependencies ${OpenCL-dependencies} SPIRV-Tools-link)
 endif()
 
+
+
 # The reflection parser requires the headers.
 target_include_directories(OpenCL-objects PRIVATE
   "${CLSPV_SOURCE_DIR}/include")
@@ -146,8 +159,8 @@ if (CLVK_CLSPV_ONLINE_COMPILER)
 else()
   if (CLVK_COMPILER_AVAILABLE)
     add_dependencies(OpenCL-objects clspv)
-    target_compile_definitions(OpenCL-objects PRIVATE
-    DEFAULT_CLSPV_BINARY_PATH="$<TARGET_FILE:clspv>")
+    target_compile_definitions(clvk-config-definitions INTERFACE
+      DEFAULT_CLSPV_BINARY_PATH="$<TARGET_FILE:clspv>")
   endif()
 endif()
 
@@ -157,7 +170,7 @@ if (CLVK_COMPILER_AVAILABLE AND CLVK_ENABLE_SPIRV_IL)
   add_dependencies(OpenCL-objects llvm-spirv)
   set_target_properties(llvm-spirv PROPERTIES RUNTIME_OUTPUT_DIRECTORY
     ${CMAKE_BINARY_DIR})
-  target_compile_definitions(OpenCL-objects PRIVATE
+  target_compile_definitions(clvk-config-definitions INTERFACE
     DEFAULT_LLVMSPIRV_BINARY_PATH="$<TARGET_FILE:llvm-spirv>")
 endif()
 
@@ -173,7 +186,8 @@ endif()
 
 function(CLLibrary target type)
   add_library(${target} ${type} $<TARGET_OBJECTS:OpenCL-objects>)
-  target_link_libraries(${target} ${OpenCL-dependencies})
+  target_link_libraries(${target} ${OpenCL-dependencies}
+      clvk-config-definitions)
   set_target_properties(${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY
       ${CMAKE_BINARY_DIR})
 endfunction(CLLibrary)

--- a/src/exports.map
+++ b/src/exports.map
@@ -2,7 +2,7 @@ CLVK_UNIT_TESTING_FCT {
 global:
     clvk_override_device_max_compute_work_group_count;
     clvk_restore_device_properties;
-    clvk_override_printf_buffer_size;
+    clvk_get_config;
 local:
     *;
 };

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -40,12 +40,11 @@ void CL_API_CALL clvk_restore_device_properties(cl_device_id device) {
 #endif
 }
 
-void CL_API_CALL clvk_override_printf_buffer_size(uint32_t size) {
+const config_struct* CL_API_CALL clvk_get_config() {
 #ifdef CLVK_UNIT_TESTING_ENABLED
-    auto printf_buffer_size =
-        (config_value<uint32_t>*)&config.printf_buffer_size;
-    printf_buffer_size->value = size;
-    printf_buffer_size->set = true;
+    return &config;
+#else
+    return nullptr;
 #endif
 }
-}
+} // extern "C"

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -29,6 +29,8 @@ TEST_F(WithCommandQueue, ManyInstancesInFlight) {
     }
     )";
 
+    CLVK_CONFIG_ASSERT_GT(max_entry_points_instances, NUM_INSTANCES);
+
     // Create kernel
     auto kernel = CreateKernel(program_source, "test_simple");
 

--- a/tests/api/printf.cpp
+++ b/tests/api/printf.cpp
@@ -131,7 +131,8 @@ TEST_F(WithCommandQueue, SimplePrintf) {
 TEST_F(WithCommandQueue, TooLongPrintf) {
     // each print takes 12 bytes (4 for the printf_id, and 2*4 for the 2 integer
     // to print) + 4 for the byte written counter
-    clvk_override_printf_buffer_size(28);
+    auto cfg1 =
+        CLVK_CONFIG_SCOPED_OVERRIDE(printf_buffer_size, uint32_t, 28, true);
 
     temp_folder_deletion temp;
     stdoutFileName = getStdoutFileName(temp);
@@ -167,7 +168,8 @@ TEST_F(WithCommandQueue, TooLongPrintf2) {
     // each print takes 12 bytes (4 for the printf_id, and 2*4 for the 2 integer
     // to print) + 4 for the byte written counter + 8 which are not enough for
     // the third print, but should not cause any issue in clvk
-    clvk_override_printf_buffer_size(36);
+    auto cfg1 =
+        CLVK_CONFIG_SCOPED_OVERRIDE(printf_buffer_size, uint32_t, 36, true);
 
     temp_folder_deletion temp;
     stdoutFileName = getStdoutFileName(temp);

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -35,6 +35,11 @@
 #define CL_USE_DEPRECATED_OPENCL_2_2_APIS
 #include "CL/cl.h"
 
+#include "unit.hpp"
+
+#define CLVK_CONFIG_ASSERT_GT(opt, val)                                        \
+    ASSERT_GT(clvk_get_config()->opt.value, val)
+
 // clang-format off
 static inline const char* cl_code_to_string(cl_int code) {
 #define code_case(X)                                                           \

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -35,10 +35,14 @@
 #define CL_USE_DEPRECATED_OPENCL_2_2_APIS
 #include "CL/cl.h"
 
+#ifdef CLVK_UNIT_TESTING_ENABLED
 #include "unit.hpp"
 
 #define CLVK_CONFIG_ASSERT_GT(opt, val)                                        \
     ASSERT_GT(clvk_get_config()->opt.value, val)
+#else
+#define CLVK_CONFIG_ASSERT_GT(opt, val)
+#endif
 
 // clang-format off
 static inline const char* cl_code_to_string(cl_int code) {


### PR DESCRIPTION
- Fix printf tests so they don't mutate the global config with impact to other tests. Restore the config at the end of the test.
- Check assumptions tests make on config values.

Tests from the API suite CANNOT be run in parallel with the current implementation.

Change-Id: I22a7bbae4ae13b224fa094bd5d01a97e8fd4e5c0