### PR TITLE
tests/api/images: force unmap/release to be perform after check

### DIFF
--- a/tests/api/images.cpp
+++ b/tests/api/images.cpp
@@ -727,7 +727,12 @@ TEST_F(WithCommandQueue, 1DBufferImageUnmapAfterRelease) {
         buffer,                       // buffer
     };
 
+    // clvk controller can decide to submit command directly after being
+    // enqueued. As we need to make sure that the unmap command will not be
+    // executed before we call Finish, we add this event to garantee this
+    // property.
     auto event = CreateUserEvent();
+
     auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc);
 
     std::atomic<bool> destructor_called = false;
@@ -771,7 +776,12 @@ TEST_F(WithCommandQueue, 1DBufferImageReleaseAfterUnmap) {
         buffer,                       // buffer
     };
 
+    // clvk controller can decide to submit command directly after being
+    // enqueued. As we need to make sure that the unmap command will not be
+    // executed before we call Finish, we add this event to garantee this
+    // property.
     auto event = CreateUserEvent();
+
     auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc);
 
     std::atomic<bool> destructor_called = false;

--- a/tests/api/images.cpp
+++ b/tests/api/images.cpp
@@ -729,7 +729,7 @@ TEST_F(WithCommandQueue, 1DBufferImageUnmapAfterRelease) {
 
     // clvk controller can decide to submit command directly after being
     // enqueued. As we need to make sure that the unmap command will not be
-    // executed before we call Finish, we add this event to garantee this
+    // executed before we call Finish, we add this event to guarantee this
     // property.
     auto event = CreateUserEvent();
 

--- a/tests/api/images.cpp
+++ b/tests/api/images.cpp
@@ -778,7 +778,7 @@ TEST_F(WithCommandQueue, 1DBufferImageReleaseAfterUnmap) {
 
     // clvk controller can decide to submit command directly after being
     // enqueued. As we need to make sure that the unmap command will not be
-    // executed before we call Finish, we add this event to garantee this
+    // executed before we call Finish, we add this event to guarantee this
     // property.
     auto event = CreateUserEvent();
 

--- a/tests/api/images.cpp
+++ b/tests/api/images.cpp
@@ -727,6 +727,7 @@ TEST_F(WithCommandQueue, 1DBufferImageUnmapAfterRelease) {
         buffer,                       // buffer
     };
 
+    auto event = CreateUserEvent();
     auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc);
 
     std::atomic<bool> destructor_called = false;
@@ -742,9 +743,11 @@ TEST_F(WithCommandQueue, 1DBufferImageUnmapAfterRelease) {
     clReleaseMemObject(released_image);
     EXPECT_FALSE(destructor_called);
 
-    EnqueueUnmapMemObject(released_image, map_ptr);
+    EnqueueUnmapMemObject(released_image, map_ptr, 1, (const cl_event*)&event,
+                          nullptr);
     EXPECT_FALSE(destructor_called);
 
+    SetUserEventStatus(event, CL_COMPLETE);
     Finish();
     EXPECT_TRUE(destructor_called);
 }
@@ -768,6 +771,7 @@ TEST_F(WithCommandQueue, 1DBufferImageReleaseAfterUnmap) {
         buffer,                       // buffer
     };
 
+    auto event = CreateUserEvent();
     auto image = CreateImage(CL_MEM_READ_WRITE, &format, &desc);
 
     std::atomic<bool> destructor_called = false;
@@ -779,13 +783,14 @@ TEST_F(WithCommandQueue, 1DBufferImageReleaseAfterUnmap) {
     auto map_ptr = EnqueueMapImage<cl_uchar>(image, CL_TRUE, 0, origin, region,
                                              nullptr, nullptr);
 
-    EnqueueUnmapMemObject(image, map_ptr);
+    EnqueueUnmapMemObject(image, map_ptr, 1, (const cl_event*)&event, nullptr);
     EXPECT_FALSE(destructor_called);
 
     cl_mem released_image = image.release();
     clReleaseMemObject(released_image);
     EXPECT_FALSE(destructor_called);
 
+    SetUserEventStatus(event, CL_COMPLETE);
     Finish();
     EXPECT_TRUE(destructor_called);
 }


### PR DESCRIPTION
Depending on values in device_properties, some platform can perform the unmap when the function is called, not when the app calls clFinish.
Force this behavior by adding a userevent to control when the unmap can be performed.

It might also fix flakyness in github CI. Not too sure.