### PR TITLE
If device does not support out-of-order exec, fail when appropriate

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -163,13 +163,13 @@ struct api_query_string : public std::string {
     size_t size_with_null() const { return size() + 1; }
 };
 
-bool out_of_order_device_support(const cl_device_id devices,
-                                 cl_int err) {
+bool out_of_order_device_support(const cl_device_id devices, cl_int err) {
     cl_command_queue_properties device_props = 0;
     err = clGetDeviceInfo(devices, CL_DEVICE_QUEUE_PROPERTIES,
-                                  sizeof(device_props), &device_props, NULL);
-    if(err != CL_SUCCESS)
+                          sizeof(device_props), &device_props, NULL);
+    if (err != CL_SUCCESS) {
         return device_props & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
+    }
     return false;
 }
 
@@ -1481,8 +1481,9 @@ cvk_create_command_queue(cl_context context, cl_device_id device,
     if (properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE &&
         !out_of_order_device_support(device, err)) {
         *errcode_ret = CL_INVALID_QUEUE_PROPERTIES;
-        if (err != CL_SUCCESS)
+        if (err != CL_SUCCESS) {
             *errcode_ret = err;
+        }
         return nullptr;
     }
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -167,7 +167,7 @@ bool out_of_order_device_support(const cl_device_id devices, cl_int err) {
     cl_command_queue_properties device_props = 0;
     err = clGetDeviceInfo(devices, CL_DEVICE_QUEUE_PROPERTIES,
                           sizeof(device_props), &device_props, NULL);
-    if (err != CL_SUCCESS) {
+    if (err == CL_SUCCESS) {
         return device_props & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
     }
     return false;

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -81,9 +81,8 @@ struct cvk_context : public _cl_context,
         }
         return -1;
     }
-    int get_prop_size(){
-        return m_properties.size();
-    }
+
+    int get_prop_size() { return m_properties.size(); }
 
 private:
     cvk_device* m_device;

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -126,7 +126,7 @@ private:
     std::vector<cl_context_properties> m_properties;
     size_t m_printf_buffersize;
     cvk_printf_callback_t m_printf_callback;
-    void * m_printf_userdata;
+    void* m_printf_userdata;
 };
 
 static inline cvk_context* icd_downcast(cl_context context) {

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -73,6 +73,15 @@ struct cvk_context : public _cl_context,
         return size <= m_device->max_mem_alloc_size();
     }
 
+    int get_property_index(const int prop) {
+        for (unsigned i = 0; i < m_properties.size(); i += 2) {
+            if (m_properties[i] == prop) {
+                return i + 1;
+            }
+        }
+        return -1;
+    }
+
 private:
     cvk_device* m_device;
     std::mutex m_callbacks_lock;

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -41,6 +41,14 @@ struct cvk_context : public _cl_context,
             }
             m_properties.push_back(*props);
         }
+        // Compute and save buffer size.
+        auto buff_size_prop_index =
+            get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
+        if (buff_size_prop_index != -1) {
+            m_buffer_size = m_properties[buff_size_prop_index];
+        } else {
+            m_buffer_size = config.printf_buffer_size;
+        }
     }
 
     virtual ~cvk_context() {
@@ -83,12 +91,14 @@ struct cvk_context : public _cl_context,
     }
 
     int get_prop_size() { return m_properties.size(); }
+    size_t get_buffer_size() { return m_buffer_size; }
 
 private:
     cvk_device* m_device;
     std::mutex m_callbacks_lock;
     std::vector<cvk_context_callback> m_destuctor_callbacks;
     std::vector<cl_context_properties> m_properties;
+    size_t m_buffer_size;
 };
 
 static inline cvk_context* icd_downcast(cl_context context) {

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -81,6 +81,9 @@ struct cvk_context : public _cl_context,
         }
         return -1;
     }
+    int get_prop_size(){
+        return m_properties.size();
+    }
 
 private:
     cvk_device* m_device;

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <type_traits>
-
 #include "device.hpp"
 #include "objects.hpp"
 

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -46,12 +46,9 @@ struct cvk_context : public _cl_context,
         // Get buffer size from extension.
         auto buff_size_prop_index =
             get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
-        if (buff_size_prop_index != -1) {
+        if (buff_size_prop_index != -1 && !config.printf_buffer_size.set) {
             m_buffer_size = m_properties[buff_size_prop_index];
-        }
-        // If buffersize is set in config then default to that.
-        if constexpr (std::is_member_object_pointer_v<
-                          decltype(&config_struct::printf_buffer_size)>) {
+        } else {
             m_buffer_size = config.printf_buffer_size;
         }
     }

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -114,7 +114,6 @@ struct cvk_context : public _cl_context,
         return -1;
     }
 
-    int get_prop_size() { return m_properties.size(); }
     size_t get_printf_buffersize() { return m_printf_buffersize; }
     cvk_printf_callback_t get_printf_callback() { return m_printf_callback; }
     void* get_printf_userdata() { return m_printf_userdata; }

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "device.hpp"
 #include "objects.hpp"
 
@@ -41,12 +43,15 @@ struct cvk_context : public _cl_context,
             }
             m_properties.push_back(*props);
         }
