### PR TITLE
add config option to expose device extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,9 @@ using the name of the corresponding environment variable.
   applications to work with the downside of not cleanly terminating clvk. Use
   with caution.
 
+* `CLVK_DEVICE_EXTENSIONS` specifies extensions to be added to the list of
+  exposed extensions. It expects a whitespace separated list of extensions.
+
 # Limitations
 
 * Only one device per CL context

--- a/src/config.def
+++ b/src/config.def
@@ -59,6 +59,8 @@ OPTION(uint32_t, enqueue_command_retry_sleep_us, UINT32_MAX) // UINT32_MAX meani
 
 OPTION(bool, supports_filter_linear, true)
 
+OPTION(std::string, device_extensions, "")
+
 //
 // Logging
 //

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -674,6 +674,26 @@ void cvk_device::build_extension_ils_list() {
         m_has_subgroup_size_selection = true;
     }
 
+    auto split_string = [](std::string input, char delimiter) {
+        std::vector<std::string> outputs;
+        size_t pos = 0;
+        while ((pos = input.find(delimiter)) != std::string::npos) {
+            outputs.push_back(input.substr(0, pos));
+            input.erase(0, pos + 1);
+        }
+        outputs.push_back(input);
+        return outputs;
+    };
+    auto config_extensions = split_string(config.device_extensions(), ',');
+    for (auto& config_extension : config_extensions) {
+        cl_name_version extension;
+        extension.version = CL_MAKE_VERSION(0, 0, 0);
+        memcpy(extension.name, config_extension.c_str(),
+               std::min(config_extension.size(),
+                        (size_t)CL_NAME_VERSION_MAX_NAME_SIZE));
+        m_extensions.push_back(extension);
+    }
+
     // Build extension string
     for (auto& ext : m_extensions) {
         m_extension_string += ext.name;


### PR DESCRIPTION
The goal is to be able to enable extensions that are not fully supported by clvk, but enough for some applications.