### PR TITLE
add config option to keep allocated memories mapped

### DIFF
--- a/src/config.def
+++ b/src/config.def
@@ -66,6 +66,8 @@ OPTION(uint32_t, enqueue_command_retry_sleep_us, UINT32_MAX) // UINT32_MAX meani
 
 OPTION(bool, supports_filter_linear, true)
 
+OPTION(bool, keep_memory_allocations_mapped, false)
+
 OPTION(std::string, device_extensions, "")
 OPTION(std::string, device_extensions_masked, "")
 

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -699,6 +699,10 @@ struct cvk_device : public _cl_device_id,
                0;
     }
 
+    bool keep_memory_allocations_mapped() const {
+        return m_clvk_properties->keep_memory_allocations_mapped();
+    }
+
 private:
     std::string version_desc() const {
         std::string ret = "CLVK on Vulkan v";

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -71,6 +71,10 @@ struct cvk_device_properties {
         return no_disabled_formats;
     }
 
+    virtual bool keep_memory_allocations_mapped() const {
+        return config.keep_memory_allocations_mapped();
+    }
+
     virtual ~cvk_device_properties() {}
 };
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -127,7 +127,8 @@ bool cvk_buffer::init() {
 
     // Allocate memory
     m_memory = std::make_shared<cvk_memory_allocation>(
-        vkdev, params.size, params.memory_type_index, params.memory_coherent);
+        vkdev, params.size, params.memory_type_index, params.memory_coherent,
+        device->keep_memory_allocations_mapped());
     res = m_memory->allocate(device->uses_physical_addressing());
 
     if (res != VK_SUCCESS) {
@@ -441,7 +442,8 @@ bool cvk_image::init_vulkan_image() {
 
     // Allocate memory
     m_memory = std::make_unique<cvk_memory_allocation>(
-        vkdev, params.size, params.memory_type_index, params.memory_coherent);
+        vkdev, params.size, params.memory_type_index, params.memory_coherent,
+        device->keep_memory_allocations_mapped());
 
     res = m_memory->allocate(device->uses_physical_addressing());
 


### PR DESCRIPTION
Some workloads on some devices can get huge performance improvement by keeping allocated memories mapped.