### PR TITLE
Marked "DaVinci Resolve" as Unsupported.

### DIFF
--- a/docs/supported-applications.md
+++ b/docs/supported-applications.md
@@ -37,7 +37,7 @@
 | [Geekbench 5](https://www.geekbench.com/) | Partial support |
 | [Libreoffice](https://www.libreoffice.org/) | Untested |
 | [hashcat](https://github.com/hashcat/hashcat) | :x: Kernel build fails |
-| [DaVinci Resolve](https://www.blackmagicdesign.com/uk/products/davinciresolve) | Untested |
+| [DaVinci Resolve](https://www.blackmagicdesign.com/uk/products/davinciresolve) | Not supported |
 | [TFLite](https://github.com/tensorflow/tensorflow.git) | :heavy_check_mark: Supported |
 
 If you've tested an application or want an application to be tested,


### PR DESCRIPTION
I've tested DaVinci Resolve and [OpenCL-Benchmark](https://github.com/ProjectPhysX/OpenCL-Benchmark) within a machine with clvk correctly installed (since OpenCL-Benchmark works).

Then, to double check, I've tested the same softwares with the mesa Clover implementation.

The devices generated by clvk are correctly recognized but attempting to do any OpenCL accelerated operation (so basically everything in the software except tweaking the settings) crashes the app instantly.