### PR TITLE
Support for cl_mem_device_address_EXT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /build
+test-dev-buffer
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 /build
-test-dev-buffer
-.vscode

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -6147,6 +6147,7 @@ cl_int clSetKernelArgDevicePointerEXT_fn(cl_kernel kernel, cl_uint arg_index, cl
     auto const& arg = kern->arguments()[arg_index];
 
     // Validate argument is a pointer type
+    // device pointer kernel argument of type __global is buffer type here so failure
     // if (!arg.is_pod_pointer()) {
     //     return CL_INVALID_ARG_VALUE;
     // }

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -30,6 +30,31 @@
 
 #define CLVK_API_CALL CL_API_CALL
 
+#ifndef cl_ext_buffer_device_address
+#define cl_ext_buffer_device_address
+
+#ifndef CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT
+#define CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT 0x11B8
+#endif
+
+#ifndef CL_MEM_DEVICE_ADDRESS_EXT
+#define CL_MEM_DEVICE_ADDRESS_EXT (1ul << 31)
+#endif
+
+#ifndef CL_MEM_DEVICE_PTR_EXT
+#define CL_MEM_DEVICE_PTR_EXT 0xff01
+#endif
+
+typedef cl_ulong cl_mem_device_address_EXT;
+
+// typedef cl_int(CL_API_CALL *clSetKernelArgDevicePointerEXT_fn)(
+//     cl_kernel kernel, cl_uint arg_index, cl_mem_device_address_EXT dev_addr);
+
+cl_int clSetKernelArgDevicePointerEXT_fn(cl_kernel kernel, cl_uint arg_index, cl_mem_device_address_EXT dev_addr);
+
+
+#endif // cl_ext_buffer_device_address
+
 namespace {
 
 // Validation functions
@@ -303,6 +328,7 @@ static const std::unordered_map<std::string, void*> gExtensionEntrypoints = {
     EXTENSION_ENTRYPOINT(clCreateCommandQueueWithPropertiesKHR),
     EXTENSION_ENTRYPOINT(clGetKernelSuggestedLocalWorkSizeKHR),
     {"clGetKernelSubGroupInfoKHR", FUNC_PTR(clGetKernelSubGroupInfo)},
+    {"clSetKernelArgDevicePointerEXT", FUNC_PTR(clSetKernelArgDevicePointerEXT_fn)},
     EXTENSION_ENTRYPOINT(clCreateSemaphoreWithPropertiesKHR),
     EXTENSION_ENTRYPOINT(clEnqueueWaitSemaphoresKHR),
     EXTENSION_ENTRYPOINT(clEnqueueSignalSemaphoresKHR),
@@ -2111,6 +2137,21 @@ cl_int CLVK_API_CALL clGetMemObjectInfo(cl_mem mem, cl_mem_info param_name,
         copy_ptr = memobj->properties().data();
         ret_size = memobj->properties().size() * sizeof(cl_mem_properties);
         break;
+    case CL_MEM_DEVICE_PTR_EXT: {
+        auto buffer = static_cast<cvk_buffer*>(memobj);
+        if (!buffer->is_buffer_type()) {
+            ret = CL_INVALID_MEM_OBJECT;
+            break;
+        }
+        if (!buffer->context()->device()->supports_buffer_device_address()) {
+            ret = CL_INVALID_OPERATION;
+            break;
+        }
+        val_sizet = buffer->device_address();
+        copy_ptr = &val_sizet;
+        ret_size = sizeof(val_sizet);
+        break;
+    }
     default:
         ret = CL_INVALID_VALUE;
     }
@@ -6082,6 +6123,36 @@ cl_int clGetSemaphoreInfoKHR(const cl_semaphore_khr sema_object,
     }
 
     return ret;
+}
+
+cl_int clSetKernelArgDevicePointerEXT_fn(cl_kernel kernel, cl_uint arg_index, cl_mem_device_address_EXT dev_addr) {
+    TRACE_FUNCTION("kernel", (uintptr_t)kernel, "arg_index", arg_index);
+    LOG_API_CALL("kernel = %p, arg_index = %u, dev_addr = %p",
+                 kernel, arg_index, (void*)dev_addr);
+
+    auto kern = icd_downcast(kernel);
+
+    // Validate kernel
+    if (!is_valid_kernel(kern)) {
+        return CL_INVALID_KERNEL;
+    }
+
+    // Validate argument index 
+    if (arg_index >= kern->num_args()) {
+        cvk_error_fn("the program has only %u arguments", kern->num_args());
+        return CL_INVALID_ARG_INDEX;
+    }
+
+    // Get argument info
+    auto const& arg = kern->arguments()[arg_index];
+
+    // Validate argument is a pointer type
+    // if (!arg.is_pod_pointer()) {
+    //     return CL_INVALID_ARG_VALUE;
+    // }
+
+    // Set the argument using the device address
+    return kern->set_arg(arg_index, sizeof(dev_addr), &dev_addr);
 }
 
 cl_int clReleaseSemaphoreKHR(cl_semaphore_khr sema_object) {

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -626,6 +626,7 @@ void cvk_device::build_extension_ils_list() {
         // Add always supported extensions
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_extended_versioning"),
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_create_command_queue"),
+        MAKE_NAME_VERSION(1, 0, 0, "cl_ext_buffer_device_address"),
 #ifdef ENABLE_SPIRV_IL
         MAKE_NAME_VERSION(1, 0, 0, "cl_khr_il_program"),
 #endif

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -47,6 +47,8 @@ struct cvk_platform;
 
 struct cvk_device : public _cl_device_id,
                     object_magic_header<object_magic::device> {
+    std::unordered_map<void*, void*> buffer_to_device_map;
+    std::unordered_map<void*, void*> device_to_buffer_map;
 
     cvk_device(cvk_platform* platform, VkPhysicalDevice pd, bool is_default)
         : m_platform(platform), m_pdev(pd) {

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -47,7 +47,8 @@ struct cvk_platform;
 
 struct cvk_device : public _cl_device_id,
                     object_magic_header<object_magic::device> {
-    std::unordered_map<void*, void*> buffer_to_device_map;
+    /// Map for storing device pointers to buffer pointers
+    /// Support cl_ext_buffer_device_address
     std::unordered_map<void*, void*> device_to_buffer_map;
 
     cvk_device(cvk_platform* platform, VkPhysicalDevice pd, bool is_default)

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -699,6 +699,10 @@ struct cvk_device : public _cl_device_id,
                0;
     }
 
+    bool supports_buffer_device_address() const {
+        return m_features_buffer_device_address.bufferDeviceAddress;
+    }
+
 private:
     std::string version_desc() const {
         std::string ret = "CLVK on Vulkan v";

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -27,6 +27,16 @@
 
 struct cvk_kernel_argument_values;
 
+#ifndef CL_MEM_DEVICE_ADDRESS_EXT
+#define CL_MEM_DEVICE_ADDRESS_EXT (1ul << 31)
+#endif
+
+#ifndef CL_MEM_DEVICE_PTR_EXT
+#define CL_MEM_DEVICE_PTR_EXT 0xff01
+#endif
+
+typedef cl_ulong cl_mem_device_address_EXT;
+
 struct cvk_kernel : public _cl_kernel, api_object<object_magic::kernel> {
 
     cvk_kernel(cvk_program* program, const char* name)
@@ -320,15 +330,22 @@ struct cvk_kernel_argument_values {
 
                 m_kernel_resources[arg.binding] = sampler;
             } else {
-                auto apimem = *reinterpret_cast<const cl_mem*>(value);
-                if (apimem == nullptr) {
-                    return CL_INVALID_MEM_OBJECT;
+                // Handle both cl_mem and device pointer cases
+                if (size == sizeof(cl_mem)) {
+                    auto apimem = *reinterpret_cast<const cl_mem*>(value);
+                    if (apimem == nullptr) {
+                        return CL_INVALID_MEM_OBJECT;
+                    }
+                    // Create a new cvk_mem object for the device pointer
+                    auto device_ptr = *reinterpret_cast<const cl_mem_device_address_EXT*>(value);
+                    auto buffer_ptr_raw = m_entry_point->program()->context()->device()->device_to_buffer_map[(void*)device_ptr];
+                    auto buffer_ptr = reinterpret_cast<cvk_buffer*>(buffer_ptr_raw);
+                    m_kernel_resources[arg.binding] = buffer_ptr;
+                    // set_pod_data(arg.offset, arg.size, &device_ptr);
+
+                } else {
+                    return CL_INVALID_ARG_SIZE;
                 }
-                auto mem = icd_downcast(apimem);
-                if (!mem->is_valid()) {
-                    return CL_INVALID_MEM_OBJECT;
-                }
-                m_kernel_resources[arg.binding] = mem;
             }
         }
 

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -330,6 +330,7 @@ struct cvk_kernel_argument_values {
 
                 m_kernel_resources[arg.binding] = sampler;
             } else {
+                // TODO: special elif the arg is a device pointer
                 // first check if the arg device pointer is in the map
                 // Create a new cvk_mem object for the device pointer
                 auto device_ptr = *reinterpret_cast<const cl_mem_device_address_EXT*>(value);

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -329,32 +329,32 @@ struct cvk_kernel_argument_values {
                 }
 
                 m_kernel_resources[arg.binding] = sampler;
-            } else {
-                // TODO: special elif the arg is a device pointer
-                // first check if the arg device pointer is in the map
-                // Create a new cvk_mem object for the device pointer
-                auto device_ptr = *reinterpret_cast<const cl_mem_device_address_EXT*>(value);
-                auto device_to_buffer_map = m_entry_point->program()->context()->device()->device_to_buffer_map;
+            } else if (arg.kind == kernel_argument_kind::buffer) {
+                auto device_ptr =
+                    *reinterpret_cast<const cl_mem_device_address_EXT*>(value);
+                auto device_to_buffer_map = m_entry_point->program()
+                                                ->context()
+                                                ->device()
+                                                ->device_to_buffer_map;
                 auto it = device_to_buffer_map.find((void*)device_ptr);
                 if (it == device_to_buffer_map.end()) {
-                    // Handle error case - pointer not found
-                    // Perhaps throw an exception or handle appropriately
-                    auto apimem = *reinterpret_cast<const cl_mem*>(value);
-                    if (apimem == nullptr) {
-                        return CL_INVALID_MEM_OBJECT;
-                    }
-                    auto mem = icd_downcast(apimem);
-                    if (!mem->is_valid()) {
                     return CL_INVALID_MEM_OBJECT;
-                    }
-                    m_kernel_resources[arg.binding] = mem;
                 }
-                
 
                 // device pointer found in map, swapping the buffer pointer
                 auto buffer_ptr_raw = it->second;
                 auto buffer_ptr = reinterpret_cast<cvk_buffer*>(buffer_ptr_raw);
                 m_kernel_resources[arg.binding] = buffer_ptr;
+            } else {
+                auto apimem = *reinterpret_cast<const cl_mem*>(value);
+                if (apimem == nullptr) {
+                    return CL_INVALID_MEM_OBJECT;
+                }
+                auto mem = icd_downcast(apimem);
+                if (!mem->is_valid()) {
+                    return CL_INVALID_MEM_OBJECT;
+                }
+                m_kernel_resources[arg.binding] = mem;
             }
         }
 

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -476,8 +476,10 @@ struct cvk_buffer : public cvk_mem {
         auto device = context()->device();
         auto vkdev = device->vulkan_device();
         auto device_address =
-            device->vkfns().vkGetBufferDeviceAddressKHR(vkdev, &info);
-        return device_address + vulkan_buffer_offset();
+            device->vkfns().vkGetBufferDeviceAddressKHR(vkdev, &info) + vulkan_buffer_offset();
+        device->buffer_to_device_map[(void*)this] = (void*)device_address;
+        device->device_to_buffer_map[(void*)device_address] = (void*)this;
+        return device_address;
     }
 
 private:

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -476,8 +476,8 @@ struct cvk_buffer : public cvk_mem {
         auto device = context()->device();
         auto vkdev = device->vulkan_device();
         auto device_address =
-            device->vkfns().vkGetBufferDeviceAddressKHR(vkdev, &info) + vulkan_buffer_offset();
-        device->buffer_to_device_map[(void*)this] = (void*)device_address;
+            device->vkfns().vkGetBufferDeviceAddressKHR(vkdev, &info) +
+            vulkan_buffer_offset();
         device->device_to_buffer_map[(void*)device_address] = (void*)this;
         return device_address;
     }

--- a/test-dev-buffer/CMakeLists.txt
+++ b/test-dev-buffer/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.10)
+project(opencl_device_ptr_test)
+# Enable debug build
+set(CMAKE_BUILD_TYPE Debug)
+
+# Add debug flags
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+
+
+
+# Find OpenCL package
+find_package(OpenCL REQUIRED)
+
+# Add executable
+add_executable(device_ptr_test main.cpp)
+
+# Link OpenCL
+target_link_libraries(device_ptr_test OpenCL::OpenCL)

--- a/test-dev-buffer/main.cpp
+++ b/test-dev-buffer/main.cpp
@@ -1,0 +1,236 @@
+#include <CL/cl.h>
+#include <iostream>
+#include <vector>
+#include <string>
+#include <cstring>
+#include <cstddef>  // for size_t
+
+// Extension definitions from CHIPBackendOpenCL.hh
+#ifndef cl_ext_buffer_device_address
+#define cl_ext_buffer_device_address 1
+#define CL_DEVICE_PTR_EXT 0xff01
+#define CL_MEM_DEVICE_ADDRESS_EXT (1ul << 31)
+#define CL_MEM_DEVICE_PTR_EXT 0xff01
+typedef cl_ulong cl_mem_device_address_EXT;
+typedef cl_int(CL_API_CALL *clSetKernelArgDevicePointerEXT_fn)(
+    cl_kernel kernel, cl_uint arg_index, cl_mem_device_address_EXT dev_addr);
+#endif
+
+// OpenCL kernel source that adds 1 to each element
+const char* kernelSource = R"(
+__kernel void increment(__global int* input) {
+    int gid = get_global_id(0);
+    input[gid] += 1;
+}
+)";
+
+// Error checking helper function
+void checkError(cl_int error, const char* operation) {
+    if (error != CL_SUCCESS) {
+        std::cerr << "Error during operation " << operation << ": " << error << std::endl;
+        exit(1);
+    }
+}
+
+// Add this helper function at the top level
+cl_device_id selectDevice(cl_platform_id& platform) {
+    cl_int err;
+    
+    // Get platforms
+    cl_uint num_platforms;
+    err = clGetPlatformIDs(0, nullptr, &num_platforms);
+    checkError(err, "getting number of platforms");
+
+    std::vector<cl_platform_id> platforms(num_platforms);
+    err = clGetPlatformIDs(num_platforms, platforms.data(), nullptr);
+    checkError(err, "getting platform IDs");
+
+    // For each platform, get and print devices
+    for (cl_uint p = 0; p < num_platforms; p++) {
+        platform = platforms[p];
+        
+        // Get number of devices
+        cl_uint num_devices;
+        err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, nullptr, &num_devices);
+        checkError(err, "getting number of devices");
+
+        std::vector<cl_device_id> devices(num_devices);
+        err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, num_devices, devices.data(), nullptr);
+        checkError(err, "getting device IDs");
+
+        // Print device info
+        std::cout << "Platform " << p << " has " << num_devices << " device(s):" << std::endl;
+        for (cl_uint d = 0; d < num_devices; d++) {
+            size_t valueSize;
+            err = clGetDeviceInfo(devices[d], CL_DEVICE_NAME, 0, nullptr, &valueSize);
+            checkError(err, "getting device name size");
+            
+            std::string deviceName(valueSize, '\0');
+            err = clGetDeviceInfo(devices[d], CL_DEVICE_NAME, valueSize, &deviceName[0], nullptr);
+            checkError(err, "getting device name");
+            
+            std::cout << "\t" << d << ": " << deviceName << std::endl;
+        }
+    }
+
+    // Get user input for device selection
+    unsigned int platformIndex, deviceIndex;
+    std::cout << "Select platform index: ";
+    std::cin >> platformIndex;
+    std::cout << "Select device index: ";
+    std::cin >> deviceIndex;
+
+    if (platformIndex >= num_platforms) {
+        std::cerr << "Invalid platform index" << std::endl;
+        exit(1);
+    }
+
+    platform = platforms[platformIndex];
+    cl_uint num_devices;
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, nullptr, &num_devices);
+    checkError(err, "getting number of devices");
+
+    if (deviceIndex >= num_devices) {
+        std::cerr << "Invalid device index" << std::endl;
+        exit(1);
+    }
+
+    std::vector<cl_device_id> devices(num_devices);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, num_devices, devices.data(), nullptr);
+    checkError(err, "getting device IDs");
+    return devices[deviceIndex];
+}
+
+bool kernelTest(cl_platform_id platform, cl_device_id device) {
+    cl_int err;
+    // Remove device selection code and start with extension check
+    size_t ext_size;
+    err = clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, 0, nullptr, &ext_size);
+    checkError(err, "getting extension size");
+
+    std::vector<char> extensions(ext_size);
+    err = clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, ext_size, extensions.data(), nullptr);
+    checkError(err, "getting extensions");
+
+    bool hasBufferDeviceAddress = 
+        std::string(extensions.data()).find("cl_ext_buffer_device_address") != std::string::npos;
+
+    if (!hasBufferDeviceAddress) {
+        std::cout << "Warning: Device does not support cl_ext_buffer_device_address extension\n";
+        std::cout << "Available extensions:\n" << extensions.data() << std::endl;
+        return false;
+    }
+    std::cout << "Device supports cl_ext_buffer_device_address extension\n";
+
+    // Get the extension function pointer
+    clSetKernelArgDevicePointerEXT_fn clSetKernelArgDevicePointerEXT = 
+        (clSetKernelArgDevicePointerEXT_fn)
+        clGetExtensionFunctionAddressForPlatform(platform, "clSetKernelArgDevicePointerEXT");
+    
+    if (!clSetKernelArgDevicePointerEXT) {
+        std::cout << "Failed to get clSetKernelArgDevicePointerEXT function pointer\n";
+        return false;
+    }
+
+    // Create context
+    cl_context context = clCreateContext(nullptr, 1, &device, nullptr, nullptr, &err);
+    checkError(err, "creating context");
+
+    // Create command queue
+    cl_command_queue queue = clCreateCommandQueue(context, device, 0, &err);
+    checkError(err, "creating command queue");
+
+    // Create and build the program
+    cl_program program = clCreateProgramWithSource(context, 1, &kernelSource, nullptr, &err);
+    checkError(err, "creating program");
+
+    err = clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr);
+    if (err != CL_SUCCESS) {
+        size_t len;
+        char buffer[2048];
+        clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, sizeof(buffer), buffer, &len);
+        std::cerr << "Build error: " << buffer << std::endl;
+        exit(1);
+    }
+
+    
+
+    // Create kernel
+    cl_kernel kernel = clCreateKernel(program, "increment", &err);
+    checkError(err, "creating kernel");
+
+    // Create a device buffer with CL_MEM_DEVICE_ADDRESS_EXT flag
+    const size_t buffer_size = 1024 * sizeof(int);
+    cl_mem device_buffer = clCreateBuffer(context, 
+                                        CL_MEM_READ_WRITE | CL_MEM_DEVICE_ADDRESS_EXT,
+                                        buffer_size, nullptr, &err);
+    checkError(err, "creating device buffer");
+
+    // Get device pointer
+    cl_mem_device_address_EXT device_ptr;
+    err = clGetMemObjectInfo(device_buffer, CL_MEM_DEVICE_PTR_EXT, 
+                            sizeof(device_ptr), &device_ptr, nullptr);
+    if (err != CL_SUCCESS) {
+        std::cout << "Failed to get device pointer (Error: " << err << ")\n";
+        return false;
+    }
+    std::cout << "Successfully obtained device pointer: 0x" << std::hex << device_ptr << std::dec << std::endl;
+
+    // Initialize buffer with test data
+    std::vector<int> host_data(1024, 1);  // Initialize with 1s
+    err = clEnqueueWriteBuffer(queue, device_buffer, CL_TRUE, 0, buffer_size, 
+                              host_data.data(), 0, nullptr, nullptr);
+    checkError(err, "writing to buffer");
+
+    // Set kernel argument using the device pointer
+    err = clSetKernelArgDevicePointerEXT(kernel, 0, device_ptr);
+    if (err != CL_SUCCESS) {
+        std::cout << "Failed to set kernel argument with device pointer (Error: " << err << ")\n";
+        return false;
+    }
+
+    // Execute kernel
+    size_t global_size = 1024;
+    err = clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &global_size, 
+                                nullptr, 0, nullptr, nullptr);
+    checkError(err, "enqueueing kernel");
+
+    // Read back results
+    std::vector<int> result(1024);
+    err = clEnqueueReadBuffer(queue, device_buffer, CL_TRUE, 0, buffer_size, 
+                             result.data(), 0, nullptr, nullptr);
+    checkError(err, "reading results");
+
+    // Verify results
+    bool correct = true;
+    for (int i = 0; i < 1024; i++) {
+        if (result[i] != 2) {  // Should be 1 + 1
+            correct = false;
+            break;
+        }
+    }
+    std::cout << "Computation " << (correct ? "successful" : "failed") << std::endl;
+
+    // Clean up
+    clReleaseMemObject(device_buffer);
+    clReleaseKernel(kernel);
+    clReleaseProgram(program);
+    clReleaseCommandQueue(queue);
+    clReleaseContext(context);
+
+    return correct;
+}
+
+int main() {
+    cl_platform_id platform;
+    cl_device_id device = selectDevice(platform);
+
+    std::cout << "\nRunning kernel test with device address extension...\n";
+    if (!kernelTest(platform, device)) {
+        std::cout << "Kernel test failed!\n";
+        return 1;
+    }
+    
+    std::cout << "All tests completed successfully\n";
+    return 0;
+}

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -28,6 +28,7 @@ add_gtest_executable(api_tests
     split_region.cpp
     subgroup_size.cpp
     workgroup.cpp
+    buffer_device_address.cpp
 )
 
 if (${CLVK_COMPILER_AVAILABLE})

