### PR TITLE
cmake: clean CLLibrary link dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,8 +186,8 @@ endif()
 
 function(CLLibrary target type)
   add_library(${target} ${type} $<TARGET_OBJECTS:OpenCL-objects>)
-  target_link_libraries(${target} ${OpenCL-dependencies}
-      clvk-config-definitions)
+  target_link_libraries(${target} PRIVATE ${OpenCL-dependencies})
+  target_link_libraries(${target} PUBLIC clvk-config-definitions)
   set_target_properties(${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY
       ${CMAKE_BINARY_DIR})
 endfunction(CLLibrary)

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -30,9 +30,9 @@ add_gtest_executable(api_tests
     workgroup.cpp
 )
 
-if (${CLVK_COMPILER_AVAILABLE})
-  add_definitions(-DCOMPILER_AVAILABLE)
-endif()
+target_include_directories(api_tests SYSTEM BEFORE PRIVATE
+    ${SPIRV_HEADERS_SOURCE_DIR}/include
+)
 
 if (${CLVK_VULKAN_IMPLEMENTATION} STREQUAL swiftshader)
   add_definitions(-DUSING_SWIFTSHADER)


### PR DESCRIPTION
Make OpenCL-dependencies PRIVATE to avoid unneeded dependencies on target linking with CLLibrary (all the tests)