### PR TITLE
Tidy up management of per-device disabled image formats

### DIFF
--- a/src/device.hpp
+++ b/src/device.hpp
@@ -561,8 +561,8 @@ struct cvk_device : public _cl_device_id,
     }
 
     bool is_image_format_disabled(cl_image_format format) const {
-        return m_clvk_properties->get_unsupported_image_format().count(
-                   format) != 0;
+        return m_clvk_properties->get_disabled_image_formats().count(format) !=
+               0;
     }
 
 private:

--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -112,8 +112,10 @@ struct cvk_device_properties_intel : public cvk_device_properties {
         return true;
     }
 
-    image_format_set get_unsupported_image_format() const override final {
-        return image_format_set({{CL_RGB, CL_UNORM_SHORT_565}});
+    const image_format_set& get_disabled_image_formats() const override final {
+        static image_format_set disabled_formats(
+            {{CL_RGB, CL_UNORM_SHORT_565}});
+        return disabled_formats;
     }
 };
 

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -17,9 +17,11 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <unordered_set>
 
 #include "cl_headers.hpp"
 #include "config.hpp"
+#include "image_format.hpp"
 
 struct cvk_device_properties {
     virtual std::string vendor() const { return "Unknown vendor"; }
@@ -56,16 +58,12 @@ struct cvk_device_properties {
         return false;
     }
 
-    struct ClFormatSetCompare {
-        int operator()(const cl_image_format& lhs,
-                       const cl_image_format& rhs) const {
-            return lhs.image_channel_order > rhs.image_channel_order ||
-                   (lhs.image_channel_order == rhs.image_channel_order &&
-                    lhs.image_channel_data_type > rhs.image_channel_data_type);
-        }
-    };
-    using image_format_set = std::set<cl_image_format, ClFormatSetCompare>;
-    virtual image_format_set get_unsupported_image_format() const { return {}; }
+    using image_format_set =
+        std::unordered_set<cl_image_format, ClFormatHash, ClFormatEqual>;
+    virtual const image_format_set& get_disabled_image_formats() const {
+        static image_format_set no_disabled_formats{};
+        return no_disabled_formats;
+    }
 
     virtual ~cvk_device_properties() {}
 };

--- a/src/image_format.hpp
+++ b/src/image_format.hpp
@@ -22,14 +22,14 @@
 
 struct cvk_device;
 
-struct ClFormatMapHash {
+struct ClFormatHash {
     size_t operator()(const cl_image_format& format) const {
         return format.image_channel_order << 16 |
                format.image_channel_data_type;
     }
 };
 
-struct ClFormatMapEqual {
+struct ClFormatEqual {
     bool operator()(const cl_image_format& lhs,
                     const cl_image_format& rhs) const {
         return lhs.image_channel_order == rhs.image_channel_order &&
@@ -54,8 +54,8 @@ struct image_format_support {
 };
 
 using format_mapping_map =
-    std::unordered_map<cl_image_format, image_format_support, ClFormatMapHash,
-                       ClFormatMapEqual>;
+    std::unordered_map<cl_image_format, image_format_support, ClFormatHash,
+                       ClFormatEqual>;
 
 const format_mapping_map& get_format_maps();
 


### PR DESCRIPTION
- Use an unordered_set and existing functors from image_format.hpp
- Rename the device properties function to match the users
- Use function scope static objects to store the set of disabled formats

Change-Id: I9e3b5a66bae9abd29ce8e41e74ea9e2ad7c8df0b