-        // Compute and save buffer size.
+        // Get buffer size from extension.
         auto buff_size_prop_index =
             get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
         if (buff_size_prop_index != -1) {
             m_buffer_size = m_properties[buff_size_prop_index];
-        } else {
+        }
+        // If buffersize is set in config then default to that.
+        if constexpr (std::is_member_object_pointer_v<
+                          decltype(&config_struct::printf_buffer_size)>) {
             m_buffer_size = config.printf_buffer_size;
         }
     }

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -619,6 +619,7 @@ void cvk_device::build_extension_ils_list() {
 #endif
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_spirv_no_integer_wrap_decoration"),
         MAKE_NAME_VERSION(1, 0, 0, "cl_arm_non_uniform_work_group_size"),
+        MAKE_NAME_VERSION(1, 0, 0, "cl_arm_printf"),
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_suggested_local_work_size"),
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_3d_image_writes"),
         // MAKE_NAME_VERSION(0, 9, 0, "cl_khr_semaphore"),

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "printf.hpp"
-
 #include <cstring>
 #include <sstream>
 
@@ -112,16 +111,15 @@ std::string print_part(const std::string& fmt, const char* data, size_t size) {
         case 'e':
         case 'g':
         case 'a': {
-            if (size == 2) {
+            if (size == 2)
                 written = snprintf(out.data(), out_size, fmt.c_str(),
                                    cl_half_to_float(read_buff<cl_half>(data)));
-            } else if (size == 4) {
+            else if (size == 4)
                 written = snprintf(out.data(), out_size, fmt.c_str(),
                                    read_buff<float>(data));
-            } else {
+            else
                 written = snprintf(out.data(), out_size, fmt.c_str(),
                                    read_buff<double>(data));
-            }
             break;
         }
         default: {
@@ -160,7 +158,7 @@ std::string print_part(const std::string& fmt, const char* data, size_t size) {
 }
 
 void process_printf(char*& data, const printf_descriptor_map_t& descs,
-                    char* data_end, printf_callback_func& printf_cb,
+                    char* data_end, printf_callback_func printf_cb,
                     size_t buffer_size) {
 
     uint32_t printf_id = read_inc_buff<uint32_t>(data);
@@ -244,7 +242,7 @@ void process_printf(char*& data, const printf_descriptor_map_t& descs,
     }
     auto output = printf_out.str().c_str();
     if (printf_cb != nullptr) {
-        printf_cb(output, buffer_size);
+        printf_cb(output, buffer_size, true, nullptr);
     } else {
         printf("%s", output);
     }

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "printf.hpp"
 #include <cstring>
 #include <sstream>
+
+#include "printf.hpp"
 
 // Extract the conversion specifier from a format string
 char get_fmt_conversion(std::string_view fmt) {
@@ -123,19 +124,18 @@ std::string print_part(const std::string& fmt, const char* data, size_t size) {
             break;
         }
         default: {
-            if (size == 1) {
+            if (size == 1)
                 written = snprintf(out.data(), out_size, fmt.c_str(),
                                    read_buff<uint8_t>(data));
-            } else if (size == 2) {
+            else if (size == 2)
                 written = snprintf(out.data(), out_size, fmt.c_str(),
                                    read_buff<uint16_t>(data));
-            } else if (size == 4) {
+            else if (size == 4)
                 written = snprintf(out.data(), out_size, fmt.c_str(),
                                    read_buff<uint32_t>(data));
-            } else {
+            else
                 written = snprintf(out.data(), out_size, fmt.c_str(),
                                    read_buff<uint64_t>(data));
-            }
             break;
         }
         }

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "printf.hpp"
 #include <cstring>
 #include <sstream>
+
+#include "printf.hpp"
 
 // Extract the conversion specifier from a format string
 char get_fmt_conversion(std::string_view fmt) {
@@ -157,8 +158,7 @@ std::string print_part(const std::string& fmt, const char* data, size_t size) {
 }
 
 void process_printf(char*& data, const printf_descriptor_map_t& descs,
-                    char* data_end, printf_callback_func printf_cb,
-                    size_t buffer_size) {
+                    char* data_end, printf_callback_func printf_cb) {
 
     uint32_t printf_id = read_inc_buff<uint32_t>(data);
     auto& format_string = descs.at(printf_id).format_string;
@@ -265,7 +265,7 @@ cl_int cvk_printf(cvk_mem* printf_buffer,
     const size_t limit = std::min(bytes_written, data_size);
     auto* data_end = data + limit;
     while (data < data_end) {
-        process_printf(data, descriptors, data_end, printf_cb, buffer_size);
+        process_printf(data, descriptors, data_end, printf_cb);
     }
 
     if (buffer_size < bytes_written) {

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -264,6 +264,7 @@ cl_int cvk_printf(cvk_mem* printf_buffer,
     const size_t bytes_written = read_inc_buff<uint32_t>(data) * 4;
     const size_t limit = std::min(bytes_written, data_size);
     auto* data_end = data + limit;
+
     while (data < data_end) {
         process_printf(data, descriptors, data_end, printf_cb);
     }

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "printf.hpp"
 #include <cstring>
 #include <sstream>
-
-#include "printf.hpp"
 
 // Extract the conversion specifier from a format string
 char get_fmt_conversion(std::string_view fmt) {

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -241,7 +241,7 @@ void process_printf(char*& data, const printf_descriptor_map_t& descs,
     }
     auto output = printf_out.str().c_str();
     if (printf_cb != nullptr) {
-        printf_cb(output, buffer_size, true, nullptr);
+        printf_cb(output, buffer_size, data >= data_end, nullptr);
     } else {
         printf("%s", output);
     }

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -239,11 +239,13 @@ void process_printf(char*& data, const printf_descriptor_map_t& descs,
         next_part = part_end;
         arg_idx++;
     }
-    auto output = printf_out.str().c_str();
+
+    auto output = printf_out.str();
     if (printf_cb != nullptr) {
-        printf_cb(output, buffer_size, data >= data_end, nullptr);
+        auto len = output.size();
+        printf_cb(output.c_str(), len, data >= data_end, nullptr);
     } else {
-        printf("%s", output);
+        printf("%s", output.c_str());
     }
 }
 
@@ -262,7 +264,6 @@ cl_int cvk_printf(cvk_mem* printf_buffer,
     const size_t bytes_written = read_inc_buff<uint32_t>(data) * 4;
     const size_t limit = std::min(bytes_written, data_size);
     auto* data_end = data + limit;
-
     while (data < data_end) {
         process_printf(data, descriptors, data_end, printf_cb, buffer_size);
     }

--- a/src/printf.hpp
+++ b/src/printf.hpp
@@ -16,6 +16,7 @@
 
 #include "memory.hpp"
 
+#include <functional>
 #include <vector>
 
 struct printf_descriptor {
@@ -25,7 +26,9 @@ struct printf_descriptor {
 };
 
 using printf_descriptor_map_t = std::unordered_map<uint32_t, printf_descriptor>;
+typedef std::function<void(const char*, size_t)> printf_callback_func;
 
 // Process the contents of the printf buffer and print the results to stdout
 cl_int cvk_printf(cvk_mem* printf_buffer,
-                  const printf_descriptor_map_t& descriptors);
+                  const printf_descriptor_map_t& descriptors,
+                  printf_callback_func = nullptr);

--- a/src/printf.hpp
+++ b/src/printf.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
+#include "context.hpp"
 #include "memory.hpp"
 
-#include <functional>
 #include <vector>
 
 struct printf_descriptor {
@@ -26,10 +26,8 @@ struct printf_descriptor {
 };
 
 using printf_descriptor_map_t = std::unordered_map<uint32_t, printf_descriptor>;
-typedef void(printf_callback_func)(const char* buffer, size_t len,
-                                   size_t complete, void* user_data);
 
 // Process the contents of the printf buffer and print the results to stdout
 cl_int cvk_printf(cvk_mem* printf_buffer,
                   const printf_descriptor_map_t& descriptors,
-                  printf_callback_func cb_func);
+                  cvk_printf_callback_t cb_func, void* printf_userdata);

--- a/src/printf.hpp
+++ b/src/printf.hpp
@@ -27,7 +27,7 @@ struct printf_descriptor {
 
 using printf_descriptor_map_t = std::unordered_map<uint32_t, printf_descriptor>;
 typedef void(printf_callback_func)(const char* buffer, size_t len,
-                                   +size_t complete, void* user_data);
+                                   size_t complete, void* user_data);
 
 // Process the contents of the printf buffer and print the results to stdout
 cl_int cvk_printf(cvk_mem* printf_buffer,

--- a/src/printf.hpp
+++ b/src/printf.hpp
@@ -26,9 +26,10 @@ struct printf_descriptor {
 };
 
 using printf_descriptor_map_t = std::unordered_map<uint32_t, printf_descriptor>;
-typedef std::function<void(const char*, size_t)> printf_callback_func;
+typedef void(printf_callback_func)(const char* buffer, size_t len,
+                                   +size_t complete, void* user_data);
 
 // Process the contents of the printf buffer and print the results to stdout
 cl_int cvk_printf(cvk_mem* printf_buffer,
                   const printf_descriptor_map_t& descriptors,
-                  printf_callback_func = nullptr);
+                  printf_callback_func cb_func);

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -967,8 +967,8 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
         }
     }
 
-    auto buff_size = config.printf_buffer_size;
-    auto buff_size_prop_index = get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
+    size_t buff_size = config.printf_buffer_size;
+    auto buff_size_prop_index = m_context->get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
 
     if (buff_size_prop_index != -1) {
         auto props = m_context->properties();

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -967,10 +967,16 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
         }
     }
 
+    auto buff_size = config.printf_buffer_size;
+    auto buff_size_prop_index = get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
+
+    if (buff_size_prop_index != -1) {
+        auto props = m_context->properties();
+        buff_size = props[buff_size_prop_index];
+    }
     options += " -enable-printf ";
-    options +=
-        " -printf-buffer-size=" + std::to_string(config.printf_buffer_size) +
-        " ";
+    options += " -printf-buffer-size=" +
+                std::to_string(buff_size) + " ";
 
 #if COMPILER_AVAILABLE
     options += " " + config.clspv_options() + " ";

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cstring>
 #include <filesystem>
+#include <iostream>
 #include <map>
 #include <sstream>
 #include <system_error>

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -967,7 +967,7 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
         }
     }
 
-    auto buff_size = m_context->get_buffer_size();
+    auto buff_size = m_context->get_printf_buffersize();
 
     options += " -enable-printf ";
     options += " -printf-buffer-size=" + std::to_string(buff_size) + " ";

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -966,14 +966,8 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
         }
     }
 
-    size_t buff_size = config.printf_buffer_size;
-    auto buff_size_prop_index =
-        m_context->get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
+    auto buff_size = m_context->get_buffer_size();
 
-    if (buff_size_prop_index != -1) {
-        auto props = m_context->properties();
-        buff_size = props[buff_size_prop_index];
-    }
     options += " -enable-printf ";
     options += " -printf-buffer-size=" + std::to_string(buff_size) + " ";
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -968,15 +968,15 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
     }
 
     size_t buff_size = config.printf_buffer_size;
-    auto buff_size_prop_index = m_context->get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
+    auto buff_size_prop_index =
+        m_context->get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
 
     if (buff_size_prop_index != -1) {
         auto props = m_context->properties();
         buff_size = props[buff_size_prop_index];
     }
     options += " -enable-printf ";
-    options += " -printf-buffer-size=" +
-                std::to_string(buff_size) + " ";
+    options += " -printf-buffer-size=" + std::to_string(buff_size) + " ";
 
 #if COMPILER_AVAILABLE
     options += " " + config.clspv_options() + " ";

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <cstring>
 #include <filesystem>
-#include <iostream>
 #include <map>
 #include <sstream>
 #include <system_error>

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -218,6 +218,7 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
         if ((err = end_current_command_batch(true)) != CL_SUCCESS) {
             return err;
         }
+
         if (!cmd->is_built_before_enqueue()) {
             // Build batchable command as non-batched (in its own command
             // buffer)
@@ -226,6 +227,7 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
                 return err;
             }
         }
+
         enqueue_command(cmd);
     }
 
