### PR TITLE
add config to override CL_DEVICE_MAX_COMPUTE_UNITS

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,10 @@ using the name of the corresponding environment variable.
 * `CLVK_FORCE_SUBGROUP_SIZE` specifies the subgroup size to use, overriding
   everything.
 
+* `CLVK_MAX_COMPUTE_UNITS` specifies the default number of compute units to
+  expose through `CL_DEVICE_MAX_COMPUTE_UNITS` if nothing is set in the device
+  properties (default: `1`).
+
 * `CLVK_QUEUE_GLOBAL_PRIORITY` specifies the queue global priority to use if it
   is supported by the driver:
 

--- a/src/config.def
+++ b/src/config.def
@@ -46,6 +46,8 @@ OPTION(std::string, llvmspirv_bin, DEFAULT_LLVMSPIRV_BINARY_PATH)
 OPTION(uint32_t, force_subgroup_size, 0u) // 0 meaning not forced
 OPTION(uint32_t, preferred_subgroup_size, 0u) // 0 meaning no preference
 
+OPTION(uint32_t, max_compute_units, 1u)
+
 //
 // Command execution
 //

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -26,7 +26,9 @@
 struct cvk_device_properties {
     virtual std::string vendor() const { return "Unknown vendor"; }
     virtual cl_ulong get_global_mem_cache_size() const { return 0; }
-    virtual cl_ulong get_num_compute_units() const { return 1; }
+    virtual cl_ulong get_num_compute_units() const {
+        return config.max_compute_units();
+    }
 
     virtual cl_uint get_max_cmd_batch_size() const {
         return config.max_cmd_batch_size();


### PR DESCRIPTION
This is useful especially with application like clpeak which choose the workload to compute using CL_DEVICE_MAX_COMPUTE_UNITS