### PR TITLE
Fix FP64 support reporting

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -620,25 +620,30 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         copy_ptr = &val_ulong;
         size_ret = sizeof(val_ulong);
         break;
+    // FIXME can we do better for vector width queries?
     case CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR:
     case CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT:
     case CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT:
     case CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG:
     case CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT:
-    case CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF:
     case CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR:
     case CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT:
     case CL_DEVICE_NATIVE_VECTOR_WIDTH_INT:
     case CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG:
     case CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT:
+        val_uint = 1;
+        copy_ptr = &val_uint;
+        size_ret = sizeof(val_uint);
+        break;
+    case CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF:
     case CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF:
-        val_uint = 1; // FIXME can we do better?
+        val_uint = device->supports_fp16() ? 1 : 0;
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;
     case CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE:
     case CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE:
-        val_uint = 0;
+        val_uint = device->supports_fp64() ? 1 : 0;
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -661,6 +661,10 @@ void cvk_device::build_extension_ils_list() {
         m_extensions.push_back(MAKE_NAME_VERSION(1, 0, 0, "cl_khr_fp16"));
     }
 
+    if (supports_fp64()) {
+        m_extensions.push_back(MAKE_NAME_VERSION(1, 0, 0, "cl_khr_fp64"));
+    }
+
     // Enable 8-bit integer support if possible
     if ((is_vulkan_extension_enabled(VK_KHR_8BIT_STORAGE_EXTENSION_NAME) &&
          m_features_8bit_storage.storageBuffer8BitAccess) &&
@@ -794,8 +798,7 @@ void cvk_device::build_extension_ils_list() {
         m_opencl_c_features.push_back(
             MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_int64"));
     }
-    if (m_features.features.shaderFloat64) {
-        m_has_fp64_support = true;
+    if (supports_fp64()) {
         m_opencl_c_features.push_back(
             MAKE_NAME_VERSION(3, 0, 0, "__opencl_c_fp64"));
     }

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -438,7 +438,10 @@ struct cvk_device : public _cl_device_id,
 
     bool supports_fp16() const { return m_has_fp16_support; }
 
-    bool supports_fp64() const { return m_has_fp64_support; }
+    // TODO(kpet): support FP64 (clspv has very little support)
+    bool supports_fp64() const {
+        return 0 && m_features.features.shaderFloat64;
+    }
 
     bool supports_int8() const { return m_has_int8_support; }
 
@@ -556,6 +559,12 @@ struct cvk_device : public _cl_device_id,
         }
         if (fptype == CL_DEVICE_SINGLE_FP_CONFIG) {
             return CL_FP_ROUND_TO_NEAREST | CL_FP_INF_NAN | CL_FP_FMA;
+        }
+
+        if ((fptype == CL_DEVICE_DOUBLE_FP_CONFIG) && supports_fp64()) {
+            return CL_FP_ROUND_TO_NEAREST | CL_FP_ROUND_TO_ZERO |
+                   CL_FP_ROUND_TO_INF | CL_FP_INF_NAN | CL_FP_FMA |
+                   CL_FP_DENORM;
         }
 
         return 0;
@@ -794,7 +803,6 @@ private:
 
     bool m_has_timer_support{};
     bool m_has_fp16_support{};
-    bool m_has_fp64_support{};
     bool m_has_int8_support{};
     bool m_has_subgroups_support{};
     bool m_has_subgroup_size_selection{};


### PR DESCRIPTION
- Make reported native and preferred vector widths conditional to support (and do the same for FP16)
- Report cl_khr_fp64 and __opencl_c_fp64 when FP64 is supported
- Always use cvk_device::supports_fp64() to determine support
- Force disable support for now

This fixes compier::features_macro and api::consistency_requirements_fp64 CTS tests.

Change-Id: I454bcb70090aeccf0c7b67911e16745e4728acc9