--- a/tests/api/buffer_device_address.cpp
+++ b/tests/api/buffer_device_address.cpp
@@ -1,0 +1,105 @@
+// Copyright 2024 The clvk authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testcl.hpp"
+
+// Extension definitions
+#ifndef cl_ext_buffer_device_address
+#define cl_ext_buffer_device_address 1
+#define CL_DEVICE_PTR_EXT 0xff01
+#define CL_MEM_DEVICE_ADDRESS_EXT (1ul << 31)
+#define CL_MEM_DEVICE_PTR_EXT 0xff01
+typedef cl_ulong cl_mem_device_address_EXT;
+typedef cl_int(CL_API_CALL *clSetKernelArgDevicePointerEXT_fn)(
+    cl_kernel kernel, cl_uint arg_index, cl_mem_device_address_EXT dev_addr);
+#endif
+
+TEST_F(WithCommandQueue, BufferDeviceAddress) {
+    // First check if device supports the extension
+    size_t ext_size;
+    GetDeviceInfo(CL_DEVICE_EXTENSIONS, 0, nullptr, &ext_size);
+    
+    std::vector<char> extensions(ext_size);
+    GetDeviceInfo(CL_DEVICE_EXTENSIONS, ext_size, extensions.data(), nullptr);
+
+    bool hasBufferDeviceAddress = 
+        std::string(extensions.data()).find("cl_ext_buffer_device_address") != std::string::npos;
+
+    if (!hasBufferDeviceAddress) {
+        GTEST_SKIP() << "Device does not support cl_ext_buffer_device_address extension";
+    }
+
+    // Get the extension function pointer
+    auto clSetKernelArgDevicePointerEXT = 
+        (clSetKernelArgDevicePointerEXT_fn)
+        clGetExtensionFunctionAddressForPlatform(platform(), "clSetKernelArgDevicePointerEXT");
+    
+    ASSERT_NE(clSetKernelArgDevicePointerEXT, nullptr) 
+        << "Failed to get clSetKernelArgDevicePointerEXT function pointer";
+
+    // Kernel that increments each element
+    static const char* program_source = R"(
+    kernel void increment(global int* input) {
+        int gid = get_global_id(0);
+        input[gid] += 1;
+    }
+    )";
+
+    const size_t BUFFER_SIZE = 1024 * sizeof(cl_int);
+    const size_t NUM_ELEMENTS = BUFFER_SIZE / sizeof(cl_int);
+
+    // Create buffer with device address extension flag
+    auto buffer = CreateBuffer(CL_MEM_READ_WRITE | CL_MEM_DEVICE_ADDRESS_EXT,
+                             BUFFER_SIZE, nullptr);
+
+    // Get device pointer
+    cl_mem_device_address_EXT device_ptr;
+    cl_int err = clGetMemObjectInfo(buffer, CL_MEM_DEVICE_PTR_EXT, 
+                                   sizeof(device_ptr), &device_ptr, nullptr);
+    ASSERT_EQ(err, CL_SUCCESS) << "Failed to get device pointer";
+
+    // Initialize buffer with test data
+    std::vector<cl_int> host_data(NUM_ELEMENTS, 1);  // Initialize with 1s
+    EnqueueWriteBuffer(buffer, CL_TRUE, 0, BUFFER_SIZE, host_data.data());
+
+    // Create and build program
+    auto kernel = CreateKernel(program_source, "increment");
+
+    // Set kernel argument using the device pointer
+    err = clSetKernelArgDevicePointerEXT(kernel, 0, device_ptr);
+    ASSERT_EQ(err, CL_SUCCESS) << "Failed to set kernel argument with device pointer";
+
+    // Execute kernel
+    size_t gws = NUM_ELEMENTS;
+    EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, nullptr);
+
+    // Complete execution
+    Finish();
+
+    // Read back and verify results
+    std::vector<cl_int> result(NUM_ELEMENTS);
+    EnqueueReadBuffer(buffer, CL_TRUE, 0, BUFFER_SIZE, result.data());
+
+    // Verify each element was incremented by 1
+    bool success = true;
+    for (size_t i = 0; i < NUM_ELEMENTS; i++) {
+        if (result[i] != 2) {  // Should be 1 + 1
+            printf("Failed comparison at data[%zu]: expected 2 but got %d\n", 
+                   i, result[i]);
+            success = false;
+        }
+    }
+
+    EXPECT_TRUE(success);
+}


### PR DESCRIPTION
still WIP, sample works but test fails though more tests fail even on main


```
╭─pvelesko@cupcake ~/clvk/test-dev-buffer/build ‹deviceAddr●› 
╰─$ ./device_ptr_test
Platform 0 has 4 device(s):
        0: Intel(R) Graphics (RPL-S)
        1: AMD Radeon VII (RADV VEGA20)
        2: Intel(R) Arc(tm) A770 Graphics (DG2)
        3: llvmpipe (LLVM 15.0.7, 256 bits)
Select platform index: 0
Select device index: 0

Running kernel test with device address extension...
Device supports cl_ext_buffer_device_address extension
Successfully obtained device pointer: 0xfffffffefff80000
Computation successful
All tests completed successfully
```