### PR TITLE
update nvidia device properties (remove fabs)

### DIFF
--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -228,17 +228,17 @@ struct cvk_device_properties_nvidia : public cvk_device_properties {
     std::string vendor() const override final { return "NVIDIA Corporation"; }
     const std::set<std::string> get_native_builtins() const override final {
         return std::set<std::string>({
-            "acos",        "acosh",          "acospi",      "asin",
-            "asinh",       "asinpi",         "atan",        "atan2",
-            "atan2pi",     "atanh",          "atanpi",      "ceil",
-            "copysign",    "fabs",           "fdim",        "floor",
-            "fma",         "fmax",           "fmin",        "frexp",
-            "half_rsqrt",  "half_sqrt",      "isequal",     "isfinite",
-            "isgreater",   "isgreaterequal", "isinf",       "isless",
-            "islessequal", "islessgreater",  "isnan",       "isnormal",
-            "isnotequal",  "isordered",      "isunordered", "ldexp",
-            "mad",         "rint",           "round",       "rsqrt",
-            "signbit",     "sqrt",           "tanh",        "trunc",
+            "acos",           "acosh",       "acospi",   "asin",
+            "asinh",          "asinpi",      "atan",     "atan2",
+            "atan2pi",        "atanh",       "atanpi",   "ceil",
+            "copysign",       "fdim",        "floor",    "fma",
+            "fmax",           "fmin",        "frexp",    "half_rsqrt",
+            "half_sqrt",      "isequal",     "isfinite", "isgreater",
+            "isgreaterequal", "isinf",       "isless",   "islessequal",
+            "islessgreater",  "isnan",       "isnormal", "isnotequal",
+            "isordered",      "isunordered", "ldexp",    "mad",
+            "rint",           "round",       "rsqrt",    "signbit",
+            "sqrt",           "tanh",        "trunc",
         });
     }
 };


### PR DESCRIPTION
update of llvm & builtins libraries in clspv change the implementation of nextafter and remainder that now requires fabs to use the "emulated" implementation.

https://github.com/google/clspv/pull/1326