### PR TITLE
add fma to native builtins for AMD

### DIFF
--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -133,17 +133,20 @@ struct cvk_device_properties_amd : public cvk_device_properties {
     cl_uint get_max_cmd_group_size() const override final { return 1; }
     const std::set<std::string> get_native_builtins() const override final {
         return std::set<std::string>({
-            "ceil",           "copysign",    "exp2",      "fdim",
-            "floor",          "fmax",        "fmin",      "frexp",
-            "half_exp",       "half_exp10",  "half_exp2", "half_log",
-            "half_log10",     "half_log2",   "half_powr", "half_rsqrt",
-            "half_sqrt",      "isequal",     "isfinite",  "isgreater",
-            "isgreaterequal", "isinf",       "isless",    "islessequal",
-            "islessgreater",  "isnan",       "isnormal",  "isnotequal",
-            "isordered",      "isunordered", "ldexp",     "log",
-            "log10",          "log2",        "mad",       "rint",
-            "round",          "rsqrt",       "signbit",   "sqrt",
-            "trunc",
+            "ceil",           "copysign",      "exp2",
+            "fdim",           "floor",         "fma",
+            "fmax",           "fmin",          "frexp",
+            "half_exp",       "half_exp10",    "half_exp2",
+            "half_log",       "half_log10",    "half_log2",
+            "half_powr",      "half_rsqrt",    "half_sqrt",
+            "isequal",        "isfinite",      "isgreater",
+            "isgreaterequal", "isinf",         "isless",
+            "islessequal",    "islessgreater", "isnan",
+            "isnormal",       "isnotequal",    "isordered",
+            "isunordered",    "ldexp",         "log",
+            "log10",          "log2",          "mad",
+            "rint",           "round",         "rsqrt",
+            "signbit",        "sqrt",          "trunc",
         });
     }
     std::string get_compile_options() const override final {


### PR DESCRIPTION
https://github.com/google/clspv/commit/c4f91b91f195cae573aa8bec21af4458b614c9bc translates `mad` to `fma`. 
 https://github.com/google/clspv/commit/720be7f459d5695da5fb9acfe70c414090167833 enforces fp32 `fma` unless `fma` is a native builtin.  Together, they prevent radv from doing fp16 packed fma.

This PR adds `fma` to native builtins for AMD.  `clang-format` changes the formatting of the list though.