### PR TITLE
fix end_current_command_batch following enqueue_retry implementation

### DIFF
--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -279,7 +279,7 @@ cl_int cvk_command_queue::enqueue_command_with_deps(
 }
 
 cl_int cvk_command_queue::end_current_command_batch() {
-    if (m_command_batch) {
+    if (m_command_batch && m_command_batch->batch_size() > 0) {
         TRACE_FUNCTION("queue", (uintptr_t)this, "batch_size",
                        m_command_batch->batch_size());
 


### PR DESCRIPTION
Since we are able to fail an enqueue to retry later on, we have a scenario where `m_command_buffer` has been allocated during `add_command` (in `cvk_command_batch`) but the `build` has failed. Then, in `enqueue_command_with_retry` we can end up calling `end_current_command_batch` which would try to enqueue an empty command buffer.

This scenario leads to different issues later on in the flow with the command buffer trying to be executed while not having any command in it.