### PR TITLE
device_properties: nvidia: remove fma

### DIFF
--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -228,17 +228,17 @@ struct cvk_device_properties_nvidia : public cvk_device_properties {
     std::string vendor() const override final { return "NVIDIA Corporation"; }
     const std::set<std::string> get_native_builtins() const override final {
         return std::set<std::string>({
-            "acos",           "acosh",       "acospi",   "asin",
-            "asinh",          "asinpi",      "atan",     "atan2",
-            "atan2pi",        "atanh",       "atanpi",   "ceil",
-            "copysign",       "fdim",        "floor",    "fma",
-            "fmax",           "fmin",        "frexp",    "half_rsqrt",
-            "half_sqrt",      "isequal",     "isfinite", "isgreater",
-            "isgreaterequal", "isinf",       "isless",   "islessequal",
-            "islessgreater",  "isnan",       "isnormal", "isnotequal",
-            "isordered",      "isunordered", "ldexp",    "mad",
-            "rint",           "round",       "rsqrt",    "signbit",
-            "sqrt",           "tanh",        "trunc",
+            "acos",        "acosh",    "acospi",      "asin",
+            "asinh",       "asinpi",   "atan",        "atan2",
+            "atan2pi",     "atanh",    "atanpi",      "ceil",
+            "copysign",    "fdim",     "floor",       "fmax",
+            "fmin",        "frexp",    "half_rsqrt",  "half_sqrt",
+            "isequal",     "isfinite", "isgreater",   "isgreaterequal",
+            "isinf",       "isless",   "islessequal", "islessgreater",
+            "isnan",       "isnormal", "isnotequal",  "isordered",
+            "isunordered", "ldexp",    "mad",         "rint",
+            "round",       "rsqrt",    "signbit",     "sqrt",
+            "tanh",        "trunc",
         });
     }
 };


### PR DESCRIPTION
Since clspv optimisation to generate fma instead of fmul+fadd (https://github.com/google/clspv/commit/c4f91b91f195cae573aa8bec21af4458b614c9bc) the erf test is failing on nvidia (as it is using fma) in google infra.
Do not use native fma on nvidia to allow that platform to stay compliant.