### PR TITLE
fix TRACE_CNT_VAR_INIT() for Perfetto uprev

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -120,7 +120,7 @@ jobs:
           PERFETTO_DIR: ${{ github.workspace }}/external/perfetto
         run: |
           echo "perfettodir=${PERFETTO_DIR}" >> $GITHUB_ENV
-          git clone --depth 1 --branch v39.0 https://android.googlesource.com/platform/external/perfetto ${PERFETTO_DIR}
+          git clone --depth 1 --branch v46.0 https://android.googlesource.com/platform/external/perfetto ${PERFETTO_DIR}
           ${PERFETTO_DIR}/tools/install-build-deps
           ${PERFETTO_DIR}/tools/setup_all_configs.py
           ${PERFETTO_DIR}/tools/ninja -C ${PERFETTO_DIR}/out/linux_clang_release trace_processor_shell

--- a/README.md
+++ b/README.md
@@ -188,13 +188,13 @@ $ LD_LIBRARY_PATH=./build ./build/simple_test
 
 > Perfetto is a production-grade open-source stack for performance instrumentation and trace analysis. It offers services and libraries and for recording system-level and app-level traces, native + java heap profiling, a library for analyzing traces using SQL and a web-based UI to visualize and explore multi-GB traces.
 >
-> -- https://github.com/google/perfetto/tree/v39.0#perfetto---system-profiling-app-tracing-and-trace-analysis
+> -- https://github.com/google/perfetto/tree/v46.0#perfetto---system-profiling-app-tracing-and-trace-analysis
 
 Perfetto can be enabled by passing the following options to CMake:
    - `-DCLVK_PERFETTO_ENABLE=ON`
    - `-DCLVK_PERFETTO_SDK_DIR=/path/to/perfetto/sdk`
 
-The perfetto SDK can be found in the [Perfetto Github repository](https://github.com/google/perfetto/tree/v39.0)
+The perfetto SDK can be found in the [Perfetto Github repository](https://github.com/google/perfetto/tree/v46.0)
 
 If you already have a perfetto library in your system, you still need to provide the path
 to the SDK directory so the build system can find `perfetto.h`.

--- a/src/tracing.hpp
+++ b/src/tracing.hpp
@@ -51,7 +51,8 @@ PERFETTO_DEFINE_CATEGORIES(
     std::unique_ptr<perfetto::CounterTrack> name
 #define TRACE_CNT_VAR_INIT(name, value)                                        \
     string_##name = value;                                                     \
-    name = std::make_unique<perfetto::CounterTrack>(string_##name.c_str())
+    name = std::make_unique<perfetto::CounterTrack>(                           \
+        perfetto::DynamicString(string_##name))
 
 #elif CVK_ENABLE_TIMING
 


### PR DESCRIPTION
The perfetto::CounterTrack no longer accepts const char* track names (https://android-review.git.corp.google.com/c/platform/external/perfetto/+/3092179/5/CHANGELOG). Fix TRACE_CNT_VAR_INIT() to use perfetto::DynamicString() for track name as the name is std::string.