### PR TITLE
fix WithCommandQueue.EnqueueTooManyCommands

### DIFF
--- a/src/config.def
+++ b/src/config.def
@@ -87,4 +87,5 @@ OPTION(std::string, perfetto_trace_dest, "clvk.perfetto-trace")
 //
 #if CLVK_UNIT_TESTING_ENABLED
 OPTION(bool, force_descriptor_set_allocation_failure, false)
+OPTION(bool, early_flush_enabled, true)
 #endif

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -231,6 +231,12 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
         cvk_debug_fn("returning event %p", *event);
     }
 
+#ifdef CLVK_UNIT_TESTING_ENABLED
+    if (!config.early_flush_enabled) {
+        return CL_SUCCESS;
+    }
+#endif
+
     auto group_size = m_groups.back()->commands.size();
     if (group_size >= m_max_cmd_group_size ||
         (m_nb_group_in_flight == 0 &&

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -456,10 +456,9 @@ TEST_F(WithCommandQueue, EnqueueTooManyCommands) {
     auto cfg_force_descriptor_set_allocation_failure =
         CLVK_CONFIG_SCOPED_OVERRIDE(force_descriptor_set_allocation_failure,
                                     bool, true, true);
+    auto cfg_early_flush_enabled =
+        CLVK_CONFIG_SCOPED_OVERRIDE(early_flush_enabled, bool, false, true);
     CLVK_CONFIG_ASSERT_EQ(enqueue_command_retry_sleep_us, UINT32_MAX);
-    // We need to make sure that the kernel don't start executing before we
-    // enqueue one too many
-    CLVK_CONFIG_ASSERT_GT(max_first_cmd_batch_size, NUM_INSTANCES);
 
     // Create kernel
     auto kernel = CreateKernel(program_source, "test_simple");
@@ -504,9 +503,8 @@ TEST_F(WithCommandQueue, EnqueueTooManyCommandsWithRetry) {
                                     bool, true, true);
     auto cfg_enqueue_command_retry_sleep_us = CLVK_CONFIG_SCOPED_OVERRIDE(
         enqueue_command_retry_sleep_us, uint32_t, 100, true);
-    // We need to make sure that the kernel don't start executing before we
-    // enqueue one too many
-    CLVK_CONFIG_ASSERT_GT(max_first_cmd_batch_size, NUM_INSTANCES);
+    auto cfg_early_flush_enabled =
+        CLVK_CONFIG_SCOPED_OVERRIDE(early_flush_enabled, bool, false, true);
 
     // Create kernel
     auto kernel = CreateKernel(program_source, "test_simple");


### PR DESCRIPTION
When using hardware that override max_first_cmd_group/batch_size in device_properties, this test is not passing.

As those properties are set much before the scope of the test and are not reevaluate later, we cannot override them in the test.

Fix the test by adding a not config to prevent early flush when testing.