### PR TITLE
Avoid creating a thread to build program when not needed

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -2303,21 +2303,8 @@ clBuildProgram(cl_program prog, cl_uint num_devices,
     // clCreateProgramWithSource or clCreateProgramWithBinary or
     // clCreateProgramWithILKHR.
 
-    if (!program->build(build_op, num_devices, device_list, options, 0, nullptr,
-                        nullptr, pfn_notify, user_data)) {
-        return CL_INVALID_OPERATION;
-    }
-
-    if (pfn_notify == nullptr) {
-
-        program->wait_for_operation();
-
-        if (program->build_status() != CL_BUILD_SUCCESS) {
-            return CL_BUILD_PROGRAM_FAILURE;
-        }
-    }
-
-    return CL_SUCCESS;
+    return program->build(build_op, num_devices, device_list, options, 0,
+                          nullptr, nullptr, pfn_notify, user_data);
 }
 
 cl_int CLVK_API_CALL clCompileProgram(
@@ -2374,22 +2361,9 @@ cl_int CLVK_API_CALL clCompileProgram(
     }
 
     // TODO Validate program
-    if (!program->build(build_operation::compile, num_devices, device_list,
-                        options, num_input_headers, input_headers,
-                        header_include_names, pfn_notify, user_data)) {
-        return CL_INVALID_OPERATION;
-    }
-
-    if (pfn_notify == nullptr) {
-
-        program->wait_for_operation();
-
-        if (program->build_status() != CL_BUILD_SUCCESS) {
-            return CL_BUILD_PROGRAM_FAILURE;
-        }
-    }
-
-    return CL_SUCCESS;
+    return program->build(build_operation::compile, num_devices, device_list,
+                          options, num_input_headers, input_headers,
+                          header_include_names, pfn_notify, user_data);
 }
 
 cl_program CLVK_API_CALL clLinkProgram(
@@ -2470,29 +2444,12 @@ cl_program CLVK_API_CALL clLinkProgram(
 
     cvk_program* prog_ret = new cvk_program(icd_downcast(context));
 
-    if (!prog_ret->build(build_operation::link, num_devices, device_list,
-                         options, num_input_programs, input_programs, nullptr,
-                         pfn_notify, user_data)) {
-        if (errcode_ret != nullptr) {
-            *errcode_ret = CL_INVALID_OPERATION;
-        }
-        return nullptr;
-    }
-
-    if (pfn_notify == nullptr) {
-
-        prog_ret->wait_for_operation();
-
-        if (prog_ret->build_status() != CL_BUILD_SUCCESS) {
-            if (errcode_ret != nullptr) {
-                *errcode_ret = CL_LINK_PROGRAM_FAILURE;
-            }
-            return nullptr;
-        }
-    }
+    cl_int ret = prog_ret->build(
+        build_operation::link, num_devices, device_list, options,
+        num_input_programs, input_programs, nullptr, pfn_notify, user_data);
 
     if (errcode_ret != nullptr) {
-        *errcode_ret = CL_SUCCESS;
+        *errcode_ret = ret;
     }
 
     return prog_ret;

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1633,12 +1633,12 @@ void cvk_program::do_build() {
     complete_operation(device, CL_BUILD_SUCCESS);
 }
 
-bool cvk_program::build(build_operation operation, cl_uint num_devices,
-                        const cl_device_id* device_list, const char* options,
-                        cl_uint num_input_programs,
-                        const cl_program* input_programs,
-                        const char** header_include_names,
-                        cvk_program_callback cb, void* data) {
+cl_int cvk_program::build(build_operation operation, cl_uint num_devices,
+                          const cl_device_id* device_list, const char* options,
+                          cl_uint num_input_programs,
+                          const cl_program* input_programs,
+                          const char** header_include_names,
+                          cvk_program_callback cb, void* data) {
     std::lock_guard<std::mutex> lock(m_lock);
 
     // Check if there is already a build in progress
@@ -1647,7 +1647,7 @@ bool cvk_program::build(build_operation operation, cl_uint num_devices,
                       [](auto& status) {
                           return status.second == CL_BUILD_IN_PROGRESS;
                       })) {
-        return false;
+        return CL_INVALID_OPERATION;
     }
 
     retain();
@@ -1681,13 +1681,30 @@ bool cvk_program::build(build_operation operation, cl_uint num_devices,
     m_operation_callback = cb;
     m_operation_callback_data = data;
 
-    // Kick off build
-    m_thread = std::make_unique<std::thread>(&cvk_program::do_build, this);
+    cl_int ret = CL_SUCCESS;
     if (cb) {
+        // Kick off build
+        m_thread = std::make_unique<std::thread>(&cvk_program::do_build, this);
         m_thread->detach();
+    } else {
+        do_build();
+        if (build_status() != CL_BUILD_SUCCESS) {
+            switch (operation) {
+            case build_operation::link:
+                ret = CL_LINK_PROGRAM_FAILURE;
+                break;
+            case build_operation::build:
+            case build_operation::build_binary:
+                ret = CL_BUILD_PROGRAM_FAILURE;
+                break;
+            case build_operation::compile:
+                ret = CL_COMPILE_PROGRAM_FAILURE;
+                break;
+            }
+            CVK_ASSERT(ret != CL_SUCCESS);
+        }
     }
-
-    return true;
+    return ret;
 }
 
 cvk_entry_point::cvk_entry_point(cvk_device* dev, cvk_program* program,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -614,12 +614,12 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
                  (binary_type(dev) == CL_PROGRAM_BINARY_TYPE_LIBRARY)));
     }
 
-    CHECK_RETURN bool build(build_operation operation, cl_uint num_devices,
-                            const cl_device_id* device_list,
-                            const char* options, cl_uint num_input_programs,
-                            const cl_program* input_programs,
-                            const char** header_include_names,
-                            cvk_program_callback cb, void* data);
+    CHECK_RETURN cl_int build(build_operation operation, cl_uint num_devices,
+                              const cl_device_id* device_list,
+                              const char* options, cl_uint num_input_programs,
+                              const cl_program* input_programs,
+                              const char** header_include_names,
+                              cvk_program_callback cb, void* data);
 
     cl_int set_user_spec_constant(uint32_t spec_id, size_t spec_size,
                                   const void* spec_value) {
@@ -666,11 +666,6 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
     }
 
     VkShaderModule shader_module() const { return m_shader_module; }
-
-    void wait_for_operation() {
-        CVK_ASSERT(m_thread->joinable());
-        m_thread->join();
-    }
 
     void complete_operation(cvk_device* device, cl_build_status status) {
         m_dev_status[device] = status;


### PR DESCRIPTION
If no callback is given, do not build in a thread. The goal is to make perfetto more readable by reducing the number of thread used only for a very small instant.
It may also reduce build time, but honestly this is less than 1%.