### PR TITLE
change file config order

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ and/or environment variables. clvk attempts to get its configuration from the
 following sources (in the order documented here). Values obtained from each
 source take precedence over previously obtained values.
 
-1. Configuration file in `/usr/local/etc/clvk.conf`
-2. System-wide configuration in `/etc/clvk.conf`
+1. System-wide configuration in `/etc/clvk.conf`
+2. Configuration file in `/usr/local/etc/clvk.conf`
 3. Per-user configuration in `~/.config/clvk.conf`
 4. `clvk.conf` in the current directory
 5. An additional configuration file specified using the `CLVK_CONFIG_FILE`

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -127,8 +127,8 @@ void parse_config_file() {
     std::ifstream config_stream;
 
     std::vector<std::string> config_file_paths;
-    config_file_paths.push_back("/usr/local/etc/clvk.conf");
     config_file_paths.push_back("/etc/clvk.conf");
+    config_file_paths.push_back("/usr/local/etc/clvk.conf");
     config_file_paths.push_back("~/.config/clvk.conf");
     config_file_paths.push_back(
         (std::filesystem::current_path() / conf_file).string());


### PR DESCRIPTION
It makes more sense to start from the most global location, which means starting with `/etc/clvk.conf`.