### PR TITLE
fix do_build_inner when compiling a program twice

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1397,6 +1397,9 @@ cl_build_status cvk_program::do_build_inner(const cvk_device* device) {
 #if !COMPILER_AVAILABLE
     UNUSED(device);
 #else
+    // m_il and m_source cannot be set together.
+    // They can both be empty when loading from binary.
+    CVK_ASSERT(m_il.empty() || m_source.empty());
 
     bool build_from_il =
         m_il.size() > 0 && m_operation != build_operation::link;
@@ -1429,10 +1432,7 @@ cl_build_status cvk_program::do_build_inner(const cvk_device* device) {
     auto build_options = prepare_build_options(device);
 
     // Add options to specify input/output types
-    if (build_from_il ||
-        m_binary_type == CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT ||
-        m_binary_type == CL_PROGRAM_BINARY_TYPE_LIBRARY ||
-        m_operation == build_operation::link) {
+    if (m_source.empty() || m_operation == build_operation::link) {
         build_options += " -x ir ";
     }
     bool build_to_ir =


### PR DESCRIPTION
test_compiler get_linked_program_info_kernel_names is failing because the test tries to compile the same program twice with different build option (changing a define).

The second time, clvk tries to compile it with `-x ir` because `m_binary_type == CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT`, which leads to trying to compile a CL source interpret as a IR source.