### PR TITLE
fix lifetime of cvk_entry_point

### DIFF
--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -161,7 +161,7 @@ private:
 
     std::mutex m_lock;
     cvk_program_holder m_program;
-    cvk_entry_point* m_entry_point;
+    std::shared_ptr<cvk_entry_point> m_entry_point;
     std::string m_name;
     std::vector<kernel_argument> m_args;
     std::shared_ptr<cvk_kernel_argument_values> m_argument_values;
@@ -177,7 +177,7 @@ using cvk_kernel_holder = refcounted_holder<cvk_kernel>;
 
 struct cvk_kernel_argument_values {
 
-    cvk_kernel_argument_values(cvk_entry_point* entry_point)
+    cvk_kernel_argument_values(std::shared_ptr<cvk_entry_point> entry_point)
         : m_entry_point(entry_point), m_is_enqueued(false),
           m_args(m_entry_point->args()), m_pod_arg(nullptr),
           m_kernel_resources(m_entry_point->num_resource_slots()),
@@ -203,7 +203,7 @@ struct cvk_kernel_argument_values {
     }
 
     static std::shared_ptr<cvk_kernel_argument_values>
-    create(cvk_entry_point* entry_point) {
+    create(std::shared_ptr<cvk_entry_point> entry_point) {
         auto val = std::make_shared<cvk_kernel_argument_values>(entry_point);
 
         if (!val->init()) {
@@ -416,7 +416,7 @@ private:
     }
 
     std::mutex m_lock;
-    cvk_entry_point* m_entry_point;
+    std::shared_ptr<cvk_entry_point> m_entry_point;
     std::unique_ptr<std::vector<uint8_t>> m_pod_data;
     bool m_is_enqueued;
     const std::vector<kernel_argument>& m_args;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -799,8 +799,8 @@ public:
 
     const VkPipelineCache& pipeline_cache() const { return m_pipeline_cache; }
 
-    CHECK_RETURN cvk_entry_point* get_entry_point(std::string& name,
-                                                  cl_int* errcode_ret);
+    CHECK_RETURN std::shared_ptr<cvk_entry_point>
+    get_entry_point(std::string& name, cl_int* errcode_ret);
 
     bool create_module_constant_data_buffer() {
         cl_int err;
@@ -901,7 +901,7 @@ private:
     std::string m_build_log;
     std::vector<cvk_sampler_holder> m_literal_samplers;
     VkPushConstantRange m_push_constant_range;
-    std::unordered_map<std::string, std::unique_ptr<cvk_entry_point>>
+    std::unordered_map<std::string, std::shared_ptr<cvk_entry_point>>
         m_entry_points;
     std::vector<uint32_t> m_stripped_binary;
     VkPipelineCache m_pipeline_cache;


### PR DESCRIPTION
cvk_entry_point are passed to other structures as a pointer. But it can be deleted at any point when do_build it called.

To avoid invalid access, make entry point a shared_ptr in the program map.

This has been detected running the compiler suite of the CTS on ChromeOS (flaky behaviour).