### PR TITLE
fix clEnqueueNDRangeKernel for NULL work_global_size

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -4080,6 +4080,11 @@ cl_int CLVK_API_CALL clEnqueueNDRangeKernel(
         command_queue, kernel, work_dim, num_events_in_wait_list,
         event_wait_list, event);
 
+    static const size_t null_global_work_size[3] = {0};
+    if (global_work_size == nullptr) {
+        global_work_size = null_global_work_size;
+    }
+
     cvk_ndrange ndrange(work_dim, global_work_offset, global_work_size,
                         local_work_size);
 


### PR DESCRIPTION
According to the OpenCL specification, work_dim can be 0 and work_global_size can be NULL.

https://github.com/KhronosGroup/OpenCL-CTS/issues/2240