@@ -335,9 +337,8 @@ cl_int cvk_command_queue::wait_for_events(cl_uint num_events,
     if (queues_to_flush.size() == 1) {
         for (auto q : queues_to_flush) {
             auto status = q->execute_cmds_required_by(num_events, event_list);
-            if (status != CL_SUCCESS) {
+            if (status != CL_SUCCESS)
                 return status;
-            }
         }
     }
 
@@ -361,9 +362,8 @@ cl_int cvk_command_group::execute_cmds() {
                      cl_command_type_to_string(cmd->type()), cmd->event());
 
         cl_int status = cmd->execute();
-        if (status != CL_COMPLETE && global_status == CL_SUCCESS) {
+        if (status != CL_COMPLETE && global_status == CL_SUCCESS)
             global_status = status;
-        }
         cvk_debug_fn("command returned %d", status);
 
         commands.pop_front();
@@ -914,9 +914,8 @@ cl_int cvk_command_kernel::dispatch_uniform_region_iterate(
                 dim - 1, region, region_lws, region_gws, region_offset,
                 command_buffer, num_workgroups);
         }
-        if (err != CL_SUCCESS) {
+        if (err != CL_SUCCESS)
             return err;
-        }
     }
 
     return CL_SUCCESS;
@@ -1536,9 +1535,9 @@ cl_int cvk_command_unmap_image::do_action() {
     return CL_COMPLETE;
 }
 
