### PR TITLE
Init the logging parts of the config before calling init_logging

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -40,8 +40,10 @@ DEFINE_OPTION_TYPE_GETTER(uint32_t, config_option_type::uint32)
 DEFINE_OPTION_TYPE_GETTER(bool, config_option_type::boolean)
 
 config_option gConfigOptions[] = {
-#define OPTION(type, name, valdef) {option_type<type>(), #name, &config.name, false},
-#define EARLY_OPTION(type, name, valdef) {option_type<type>(), #name, &config.name, true},
+#define OPTION(type, name, valdef)                                             \
+    {option_type<type>(), #name, &config.name, false},
+#define EARLY_OPTION(type, name, valdef)                                       \
+    {option_type<type>(), #name, &config.name, true},
 #include "config.def"
 #undef EARLY_OPTION
 #undef OPTION

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -40,8 +40,10 @@ DEFINE_OPTION_TYPE_GETTER(uint32_t, config_option_type::uint32)
 DEFINE_OPTION_TYPE_GETTER(bool, config_option_type::boolean)
 
 config_option gConfigOptions[] = {
-#define OPTION(type, name, valdef) {option_type<type>(), #name, &config.name},
+#define OPTION(type, name, valdef) {option_type<type>(), #name, &config.name, false},
+#define EARLY_OPTION(type, name, valdef) {option_type<type>(), #name, &config.name, true},
 #include "config.def"
+#undef EARLY_OPTION
 #undef OPTION
 };
 
@@ -121,7 +123,7 @@ void read_config_file(std::unordered_map<std::string, std::string>& umap,
     config_stream.close();
 }
 
-void parse_config_file() {
+void parse_config_file(bool early_option) {
     std::unordered_map<std::string, std::string> file_config_values;
     std::string conf_file = "clvk.conf";
     std::ifstream config_stream;
@@ -157,6 +159,9 @@ void parse_config_file() {
     }
 
     for (auto& opt : gConfigOptions) {
+        if (early_option != opt.early_option) {
+            continue;
+        }
         if (file_config_values.find(opt.name) == file_config_values.end()) {
             continue;
         }
@@ -178,16 +183,17 @@ void parse_config_file() {
     return;
 }
 
-void parse_env() {
+void parse_env(bool early_option) {
     for (auto& opt : gConfigOptions) {
-        // printf("var_name = '%s' ", var_name.c_str());
+        if (early_option != opt.early_option) {
+            continue;
+        }
         auto var_name = get_clvk_env_name(opt.name);
         const char* txt = getenv(var_name.c_str());
         if (txt == nullptr) {
-            //    printf("is not set\n");
             continue;
         }
-        // printf("is set\n");
+        cvk_debug_group_fn(loggroup::cfg, "'%s' = '%s'", var_name.c_str(), txt);
         void* optval = const_cast<void*>(opt.value);
         switch (opt.type) {
         case config_option_type::string:
@@ -205,9 +211,12 @@ void parse_env() {
 
 } // namespace
 
-void init_config_from_env_only() { parse_env(); }
-
 void init_config() {
-    parse_config_file();
-    parse_env();
+    parse_config_file(false);
+    parse_env(false);
+}
+
+void init_early_config() {
+    parse_config_file(true);
+    parse_env(true);
 }

--- a/src/config.def
+++ b/src/config.def
@@ -70,10 +70,10 @@ OPTION(std::string, device_extensions_masked, "")
 //
 // Logging
 //
-OPTION(uint32_t, log, 0u)
-OPTION(bool, log_colour, false)
-OPTION(std::string, log_dest, "")
-OPTION(std::string, log_groups, "")
+EARLY_OPTION(uint32_t, log, 0u)
+EARLY_OPTION(bool, log_colour, false)
+EARLY_OPTION(std::string, log_dest, "")
+EARLY_OPTION(std::string, log_groups, "")
 
 //
 // Debug

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -33,6 +33,7 @@ struct config_option {
     config_option_type type;
     std::string name;
     const void* value;
+    bool early_option;
 };
 
 template <typename T> struct config_value {
@@ -48,12 +49,14 @@ template <typename T> struct config_value {
 
 struct config_struct {
 #define OPTION(type, name, valdef) const config_value<type> name{valdef};
+#define EARLY_OPTION OPTION
 #include "config.def"
+#undef EARLY_OPTION
 #undef OPTION
 };
 
 extern const config_struct config;
 
-extern void init_config_from_env_only();
-
 extern void init_config();
+
+extern void init_early_config();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -242,6 +242,9 @@ clvk_global_state::clvk_global_state() {
     init_config_from_env_only();
     init_logging();
     init_config();
+    // Re-init logging after init_config to take configuration values into
+    // account.
+    init_logging();
     cvk_info("Starting initialisation");
     init_tracing();
     init_vulkan();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -237,14 +237,9 @@ void clvk_global_state::init_executors() {
 void clvk_global_state::term_executors() { delete m_thread_pool; }
 
 clvk_global_state::clvk_global_state() {
-    // Init the configuration using environment variables before logging so
-    // we can enable full logging support before parsing configuration files.
-    init_config_from_env_only();
+    init_early_config();
     init_logging();
     init_config();
-    // Re-init logging after init_config to take configuration values into
-    // account.
-    init_logging();
     cvk_info("Starting initialisation");
     init_tracing();
     init_vulkan();


### PR DESCRIPTION
This is needed when logging properties are set in a configuration file.