### PR TITLE
add config option to mask device extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,10 @@ using the name of the corresponding environment variable.
   with caution.
 
 * `CLVK_DEVICE_EXTENSIONS` specifies extensions to be added to the list of
-  exposed extensions. It expects a whitespace separated list of extensions.
+  exposed extensions. It expects a comma separated list of extensions.
+
+* `CLVK_DEVICE_EXTENSIONS_MASKED` specifies extensions to be removed from the
+  list of exposed extensions. It expects a comma separated list of extensions.
 
 * `CLVK_BUILD_IN_SEPARATE_THREAD` force to build kernels in a separate thread
   (default: false). It brings a slight overhead when creating the thread, but

--- a/src/config.def
+++ b/src/config.def
@@ -62,6 +62,7 @@ OPTION(uint32_t, enqueue_command_retry_sleep_us, UINT32_MAX) // UINT32_MAX meani
 OPTION(bool, supports_filter_linear, true)
 
 OPTION(std::string, device_extensions, "")
+OPTION(std::string, device_extensions_masked, "")
 
 //
 // Logging

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -722,11 +722,23 @@ void cvk_device::build_extension_ils_list() {
         m_extensions.push_back(extension);
     }
 
+    auto config_extensions_masked =
+        split_string(config.device_extensions_masked(), ',');
+    for (auto& config_extension_masked : config_extensions_masked) {
+        for (auto it = m_extensions.begin(); it != m_extensions.end(); it++) {
+            if (strcmp(config_extension_masked.c_str(), it->name) == 0) {
+                m_extensions.erase(it);
+                break;
+            }
+        }
+    }
+
     // Build extension string
     for (auto& ext : m_extensions) {
         m_extension_string += ext.name;
         m_extension_string += " ";
     }
+    cvk_info_fn("extensions: '%s'", m_extension_string.c_str());
 
     // Build list of ILs
     m_ils = {


### PR DESCRIPTION
This is useful when experimenting with complex applications, without having to modify clvk nor the application.