-VkImageSubresourceLayers
-prepare_subresource(const cvk_image* image, const std::array<size_t, 3>& origin,
-                    const std::array<size_t, 3>& region) {
+VkImageSubresourceLayers prepare_subresource(const cvk_image* image,
+                                             const std::array<size_t, 3>& origin,
+                                             const std::array<size_t, 3>& region) {
     uint32_t baseArrayLayer = 0;
     uint32_t layerCount = 1;
 
@@ -1560,8 +1559,7 @@ prepare_subresource(const cvk_image* image, const std::array<size_t, 3>& origin,
     return ret;
 }
 
-VkOffset3D prepare_offset(const cvk_image* image,
-                          const std::array<size_t, 3>& origin) {
+VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& origin) {
 
     auto x = static_cast<int32_t>(origin[0]);
     auto y = static_cast<int32_t>(origin[1]);
@@ -1584,8 +1582,7 @@ VkOffset3D prepare_offset(const cvk_image* image,
     return offset;
 }
 
-VkExtent3D prepare_extent(const cvk_image* image,
-                          const std::array<size_t, 3>& region) {
+VkExtent3D prepare_extent(const cvk_image* image, const std::array<size_t, 3>& region) {
     uint32_t extentHeight = region[1];
     uint32_t extentDepth = region[2];
 
@@ -1608,13 +1605,12 @@ VkExtent3D prepare_extent(const cvk_image* image,
     return extent;
 }
 
-VkBufferImageCopy
-prepare_buffer_image_copy(const cvk_image* image, size_t bufferOffset,
-                          const std::array<size_t, 3>& origin,
-                          const std::array<size_t, 3>& region) {
+VkBufferImageCopy prepare_buffer_image_copy(const cvk_image* image,
+                                            size_t bufferOffset,
+                                            const std::array<size_t, 3>& origin,
+                                            const std::array<size_t, 3>& region) {
 
-    VkImageSubresourceLayers subResource =
-        prepare_subresource(image, origin, region);
+    VkImageSubresourceLayers subResource = prepare_subresource(image, origin, region);
 
     VkOffset3D offset = prepare_offset(image, origin);
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1562,7 +1562,6 @@ VkImageSubresourceLayers prepare_subresource(const cvk_image* image,
 
 VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& origin) {
 
-
     auto x = static_cast<int32_t>(origin[0]);
     auto y = static_cast<int32_t>(origin[1]);
     auto z = static_cast<int32_t>(origin[2]);

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1560,8 +1560,8 @@ VkImageSubresourceLayers prepare_subresource(const cvk_image* image,
     return ret;
 }
 
-VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& origin) {
-    auto x = static_cast<int32_t>(origin[0]);
+VkOffset3D prepare_offset(const cvk_image* image,
+                          const std::array<size_t, 3>& origin) {    auto x = static_cast<int32_t>(origin[0]);
     auto y = static_cast<int32_t>(origin[1]);
     auto z = static_cast<int32_t>(origin[2]);
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -370,16 +370,6 @@ cl_int cvk_command_group::execute_cmds() {
     return global_status;
 }
 
-int cvk_command_queue::get_property_index(const int prop) {
-    auto& properties = m_context->properties();
-    for (unsigned i = 0; i < properties.size(); i += 2) {
-        if (properties[i] == prop) {
-            return i + 1;
-        }
-    }
-    return -1;
-}
-
 cl_int cvk_command_queue::execute_cmds_required_by_no_lock(
     cl_uint num_events, _cl_event* const* event_list) {
     auto* exec = m_executor;
@@ -1133,7 +1123,8 @@ cl_int cvk_command_kernel::do_post_action() {
             cvk_error_fn("printf buffer was not created");
             return CL_OUT_OF_RESOURCES;
         }
-        auto cb_index = m_queue->get_property_index(CL_PRINTF_CALLBACK_ARM);
+        auto cb_index =
+            m_queue->context()->get_property_index(CL_PRINTF_CALLBACK_ARM);
         if (cb_index == -1) {
             cvk_error_fn("failed to get printf callback function");
             return CL_INVALID_PROPERTY;
@@ -1571,6 +1562,7 @@ VkImageSubresourceLayers prepare_subresource(const cvk_image* image,
 
 VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& origin) {
 
+
     auto x = static_cast<int32_t>(origin[0]);
     auto y = static_cast<int32_t>(origin[1]);
     auto z = static_cast<int32_t>(origin[2]);
@@ -1592,8 +1584,8 @@ VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& o
     return offset;
 }
 
-VkExtent3D prepare_extent(const cvk_image* image,
-                          const std::array<size_t, 3>& region) {
+VkExtent3D prepare_extent(const cvk_image* image, const std::array<size_t, 3>& region) {
+
     uint32_t extentHeight = region[1];
     uint32_t extentDepth = region[2];
 
@@ -1607,8 +1599,8 @@ VkExtent3D prepare_extent(const cvk_image* image,
         break;
     }
 
-VkExtent3D prepare_extent(const cvk_image* image, const std::array<size_t, 3>& region) {
-
+    VkExtent3D extent = {static_cast<uint32_t>(region[0]), extentHeight,
+                         extentDepth};
 
     cvk_debug_fn("extent: %u, %u, %u", extent.width, extent.height,
                  extent.depth);

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1560,8 +1560,10 @@ VkImageSubresourceLayers prepare_subresource(const cvk_image* image,
     return ret;
 }
 
-VkOffset3D prepare_offset(const cvk_image* image,
-                          const std::array<size_t, 3>& origin) {    auto x = static_cast<int32_t>(origin[0]);
+VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& origin) {
+
+
+    auto x = static_cast<int32_t>(origin[0]);
     auto y = static_cast<int32_t>(origin[1]);
     auto z = static_cast<int32_t>(origin[2]);
 
@@ -1583,7 +1585,6 @@ VkOffset3D prepare_offset(const cvk_image* image,
 }
 
 VkExtent3D prepare_extent(const cvk_image* image, const std::array<size_t, 3>& region) {
-
     uint32_t extentHeight = region[1];
     uint32_t extentDepth = region[2];
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -67,8 +67,6 @@ cvk_command_queue::cvk_command_queue(
     if (cb_index != -1) {
         auto all_props = m_context->properties();
         m_cb_func = (printf_callback_func*)all_props[cb_index];
-    } else {
-        m_cb_func = nullptr;
     }
 }
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1561,8 +1561,6 @@ VkImageSubresourceLayers prepare_subresource(const cvk_image* image,
 }
 
 VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& origin) {
-
-
     auto x = static_cast<int32_t>(origin[0]);
     auto y = static_cast<int32_t>(origin[1]);
     auto z = static_cast<int32_t>(origin[2]);
@@ -1614,7 +1612,6 @@ VkBufferImageCopy prepare_buffer_image_copy(const cvk_image* image,
                                             const std::array<size_t, 3>& region) {
 
     VkImageSubresourceLayers subResource = prepare_subresource(image, origin, region);
-
 
     VkOffset3D offset = prepare_offset(image, origin);
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -63,11 +63,6 @@ cvk_command_queue::cvk_command_queue(
 
     TRACE_CNT(batch_in_flight_counter, 0);
     TRACE_CNT(group_in_flight_counter, 0);
-    auto cb_index = m_context->get_property_index(CL_PRINTF_CALLBACK_ARM);
-    if (cb_index != -1) {
-        auto all_props = m_context->properties();
-        m_cb_func = (printf_callback_func*)all_props[cb_index];
-    }
 }
 
 cl_int cvk_command_queue::init() {
@@ -1129,7 +1124,8 @@ cl_int cvk_command_kernel::do_post_action() {
             return CL_OUT_OF_RESOURCES;
         }
         return cvk_printf(buffer, m_kernel->program()->printf_descriptors(),
-                          m_queue->get_printf_cb_func());
+                          m_queue->context()->get_printf_callback(),
+                          m_queue->context()->get_printf_userdata());
     }
 
     return CL_SUCCESS;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -111,9 +111,10 @@ cl_int cvk_command_queue::satisfy_data_dependencies(cvk_command* cmd) {
         auto downcastev = icd_downcast(initev);
         tracker.set_event(downcastev);
 
-        // The event has been retained by `enqueue_command` to give its user
-        // a refcount on the event. The tracker will request a refcount so we
-        // need to give up the one we got from `enqueue_command`.
+        // The event has been retained by `enqueue_command` to give its
+        // user a refcount on the event. The tracker will request a
+        // refcount so we need to give up the one we got from
+        // `enqueue_command`.
         downcastev->release();
     }
 
@@ -123,9 +124,9 @@ cl_int cvk_command_queue::satisfy_data_dependencies(cvk_command* cmd) {
 void cvk_command_queue::enqueue_command(cvk_command* cmd) {
     TRACE_FUNCTION("queue", (uintptr_t)this, "cmd", (uintptr_t)cmd);
     // clvk only supports inorder queues at the moment.
-    // But as the commands can be executed by 2 threads (1 executor and the main
-    // thread), we need to explicit the dependency to ensure it will be
-    // respected.
+    // But as the commands can be executed by 2 threads (1 executor and
+    // the main thread), we need to explicit the dependency to ensure it
+    // will be respected.
     if (!m_groups.back()->commands.empty()) {
         cmd->add_dependency(m_groups.back()->commands.back()->event());
     } else if (m_finish_event != nullptr) {
@@ -213,8 +214,8 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
         }
 
         if (!cmd->is_built_before_enqueue()) {
-            // Build batchable command as non-batched (in its own command
-            // buffer)
+            // Build batchable command as non-batched (in its own
+            // command buffer)
             err = static_cast<cvk_command_batchable*>(cmd)->build();
             if (err != CL_SUCCESS) {
                 return err;
@@ -330,8 +331,9 @@ cl_int cvk_command_queue::wait_for_events(cl_uint num_events,
     if (queues_to_flush.size() == 1) {
         for (auto q : queues_to_flush) {
             auto status = q->execute_cmds_required_by(num_events, event_list);
-            if (status != CL_SUCCESS)
+            if (status != CL_SUCCESS) {
                 return status;
+            }
         }
     }
 
@@ -355,19 +357,34 @@ cl_int cvk_command_group::execute_cmds() {
                      cl_command_type_to_string(cmd->type()), cmd->event());
 
         cl_int status = cmd->execute();
-        if (status != CL_COMPLETE && global_status == CL_SUCCESS)
+        if (status != CL_COMPLETE && global_status == CL_SUCCESS) {
             global_status = status;
+        }
         cvk_debug_fn("command returned %d", status);
 
         commands.pop_front();
 
-        // Deleting batch with many commands can take a while. Trace it to be
-        // able to understand it easily.
+        // Deleting batch with many commands can take a while. Trace it
+        // to be able to understand it easily.
         TRACE_BEGIN("delete_cmd");
         delete cmd;
         TRACE_END();
     }
     return global_status;
+}
+
+bool cvk_command_queue::get_printf_callback(printf_callback_func& callback) {
+    auto& properties = m_context->properties();
+    for (unsigned i = 0; i < properties.size(); i += 2) {
+        if (properties[i] == CL_PRINTF_CALLBACK_ARM) {
+            void (*func_ptr)(const char*, long unsigned int) =
+                reinterpret_cast<void (*)(const char*, long unsigned int)>(
+                    (properties[i + 1]));
+            callback = func_ptr;
+            return true;
+        }
+    }
+    return false;
 }
 
 cl_int cvk_command_queue::execute_cmds_required_by_no_lock(
@@ -722,8 +739,9 @@ cl_int cvk_command_kernel::update_global_push_constants(
                 CVK_ASSERT(arg.offset + arg.size <=
                            m_argument_values->pod_data().size());
 
-                // Vulkan valid usage states push constants can only be updated
-                // in chunks whose offset and size are a multiple of 4.
+                // Vulkan valid usage states push constants can only be
+                // updated in chunks whose offset and size are a
+                // multiple of 4.
                 uint32_t size = round_up(arg.size, 4);
                 uint32_t offset = arg.offset & ~0x3U;
                 vkCmdPushConstants(command_buffer, m_kernel->pipeline_layout(),
@@ -754,9 +772,10 @@ cl_int cvk_command_kernel::dispatch_uniform_region_within_vklimits(
 
     auto program = m_kernel->program();
     auto constants = program->spec_constants();
-    // TODO: if all kernels in the module use the same reqd_workgroup_size ,
-    // clspv will not generate specialization constants for workgroup size, but
-    // these values should be error checked.
+    // TODO: if all kernels in the module use the same
+    // reqd_workgroup_size , clspv will not generate specialization
+    // constants for workgroup size, but these values should be error
+    // checked.
     uint32_t wgsize_x_id = 0;
     auto where = constants.find(spec_constant::workgroup_size_x);
     if (where != constants.end()) {
@@ -782,8 +801,8 @@ cl_int cvk_command_kernel::dispatch_uniform_region_within_vklimits(
          m_argument_values->specialization_constants()) {
         specConstants[spec_value.first] = spec_value.second;
     }
-    // Clspv allocates a spec constant for work dimensions if get_work_dim() is
-    // used.
+    // Clspv allocates a spec constant for work dimensions if
+    // get_work_dim() is used.
     where = constants.find(spec_constant::work_dim);
     if (where != constants.end()) {
         uint32_t dim_id = where->second;
@@ -849,9 +868,9 @@ cl_int cvk_command_kernel::dispatch_uniform_region_within_vklimits(
     vkCmdDispatch(command_buffer, num_workgroups[0], num_workgroups[1],
                   num_workgroups[2]);
 
-    // If we have a kernel that requires serial execution (i.e. regions are not
-    // executed in parallel with other regions or other kernels) then serialize
-    // the command buffer
+    // If we have a kernel that requires serial execution (i.e. regions
+    // are not executed in parallel with other regions or other kernels)
+    // then serialize the command buffer
     if (m_kernel->requires_serialized_execution()) {
         VkMemoryBarrier memoryBarrier = {VK_STRUCTURE_TYPE_MEMORY_BARRIER,
                                          nullptr, VK_ACCESS_SHADER_WRITE_BIT,
@@ -907,8 +926,9 @@ cl_int cvk_command_kernel::dispatch_uniform_region_iterate(
                 dim - 1, region, region_lws, region_gws, region_offset,
                 command_buffer, num_workgroups);
         }
-        if (err != CL_SUCCESS)
+        if (err != CL_SUCCESS) {
             return err;
+        }
     }
 
     return CL_SUCCESS;
@@ -937,10 +957,11 @@ cl_int cvk_command_kernel::dispatch_uniform_region(
                              vklimits.maxComputeWorkGroupCount[0],
                              vklimits.maxComputeWorkGroupCount[1],
                              vklimits.maxComputeWorkGroupCount[2]);
-                cvk_error_fn(
-                    "Splitting this region is required, but it is not possible "
-                    "because the support has been disabled (most probably by "
-                    "'-uniform-workgroup-size').");
+                cvk_error_fn("Splitting this region is required, but "
+                             "it is not possible "
+                             "because the support has been disabled "
+                             "(most probably by "
+                             "'-uniform-workgroup-size').");
 
                 return CL_INVALID_WORK_ITEM_SIZE;
             }
@@ -1022,8 +1043,8 @@ cl_int
 cvk_command_kernel::build_batchable_inner(cvk_command_buffer& command_buffer) {
 
     // TODO check against the size specified at compile time, if any
-    // TODO CL_INVALID_KERNEL_ARGS if the kernel argument values have not been
-    // specified.
+    // TODO CL_INVALID_KERNEL_ARGS if the kernel argument values have
+    // not been specified.
 
     m_argument_values = m_kernel->argument_values();
     m_argument_values->retain_resources();
@@ -1123,7 +1144,11 @@ cl_int cvk_command_kernel::do_post_action() {
             cvk_error_fn("printf buffer was not created");
             return CL_OUT_OF_RESOURCES;
         }
-        return cvk_printf(buffer, m_kernel->program()->printf_descriptors());
+        printf_callback_func printf_cb;
+        m_queue->get_printf_callback(printf_cb);
+
+        return cvk_printf(buffer, m_kernel->program()->printf_descriptors(),
+                          printf_cb);
     }
 
     return CL_SUCCESS;
@@ -1527,9 +1552,9 @@ cl_int cvk_command_unmap_image::do_action() {
     return CL_COMPLETE;
 }
 
-VkImageSubresourceLayers prepare_subresource(const cvk_image* image,
-                                             const std::array<size_t, 3>& origin,
-                                             const std::array<size_t, 3>& region) {
+VkImageSubresourceLayers
+prepare_subresource(const cvk_image* image, const std::array<size_t, 3>& origin,
+                    const std::array<size_t, 3>& region) {
     uint32_t baseArrayLayer = 0;
     uint32_t layerCount = 1;
 
@@ -1551,7 +1576,8 @@ VkImageSubresourceLayers prepare_subresource(const cvk_image* image,
     return ret;
 }
 
-VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& origin) {
+VkOffset3D prepare_offset(const cvk_image* image,
+                          const std::array<size_t, 3>& origin) {
 
     auto x = static_cast<int32_t>(origin[0]);
     auto y = static_cast<int32_t>(origin[1]);
@@ -1574,7 +1600,8 @@ VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& o
     return offset;
 }
 
-VkExtent3D prepare_extent(const cvk_image* image, const std::array<size_t, 3>& region) {
+VkExtent3D prepare_extent(const cvk_image* image,
+                          const std::array<size_t, 3>& region) {
     uint32_t extentHeight = region[1];
     uint32_t extentDepth = region[2];
 
@@ -1597,12 +1624,13 @@ VkExtent3D prepare_extent(const cvk_image* image, const std::array<size_t, 3>& r
     return extent;
 }
 
-VkBufferImageCopy prepare_buffer_image_copy(const cvk_image* image,
-                                            size_t bufferOffset,
-                                            const std::array<size_t, 3>& origin,
-                                            const std::array<size_t, 3>& region) {
+VkBufferImageCopy
+prepare_buffer_image_copy(const cvk_image* image, size_t bufferOffset,
+                          const std::array<size_t, 3>& origin,
+                          const std::array<size_t, 3>& region) {
 
-    VkImageSubresourceLayers subResource = prepare_subresource(image, origin, region);
+    VkImageSubresourceLayers subResource =
+        prepare_subresource(image, origin, region);
 
     VkOffset3D offset = prepare_offset(image, origin);
 
@@ -1766,17 +1794,17 @@ cl_int cvk_command_buffer_image_copy::build_batchable_inner(
         VK_STRUCTURE_TYPE_MEMORY_BARRIER, nullptr, VK_ACCESS_TRANSFER_WRITE_BIT,
         VK_ACCESS_MEMORY_WRITE_BIT | VK_ACCESS_MEMORY_READ_BIT};
 
-    vkCmdPipelineBarrier(
-        cmdbuf, VK_PIPELINE_STAGE_TRANSFER_BIT,
-        // TODO HOST only when the dest buffer is an image mapping buffer
-        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        0, // dependencyFlags
-        1, // memoryBarrierCount
-        &memoryBarrier,
-        0,        // bufferMemoryBarrierCount
-        nullptr,  // pBufferMemoryBarriers
-        0,        // imageMemoryBarrierCount
-        nullptr); // pImageMemoryBarriers
+    vkCmdPipelineBarrier(cmdbuf, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                         // TODO HOST only when the dest buffer is an
+                         // image mapping buffer
+                         VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                         0, // dependencyFlags
+                         1, // memoryBarrierCount
+                         &memoryBarrier,
+                         0,        // bufferMemoryBarrierCount
+                         nullptr,  // pBufferMemoryBarriers
+                         0,        // imageMemoryBarrierCount
+                         nullptr); // pImageMemoryBarriers
 
     return CL_SUCCESS;
 }

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1571,7 +1571,6 @@ VkImageSubresourceLayers prepare_subresource(const cvk_image* image,
 
 VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& origin) {
 
-
     auto x = static_cast<int32_t>(origin[0]);
     auto y = static_cast<int32_t>(origin[1]);
     auto z = static_cast<int32_t>(origin[2]);
@@ -1608,8 +1607,8 @@ VkExtent3D prepare_extent(const cvk_image* image,
         break;
     }
 
-    VkExtent3D extent = {static_cast<uint32_t>(region[0]), extentHeight,
-                         extentDepth};
+VkExtent3D prepare_extent(const cvk_image* image, const std::array<size_t, 3>& region) {
+
 
     cvk_debug_fn("extent: %u, %u, %u", extent.width, extent.height,
                  extent.depth);
@@ -1622,8 +1621,8 @@ VkBufferImageCopy prepare_buffer_image_copy(const cvk_image* image,
                                             const std::array<size_t, 3>& origin,
                                             const std::array<size_t, 3>& region) {
 
-    VkImageSubresourceLayers subResource =
-        prepare_subresource(image, origin, region);
+    VkImageSubresourceLayers subResource = prepare_subresource(image, origin, region);
+
 
     VkOffset3D offset = prepare_offset(image, origin);
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -67,7 +67,8 @@ cvk_command_queue::cvk_command_queue(
     if (cb_index != -1) {
         auto all_props = m_context->properties();
         m_cb_func = (printf_callback_func*)all_props[cb_index];
-
+    } else {
+        m_cb_func = nullptr;
     }
 }
 
@@ -334,8 +335,9 @@ cl_int cvk_command_queue::wait_for_events(cl_uint num_events,
     if (queues_to_flush.size() == 1) {
         for (auto q : queues_to_flush) {
             auto status = q->execute_cmds_required_by(num_events, event_list);
-            if (status != CL_SUCCESS)
+            if (status != CL_SUCCESS) {
                 return status;
+            }
         }
     }
 
@@ -359,8 +361,9 @@ cl_int cvk_command_group::execute_cmds() {
                      cl_command_type_to_string(cmd->type()), cmd->event());
 
         cl_int status = cmd->execute();
-        if (status != CL_COMPLETE && global_status == CL_SUCCESS)
+        if (status != CL_COMPLETE && global_status == CL_SUCCESS) {
             global_status = status;
+        }
         cvk_debug_fn("command returned %d", status);
 
         commands.pop_front();
@@ -911,8 +914,9 @@ cl_int cvk_command_kernel::dispatch_uniform_region_iterate(
                 dim - 1, region, region_lws, region_gws, region_offset,
                 command_buffer, num_workgroups);
         }
-        if (err != CL_SUCCESS)
+        if (err != CL_SUCCESS) {
             return err;
+        }
     }
 
     return CL_SUCCESS;
@@ -1532,9 +1536,9 @@ cl_int cvk_command_unmap_image::do_action() {
     return CL_COMPLETE;
 }
 
-VkImageSubresourceLayers prepare_subresource(const cvk_image* image,
-                                             const std::array<size_t, 3>& origin,
-                                             const std::array<size_t, 3>& region) {
+VkImageSubresourceLayers
+prepare_subresource(const cvk_image* image, const std::array<size_t, 3>& origin,
+                    const std::array<size_t, 3>& region) {
     uint32_t baseArrayLayer = 0;
     uint32_t layerCount = 1;
 
@@ -1556,7 +1560,8 @@ VkImageSubresourceLayers prepare_subresource(const cvk_image* image,
     return ret;
 }
 
-VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& origin) {
+VkOffset3D prepare_offset(const cvk_image* image,
+                          const std::array<size_t, 3>& origin) {
 
     auto x = static_cast<int32_t>(origin[0]);
     auto y = static_cast<int32_t>(origin[1]);
@@ -1579,7 +1584,8 @@ VkOffset3D prepare_offset(const cvk_image* image, const std::array<size_t, 3>& o
     return offset;
 }
 
-VkExtent3D prepare_extent(const cvk_image* image, const std::array<size_t, 3>& region) {
+VkExtent3D prepare_extent(const cvk_image* image,
+                          const std::array<size_t, 3>& region) {
     uint32_t extentHeight = region[1];
     uint32_t extentDepth = region[2];
 
@@ -1602,12 +1608,13 @@ VkExtent3D prepare_extent(const cvk_image* image, const std::array<size_t, 3>& r
     return extent;
 }
 
-VkBufferImageCopy prepare_buffer_image_copy(const cvk_image* image,
-                                            size_t bufferOffset,
-                                            const std::array<size_t, 3>& origin,
-                                            const std::array<size_t, 3>& region) {
+VkBufferImageCopy
+prepare_buffer_image_copy(const cvk_image* image, size_t bufferOffset,
+                          const std::array<size_t, 3>& origin,
+                          const std::array<size_t, 3>& region) {
 
-    VkImageSubresourceLayers subResource = prepare_subresource(image, origin, region);
+    VkImageSubresourceLayers subResource =
+        prepare_subresource(image, origin, region);
 
     VkOffset3D offset = prepare_offset(image, origin);
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -63,6 +63,12 @@ cvk_command_queue::cvk_command_queue(
 
     TRACE_CNT(batch_in_flight_counter, 0);
     TRACE_CNT(group_in_flight_counter, 0);
+    auto cb_index = m_context->get_property_index(CL_PRINTF_CALLBACK_ARM);
+    if (cb_index != -1) {
+        auto all_props = m_context->properties();
+        m_cb_func = (printf_callback_func*)all_props[cb_index];
+
+    }
 }
 
 cl_int cvk_command_queue::init() {
@@ -211,7 +217,6 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
         if ((err = end_current_command_batch(true)) != CL_SUCCESS) {
             return err;
         }
-
         if (!cmd->is_built_before_enqueue()) {
             // Build batchable command as non-batched (in its own command
             // buffer)
@@ -220,7 +225,6 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
                 return err;
             }
         }
-
         enqueue_command(cmd);
     }
 
@@ -1123,16 +1127,8 @@ cl_int cvk_command_kernel::do_post_action() {
             cvk_error_fn("printf buffer was not created");
             return CL_OUT_OF_RESOURCES;
         }
-        auto cb_index =
-            m_queue->context()->get_property_index(CL_PRINTF_CALLBACK_ARM);
-        if (cb_index == -1) {
-            cvk_error_fn("failed to get printf callback function");
-            return CL_INVALID_PROPERTY;
-        }
-        auto all_props = m_queue->context()->properties();
-        auto cb_func = (printf_callback_func*)all_props[cb_index];
         return cvk_printf(buffer, m_kernel->program()->printf_descriptors(),
-                          cb_func);
+                          m_queue->get_printf_cb_func());
     }
 
     return CL_SUCCESS;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1720,17 +1720,15 @@ void cvk_command_buffer_image_copy::build_inner_image_to_buffer(
         subresourceRange,
     };
 
-    vkCmdPipelineBarrier(
-        cmdbuf, VK_PIPELINE_STAGE_TRANSFER_BIT,
-        // TODO HOST only when the dest buffer is an image mapping buffer
-        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        0, // dependencyFlags
-        1, // memoryBarrierCount
-        &memoryBarrier,
-        0,        // bufferMemoryBarrierCount
-        nullptr,  // pBufferMemoryBarriers
-        0,        // imageMemoryBarrierCount
-        nullptr); // pImageMemoryBarriers
+    vkCmdPipelineBarrier(cmdbuf, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                         VK_PIPELINE_STAGE_TRANSFER_BIT,
+                         0,              // dependencyFlags
+                         0,              // memoryBarrierCount
+                         nullptr,        // pMemoryBarriers
+                         0,              // bufferMemoryBarrierCount
+                         nullptr,        // pBufferMemoryBarriers
+                         1,              // imageMemoryBarrierCount
+                         &imageBarrier); // pImageMemoryBarriers
 
     vkCmdCopyImageToBuffer(cmdbuf, m_image->vulkan_image(),
                            VK_IMAGE_LAYOUT_GENERAL, m_buffer->vulkan_buffer(),
@@ -1789,17 +1787,17 @@ cl_int cvk_command_buffer_image_copy::build_batchable_inner(
         VK_STRUCTURE_TYPE_MEMORY_BARRIER, nullptr, VK_ACCESS_TRANSFER_WRITE_BIT,
         VK_ACCESS_MEMORY_WRITE_BIT | VK_ACCESS_MEMORY_READ_BIT};
 
-    vkCmdPipelineBarrier(cmdbuf, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                         // TODO HOST only when the dest buffer is an
-                         // image mapping buffer
-                         VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-                         0, // dependencyFlags
-                         1, // memoryBarrierCount
-                         &memoryBarrier,
-                         0,        // bufferMemoryBarrierCount
-                         nullptr,  // pBufferMemoryBarriers
-                         0,        // imageMemoryBarrierCount
-                         nullptr); // pImageMemoryBarriers
+    vkCmdPipelineBarrier(
+        cmdbuf, VK_PIPELINE_STAGE_TRANSFER_BIT,
+        // TODO HOST only when the dest buffer is an image mapping buffer
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+        0, // dependencyFlags
+        1, // memoryBarrierCount
+        &memoryBarrier,
+        0,        // bufferMemoryBarrierCount
+        nullptr,  // pBufferMemoryBarriers
+        0,        // imageMemoryBarrierCount
+        nullptr); // pImageMemoryBarriers
 
     return CL_SUCCESS;
 }

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -176,10 +176,10 @@ struct cvk_command_queue : public _cl_command_queue,
 
     cvk_buffer* get_or_create_printf_buffer() {
         if (!m_printf_buffer) {
-            cl_int status = CL_SUCCESS;
-
+            cl_int status;
             m_printf_buffer = cvk_buffer::create(
-                context(), 0, m_context->get_buffer_size(), nullptr, &status);
+                context(), 0, m_context->get_printf_buffersize(), nullptr,
+                &status);
             CVK_ASSERT(status == CL_SUCCESS);
         }
         return m_printf_buffer.get();
@@ -236,9 +236,6 @@ struct cvk_command_queue : public _cl_command_queue,
                                     _cl_event* const* event_list);
     cl_int execute_cmds_required_by_no_lock(cl_uint num_events,
                                             _cl_event* const* event_list);
-    int get_property_index(const int prop);
-
-    printf_callback_func* get_printf_cb_func() { return m_cb_func; }
 
 private:
     CHECK_RETURN cl_int satisfy_data_dependencies(cvk_command* cmd);
@@ -268,8 +265,6 @@ private:
     cl_uint m_max_first_cmd_batch_size;
     cl_uint m_max_cmd_group_size;
     cl_uint m_max_first_cmd_group_size;
-
-    printf_callback_func* m_cb_func = nullptr;
 
     std::atomic<uint64_t> m_nb_batch_in_flight;
     std::atomic<uint64_t> m_nb_group_in_flight;

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -174,16 +174,6 @@ struct cvk_command_queue : public _cl_command_queue,
         return m_command_pool.free_command_buffer(cmdbuf);
     }
 
-    size_t get_printf_buffer_size() {
-        auto& properties = m_context->properties();
-        for (unsigned i = 0; i < properties.size(); i += 2) {
-            if (properties[i] == CL_PRINTF_BUFFERSIZE_ARM) {
-                return properties[i + 1];
-            }
-        }
-        return config.printf_buffer_size;
-    }
-
     cvk_buffer* get_or_create_printf_buffer() {
         if (!m_printf_buffer) {
             cl_int status = CL_SUCCESS;

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <array>
-#include <iostream>
 #include <memory>
 
 #include "config.hpp"
@@ -185,7 +184,6 @@ struct cvk_command_queue : public _cl_command_queue,
                 auto all_props = m_context->properties();
                 buff_size = all_props[buff_size_prop_index];
             }
-           
             CVK_ASSERT(status == CL_SUCCESS);
             m_printf_buffer =
                 cvk_buffer::create(context(), 0, buff_size, nullptr, &status);
@@ -247,9 +245,7 @@ struct cvk_command_queue : public _cl_command_queue,
                                             _cl_event* const* event_list);
     int get_property_index(const int prop);
 
-    printf_callback_func* get_printf_cb_func() {
-        return m_cb_func;
-    }
+    printf_callback_func* get_printf_cb_func() { return m_cb_func; }
 
 private:
     CHECK_RETURN cl_int satisfy_data_dependencies(cvk_command* cmd);
@@ -280,10 +276,9 @@ private:
     cl_uint m_max_cmd_group_size;
     cl_uint m_max_first_cmd_group_size;
 
-    printf_callback_func* m_cb_func;
+    printf_callback_func* m_cb_func = nullptr;
 
-        std::atomic<uint64_t>
-            m_nb_batch_in_flight;
+    std::atomic<uint64_t> m_nb_batch_in_flight;
     std::atomic<uint64_t> m_nb_group_in_flight;
 
     TRACE_CNT_VAR(batch_in_flight_counter);

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -177,16 +177,9 @@ struct cvk_command_queue : public _cl_command_queue,
     cvk_buffer* get_or_create_printf_buffer() {
         if (!m_printf_buffer) {
             cl_int status = CL_SUCCESS;
-            auto buff_size_prop_index =
-                m_context->get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
-            unsigned int buff_size = config.printf_buffer_size;
-            if (buff_size_prop_index != -1) {
-                auto all_props = m_context->properties();
-                buff_size = all_props[buff_size_prop_index];
-            }
-            CVK_ASSERT(status == CL_SUCCESS);
-            m_printf_buffer =
-                cvk_buffer::create(context(), 0, buff_size, nullptr, &status);
+
+            m_printf_buffer = cvk_buffer::create(
+                context(), 0, m_context->get_buffer_size(), nullptr, &status);
             CVK_ASSERT(status == CL_SUCCESS);
         }
         return m_printf_buffer.get();

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -186,9 +186,18 @@ struct cvk_command_queue : public _cl_command_queue,
 
     cvk_buffer* get_or_create_printf_buffer() {
         if (!m_printf_buffer) {
-            cl_int status;
-            m_printf_buffer = cvk_buffer::create(
-                context(), 0, get_printf_buffer_size(), nullptr, &status);
+            cl_int status = CL_SUCCESS;
+            auto buff_size_prop_index =
+                get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
+            if (buff_size_prop_index == -1) {
+                cvk_error_fn("Could not get printf buffer size");
+                status = CL_INVALID_BUFFER_SIZE;
+            }
+            auto all_props = m_context->properties();
+            auto buff_size = all_props[buff_size_prop_index];
+            CVK_ASSERT(status == CL_SUCCESS);
+            m_printf_buffer =
+                cvk_buffer::create(context(), 0, buff_size, nullptr, &status);
             CVK_ASSERT(status == CL_SUCCESS);
         }
         return m_printf_buffer.get();
@@ -245,7 +254,7 @@ struct cvk_command_queue : public _cl_command_queue,
                                     _cl_event* const* event_list);
     cl_int execute_cmds_required_by_no_lock(cl_uint num_events,
                                             _cl_event* const* event_list);
-    bool get_printf_callback(printf_callback_func& callback);
+    int get_property_index(const int prop);
 
 private:
     CHECK_RETURN cl_int satisfy_data_dependencies(cvk_command* cmd);
@@ -783,12 +792,6 @@ struct cvk_command_kernel final : public cvk_command_batchable {
 
     cvk_command_kernel(cvk_command_queue* q, cvk_kernel* kernel, uint32_t dims,
                        const cvk_ndrange& ndrange)
-        : cvk_command_batchable(CL_COMMAND_NDRANGE_KERNEL, q), m_kernel(kernel),
-          m_dimensions(dims), m_ndrange(ndrange), m_pipeline(VK_NULL_HANDLE),
-          m_argument_values(nullptr) {}
-    cvk_command_kernel(cvk_command_queue* q, cvk_kernel* kernel, uint32_t dims,
-                       const cvk_ndrange& ndrange,
-                       std::function<void(const char*, size_t)> callback)
         : cvk_command_batchable(CL_COMMAND_NDRANGE_KERNEL, q), m_kernel(kernel),
           m_dimensions(dims), m_ndrange(ndrange), m_pipeline(VK_NULL_HANDLE),
           m_argument_values(nullptr) {}

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -178,7 +178,7 @@ struct cvk_command_queue : public _cl_command_queue,
         if (!m_printf_buffer) {
             cl_int status = CL_SUCCESS;
             auto buff_size_prop_index =
-                get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
+                m_context->get_property_index(CL_PRINTF_BUFFERSIZE_ARM);
             if (buff_size_prop_index == -1) {
                 cvk_error_fn("Could not get printf buffer size");
                 status = CL_INVALID_BUFFER_SIZE;

--- a/src/unit.hpp
+++ b/src/unit.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#define CLVK_PRINTF_USERDATA 0x5100
+
 #ifdef CLVK_UNIT_TESTING_ENABLED
 
 #include "config.hpp"

--- a/tests/api/compiler.cpp
+++ b/tests/api/compiler.cpp
@@ -447,13 +447,16 @@ TEST_F(WithContext, SetUnusedSamplerArg) {
 
     SetKernelArg(kernel, 0, sampler);
 }
-
+#include <iostream>
 TEST_F(WithContext, SetUnusedLocalArg) {
+    std::cout << "testing 1" << std::endl;
     static const char* source = R"(
       kernel void foo(local int* ptr) {}
     )";
+    std::cout << "testing 1" << std::endl;
 
     auto kernel = CreateKernel(source, "foo");
+    std::cout << "testing 1" << std::endl;
 
     SetKernelArg(kernel, 0, 64, nullptr);
 }

--- a/tests/api/compiler.cpp
+++ b/tests/api/compiler.cpp
@@ -447,7 +447,7 @@ TEST_F(WithContext, SetUnusedSamplerArg) {
 
     SetKernelArg(kernel, 0, sampler);
 }
-#include <iostream>
+
 TEST_F(WithContext, SetUnusedLocalArg) {
     static const char* source = R"(
       kernel void foo(local int* ptr) {}

--- a/tests/api/compiler.cpp
+++ b/tests/api/compiler.cpp
@@ -449,14 +449,11 @@ TEST_F(WithContext, SetUnusedSamplerArg) {
 }
 #include <iostream>
 TEST_F(WithContext, SetUnusedLocalArg) {
-    std::cout << "testing 1" << std::endl;
     static const char* source = R"(
       kernel void foo(local int* ptr) {}
     )";
-    std::cout << "testing 1" << std::endl;
 
     auto kernel = CreateKernel(source, "foo");
-    std::cout << "testing 1" << std::endl;
 
     SetKernelArg(kernel, 0, 64, nullptr);
 }

--- a/tests/api/printf.cpp
+++ b/tests/api/printf.cpp
@@ -37,8 +37,6 @@ static char stdoutBuffer[BUFFER_SIZE];
 std::vector<char> GLOBAL_BUFFER;
 size_t BUFFER_FILL_LEVEL = 0;
 
-std::string EXPECTED_STRING;
-
 static void releaseStdout(int fd) {
     fflush(stdout);
     dup2(fd, fileno(stdout));
@@ -87,14 +85,10 @@ private:
 static char* mkdtemp(char* tmpl, size_t size) {
 #ifdef WIN32
     if (_mktemp_s(tmpl, size + 1) != 0) {
-        fprintf(stderr, "Error creating temporary directory: %s\n",
-                tmpl); // Error handling
         return nullptr;
     }
 
     if (!CreateDirectory(tmpl, nullptr)) {
-        fprintf(stderr, "Error creating temporary directory: %s\n",
-                tmpl); // Error handling
         return nullptr;
     }
 
@@ -226,9 +220,7 @@ TEST_F(WithPrintfEnabled, PrintfMissingLengthModifier) {
     long int buff_size = 24;
     char source[512];
     const char message[] = "1,2,3,4";
-    EXPECTED_STRING = message;
     GLOBAL_BUFFER.resize(buff_size);
-
     sprintf(source, "kernel void test_printf() { printf(\"%s\");}", message);
     /* Create a cl_context with a printf_callback and user specified buffer
      * size. */

--- a/tests/api/printf.cpp
+++ b/tests/api/printf.cpp
@@ -228,7 +228,7 @@ TEST_F(WithCommandQueue, PrintfMissingLengthModifier) {
 }
 
 void printf_callback(const char* buffer, size_t len, size_t complete,
-                     +void* user_data) {
+                     void* user_data) {
     ASSERT_EQ(strlen(buffer), len);
     printf("Received data: %s (length: %zu)\n", buffer, len);
 }

--- a/tests/api/printf.cpp
+++ b/tests/api/printf.cpp
@@ -19,7 +19,6 @@
 #include "utils.hpp"
 #include <cstring>
 #include <filesystem>
-#include <iostream>
 
 #ifdef __APPLE__
 #include <unistd.h>
@@ -139,8 +138,8 @@ TEST_F(WithCommandQueue, SimplePrintf) {
 TEST_F(WithCommandQueue, TooLongPrintf) {
     // each print takes 12 bytes (4 for the printf_id, and 2*4 for the 2 integer
     // to print) + 4 for the byte written counter
-   // auto cfg1 =
-     //   CLVK_CONFIG_SCOPED_OVERRIDE(printf_buffer_size, uint32_t, 100000, true);
+    auto cfg1 =
+        CLVK_CONFIG_SCOPED_OVERRIDE(printf_buffer_size, uint32_t, 28, true);
 
     temp_folder_deletion temp;
     stdoutFileName = getStdoutFileName(temp);
@@ -238,7 +237,6 @@ TEST_F(WithCommandQueue, PrintfMissingLengthModifier) {
 void printf_callback(const char* buffer, size_t len, size_t complete,
                      void* user_data) {
     ASSERT_EQ(strlen(buffer), len);
-    printf("Received data: %s (length: %zu)\n", buffer, len);
 }
 
 TEST_F(WithPrintfEnabled, PrintSimple) {

--- a/tests/api/printf.cpp
+++ b/tests/api/printf.cpp
@@ -17,7 +17,6 @@
 #include "testcl.hpp"
 #include "unit.hpp"
 #include "utils.hpp"
-
 #include <cstring>
 #include <filesystem>
 
@@ -56,9 +55,8 @@ static char* getStdoutContent() {
     memset(stdoutBuffer, 0, BUFFER_SIZE);
     fflush(stdout);
     f = fopen(stdoutFileName.c_str(), "r");
-    if (f == nullptr) {
+    if (f == nullptr)
         return nullptr;
-    }
 
     char* ptr = stdoutBuffer;
     do {
@@ -72,9 +70,8 @@ static char* getStdoutContent() {
 
 struct temp_folder_deletion {
     ~temp_folder_deletion() {
-        if (!m_path.empty()) {
+        if (!m_path.empty())
             std::filesystem::remove_all(m_path.c_str());
-        }
     }
     void set_path(std::string path) { m_path = path; }
 
@@ -230,9 +227,10 @@ TEST_F(WithCommandQueue, PrintfMissingLengthModifier) {
     ASSERT_STREQ(printf_buffer, message);
 }
 
-void printf_callback(const char* buffer, size_t len) {
+void printf_callback(const char* buffer, size_t len, size_t complete,
+                     +void* user_data) {
     ASSERT_EQ(strlen(buffer), len);
-    printf("%.*s", len, buffer);
+    printf("Received data: %s (length: %zu)\n", buffer, len);
 }
 
 TEST_F(WithPrintfEnabled, PrintSimple) {

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -773,7 +773,7 @@ protected:
 
 class WithPrintfEnabled : public WithCommandQueue {
 protected:
-    void SetUp() override {};
+    void SetUp() override{};
     void TearDown() override {
         cl_int err = clReleaseContext(m_context);
         ASSERT_CL_SUCCESS(err);

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -39,6 +39,15 @@
 #include "unit.hpp"
 #include "utils.hpp"
 
+#ifdef __APPLE__
+#include <unistd.h>
+#endif
+
+#ifdef WIN32
+#include <Windows.h>
+#include <io.h>
+#endif
+
 #define CLVK_CONFIG_ASSERT_GT(opt, val)                                        \
     ASSERT_GT(clvk_get_config()->opt.value, val)
 #define CLVK_CONFIG_ASSERT_EQ(opt, val)                                        \

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -779,5 +779,5 @@ protected:
 
 class WithCommandQueueNoSetUp : public WithCommandQueue {
 protected:
-    void SetUp() override {};
+    void SetUp() override{};
 };

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -523,7 +523,6 @@ protected:
     void SetUp() override { SetUpQueue(0); }
 
     void TearDown() override {
-
 #ifdef COMPILER_AVAILABLE 
         ReleaseCommandQueue(m_queue);
         WithContext::TearDown();

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -777,9 +777,7 @@ protected:
 
 class WithProfiledCommandQueue : public WithCommandQueue {
 protected:
-    void SetUp() override {
-        SetUpWithQueueProperties(CL_QUEUE_PROFILING_ENABLE);
-    }
+    void SetUp() override { SetUpWithContextProperties(nullptr); }
 };
 
 class WithPrintfEnabled : public WithCommandQueue {

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -769,7 +769,7 @@ protected:
 
 class WithPrintfEnabled : public WithCommandQueue {
 protected:
-    void SetUp() override {};
+    void SetUp() override{};
     void TearDown() override {
         if (m_queue != nullptr) {
             WithCommandQueue::TearDown();

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -785,7 +785,7 @@ protected:
 
 class WithPrintfEnabled : public WithCommandQueue {
 protected:
-    void SetUp() override {};
+    void SetUp() override{};
     void TearDown() override { WithCommandQueue::TearDown(); }
 
     void SetUpWithContextProperties(const cl_context_properties* _props) {

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -531,12 +531,6 @@ protected:
         SetUpQueue(0);
     }
 
-    void reset_buffer_size(size_t new_size) {
-        CLVK_CONFIG_SCOPED_OVERRIDE(printf_buffer_size, uint32_t, new_size,
-                                    true);
-        WithCommandQueue::SetUp();
-    }
-
     void TearDown() override {
 #ifdef COMPILER_AVAILABLE
         ReleaseCommandQueue(m_queue);

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -524,7 +524,8 @@ protected:
 
     void TearDown() override {
 
-#ifdef COMPILER_AVAILABLE ReleaseCommandQueue(m_queue);
+#ifdef COMPILER_AVAILABLE 
+        ReleaseCommandQueue(m_queue);
         WithContext::TearDown();
 #endif
     }

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -1,7 +1,7 @@
 // Copyright 2018 The clvk authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// you may not use this file except in compliance with the License.co
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
@@ -761,4 +761,21 @@ protected:
 class WithProfiledCommandQueue : public WithCommandQueue {
 protected:
     void SetUp() override { SetUpQueue(CL_QUEUE_PROFILING_ENABLE); }
+};
+
+class WithPrintfEnabled : public WithCommandQueue {
+protected:
+    void SetUp() override {};
+    void TearDown() override {
+        cl_int err = clReleaseContext(m_context);
+        ASSERT_CL_SUCCESS(err);
+    }
+
+    void SetupPrintfCallback(const cl_context_properties* props) {
+        cl_int err;
+        m_context = clCreateContext(props, 1, &gDevice, nullptr, nullptr, &err);
+        ASSERT_CL_SUCCESS(err);
+        m_queue = clCreateCommandQueue(m_context, gDevice, 0, &err);
+        ASSERT_CL_SUCCESS(err);
+    }
 };

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -520,7 +520,9 @@ protected:
         m_queue = queue.release();
     }
 
-    void SetUp() override { SetUpWithContextProperties(nullptr); }
+    void SetUp() override {
+        SetUpWithContextProperties(nullptr);
+    }
 
     void SetUpWithContextProperties(const cl_context_properties* _prop) {
         WithContext::SetUpWithContextProperties(_prop);
@@ -775,7 +777,7 @@ protected:
 
 class WithProfiledCommandQueue : public WithCommandQueue {
 protected:
-    void SetUp() override { SetUpWithContextProperties(nullptr); }
+    void SetUp() override { SetUpWithQueueProperties(CL_QUEUE_PROFILING_ENABLE); }
 };
 
 class WithPrintfEnabled : public WithCommandQueue {

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -520,9 +520,7 @@ protected:
         m_queue = queue.release();
     }
 
-    void SetUp() override {
-        SetUpWithContextProperties(nullptr);
-    }
+    void SetUp() override { SetUpWithContextProperties(nullptr); }
 
     void SetUpWithContextProperties(const cl_context_properties* _prop) {
         WithContext::SetUpWithContextProperties(_prop);
@@ -777,7 +775,7 @@ protected:
 
 class WithProfiledCommandQueue : public WithCommandQueue {
 protected:
-    void SetUp() override { 
+    void SetUp() override {
         SetUpWithQueueProperties(CL_QUEUE_PROFILING_ENABLE);
     }
 };

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -765,7 +765,7 @@ protected:
 
 class WithPrintfEnabled : public WithCommandQueue {
 protected:
-    void SetUp() override {};
+    void SetUp() override{};
     void TearDown() override {
         cl_int err = clReleaseContext(m_context);
         ASSERT_CL_SUCCESS(err);

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -777,7 +777,9 @@ protected:
 
 class WithProfiledCommandQueue : public WithCommandQueue {
 protected:
-    void SetUp() override { SetUpWithQueueProperties(CL_QUEUE_PROFILING_ENABLE); }
+    void SetUp() override { 
+        SetUpWithQueueProperties(CL_QUEUE_PROFILING_ENABLE);
+    }
 };
 
 class WithPrintfEnabled : public WithCommandQueue {

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -782,7 +782,7 @@ protected:
 
 class WithPrintfEnabled : public WithCommandQueue {
 protected:
-    void SetUp() override {};
+    void SetUp() override{};
     void TearDown() override { WithCommandQueue::TearDown(); }
 
     void SetupPrintfCallback(const cl_context_properties* _props) {

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -520,9 +520,7 @@ protected:
         m_queue = queue.release();
     }
 
-    void SetUp() override {
-        SetUpWithContextProperties(nullptr);
-    }
+    void SetUp() override { SetUpWithContextProperties(nullptr); }
 
     void SetUpWithContextProperties(const cl_context_properties* _prop) {
         WithContext::SetUpWithContextProperties(_prop);

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -37,6 +37,7 @@
 
 #ifdef CLVK_UNIT_TESTING_ENABLED
 #include "unit.hpp"
+#include "utils.hpp"
 
 #define CLVK_CONFIG_ASSERT_GT(opt, val)                                        \
     ASSERT_GT(clvk_get_config()->opt.value, val)
@@ -802,7 +803,7 @@ protected:
             CL_PRINTF_CALLBACK_ARM,
             (cl_context_properties)printf_cb,
             CL_PRINTF_BUFFERSIZE_ARM,
-            buff_size,
+            (long)buff_size,
         };
 
         WithCommandQueue::SetUpWithContextProperties(properties.data());

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
-
 #pragma once
 
 #if defined(USING_SWIFTSHADER)
@@ -771,18 +769,15 @@ protected:
 
 class WithPrintfEnabled : public WithCommandQueue {
 protected:
-    void SetUp() override { WithContext::SetUp(); };
+    void SetUp() override {};
     void TearDown() override {
-        cl_int err = clReleaseContext(m_context);
-        ASSERT_CL_SUCCESS(err);
-        if (m_context != nullptr) {
-            WithContext::TearDown();
+        if (m_queue != nullptr) {
+            WithCommandQueue::TearDown();
         }
     }
 
     void SetupPrintfCallback(const cl_context_properties* props) {
         m_props = props;
-        WithContext::SetUp();
-        SetUpQueue(0);
+        WithCommandQueue::SetUp();
     }
 };

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -523,7 +523,7 @@ protected:
     void SetUp() override { SetUpQueue(0); }
 
     void TearDown() override {
-#ifdef COMPILER_AVAILABLE 
+#ifdef COMPILER_AVAILABLE
         ReleaseCommandQueue(m_queue);
         WithContext::TearDown();
 #endif


### PR DESCRIPTION
This addresses #710 and fails with the correct argument when out of order execution is attempted on a device that does not support out of order execution.