### PR TITLE
clean execute_cmds_required_by_no_lock to avoid -Wthread-safety-analysis error

### DIFF
--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -237,7 +237,8 @@ struct cvk_command_queue : public _cl_command_queue,
     cl_int execute_cmds_required_by(cl_uint num_events,
                                     _cl_event* const* event_list);
     cl_int execute_cmds_required_by_no_lock(cl_uint num_events,
-                                            _cl_event* const* event_list);
+                                            _cl_event* const* event_list,
+                                            std::unique_lock<std::mutex>& lock);
 
     void detach_from_context();
 


### PR DESCRIPTION
`-Wthread-safety-analysis` has been enabled in google infrastructure, generating:
```
third_party/clvk/src/queue.cpp:389:12: error: releasing mutex 'm_lock' that was not held [-Werror,-Wthread-safety-analysis]
  389 |     m_lock.unlock();
      |            ^
third_party/clvk/src/queue.cpp:395:1: error: mutex 'm_lock' is not held on every path through here [-Werror,-Wthread-safety-analysis]
  395 | }
      | ^
third_party/clvk/src/queue.cpp:392:12: note: mutex acquired here
  392 |     m_lock.lock();
      |            ^
2 errors generated.
```
This CL cleans the usage of lock in `execute_cmds_required_by_no_lock` to make it understandable by the compiler.