### PR TITLE
Use VK_KHR_timeline_semaphore to reduce cvk_command_batch submit latency

### DIFF
--- a/src/config.def
+++ b/src/config.def
@@ -216,6 +216,15 @@ OPTION(std::string, perfetto_trace_dest, "clvk.perfetto-trace")
 // the application point of view.
 PROPERTY(bool, reuse_descriptor_set, false)
 
+// Use `cvk_semaphore::poll` (instead of `cvk_semaphore::wait`) on the executor
+// thread to know where a semaphore
+// has reached an expected value.
+OPTION(bool, poll_executor, false)
+
+// Use `cvk_semaphore::poll` (instead of `cvk_semaphore::wait`) on the main
+// thread to know where a semaphore has reached an expected value.
+PROPERTY(bool, poll_main_thread, false)
+
 
 ////////////////////////////////////////////////////////////
 // LOGGING & VALIDATION ////////////////////////////////////

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -58,6 +58,8 @@ void cvk_device::init_vulkan_properties(VkInstance instance) {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES;
     m_integer_dot_product_properties.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES;
+    m_timeline_semaphore_properties.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES;
 
     //--- Get maxMemoryAllocationSize for figuring out the  max single buffer
     // allocation size and default init when the extension is not supported
@@ -88,6 +90,9 @@ void cvk_device::init_vulkan_properties(VkInstance instance) {
                          m_float_controls_properties),
             VER_EXT_PROP(VK_MAKE_VERSION(1, 3, 0), nullptr,
                          m_integer_dot_product_properties),
+            VER_EXT_PROP(VK_MAKE_VERSION(1, 2, 0),
+                         VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+                         m_timeline_semaphore_properties),
         };
 #undef VER_EXT_PROP
 
@@ -253,6 +258,7 @@ bool cvk_device::init_extensions() {
         VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
         VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
         VK_KHR_GLOBAL_PRIORITY_EXTENSION_NAME,
+        VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
     };
 
     if (m_properties.apiVersion < VK_MAKE_VERSION(1, 2, 0)) {
@@ -316,6 +322,8 @@ void cvk_device::init_features(VkInstance instance) {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES;
     m_features_queue_global_priority.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR;
+    m_features_timeline_semaphore.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
 
     std::vector<std::tuple<uint32_t, const char*, VkBaseOutStructure*>>
         coreversion_extension_features = {
@@ -352,7 +360,9 @@ void cvk_device::init_features(VkInstance instance) {
                          m_features_shader_integer_dot_product),
             VER_EXT_FEAT(0, VK_KHR_GLOBAL_PRIORITY_EXTENSION_NAME,
                          m_features_queue_global_priority),
-
+            VER_EXT_FEAT(VK_MAKE_VERSION(1, 2, 0),
+                         VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+                         m_features_timeline_semaphore),
 #undef VER_EXT_FEAT
         };
 
@@ -399,6 +409,8 @@ void cvk_device::init_features(VkInstance instance) {
     cvk_info(
         "subgroup extended types: %d",
         m_features_shader_subgroup_extended_types.shaderSubgroupExtendedTypes);
+    cvk_info("timeline semaphore: %d",
+             m_features_timeline_semaphore.timelineSemaphore);
 
     // Selectively enable core features.
     if (supported_features.features.shaderInt16) {

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -302,6 +302,10 @@ struct cvk_device : public _cl_device_id,
         return m_clvk_properties->max_compute_units();
     }
 
+    bool poll_main_thread() const {
+        return m_clvk_properties->poll_main_thread();
+    }
+
     cl_uint max_samplers() const {
         // There are only 20 different possible samplers in OpenCL 1.2, cap the
         // number of supported samplers to that to help with negative testing of

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -626,6 +626,15 @@ struct cvk_device : public _cl_device_id,
 
     CHECK_RETURN bool has_timer_support() const { return m_has_timer_support; }
 
+    CHECK_RETURN bool has_timeline_semaphore_support() const {
+        return m_features_timeline_semaphore.timelineSemaphore;
+    }
+
+    CHECK_RETURN uint64_t maxTimelineSemaphoreValueDifference() const {
+        return m_timeline_semaphore_properties
+            .maxTimelineSemaphoreValueDifference;
+    }
+
     CHECK_RETURN cl_int get_device_host_timer(cl_ulong* dev_ts,
                                               cl_ulong* host_ts) const;
     CHECK_RETURN cl_int update_device_host_timer();
@@ -773,6 +782,7 @@ private:
     VkPhysicalDevicePCIBusInfoPropertiesEXT m_pci_bus_info_properties;
     VkPhysicalDeviceShaderIntegerDotProductProperties
         m_integer_dot_product_properties{};
+    VkPhysicalDeviceTimelineSemaphoreProperties m_timeline_semaphore_properties;
     // Vulkan features
     VkPhysicalDeviceFeatures2 m_features{};
     VkPhysicalDeviceVariablePointerFeatures m_features_variable_pointer{};
@@ -792,6 +802,7 @@ private:
     VkPhysicalDeviceFloatControlsProperties m_float_controls_properties{};
     VkPhysicalDeviceShaderIntegerDotProductFeatures
         m_features_shader_integer_dot_product{};
+    VkPhysicalDeviceTimelineSemaphoreFeatures m_features_timeline_semaphore{};
     VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR
         m_features_queue_global_priority{};
 

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -18,6 +18,7 @@
 #include "context.hpp"
 #include "icd.hpp"
 #include "objects.hpp"
+#include "semaphore.hpp"
 #include "tracing.hpp"
 #include "utils.hpp"
 
@@ -35,12 +36,68 @@ struct cvk_event_callback {
     void* data;
 };
 
+struct cvk_condition_variable {
+    virtual ~cvk_condition_variable() {}
+
+    virtual void notify() = 0;
+    CHECK_RETURN virtual bool wait(std::unique_lock<std::mutex>&) = 0;
+
+    virtual cvk_semaphore* get_semaphore() {
+        CVK_ASSERT(false && "Should never be called");
+        return NULL;
+    }
+    virtual uint64_t get_value() {
+        CVK_ASSERT(false && "Should never be called");
+        return 0;
+    }
+
+    // By default, completion is managed by the user. Only timeline semaphore
+    // can have unnotified completion requiring an additionnal manual check.
+    CHECK_RETURN virtual bool is_complete() { return false; }
+};
+
+struct cvk_semaphore_condition_variable final : public cvk_condition_variable {
+    cvk_semaphore_condition_variable(cvk_semaphore* sem, uint64_t value)
+        : m_sem(sem), m_value(value) {
+        sem->retain();
+    }
+    ~cvk_semaphore_condition_variable() { m_sem->release(); }
+
+    void notify() override final { m_sem->notify(m_value); }
+    CHECK_RETURN bool wait(std::unique_lock<std::mutex>& lock) override final {
+        lock.unlock();
+        bool ret = m_sem->wait(m_value);
+        lock.lock();
+        return ret;
+    }
+
+    bool is_complete() override final { return m_sem->poll_once(m_value); }
+
+    cvk_semaphore* get_semaphore() override final { return m_sem; }
+    uint64_t get_value() override final { return m_value; }
+
+private:
+    cvk_semaphore* m_sem;
+    uint64_t m_value;
+};
+
+struct cvk_std_condition_variable final : public cvk_condition_variable {
+    void notify() override final { m_cv.notify_all(); }
+    CHECK_RETURN bool wait(std::unique_lock<std::mutex>& lock) override final {
+        m_cv.wait(lock);
+        return true;
+    }
+
+private:
+    std::condition_variable m_cv;
+};
+
 struct cvk_event : public _cl_event, api_object<object_magic::event> {
 
     cvk_event(cvk_context* ctx, cvk_command_queue* queue)
         : api_object(ctx), m_command_type(0), m_queue(queue) {}
 
-    virtual cl_int get_status() const = 0;
+    virtual cl_int get_status() = 0;
 
     bool completed() { return get_status() == CL_COMPLETE; }
 
@@ -65,6 +122,15 @@ struct cvk_event : public _cl_event, api_object<object_magic::event> {
 
     virtual uint64_t get_profiling_info(cl_profiling_info pinfo) const = 0;
 
+    virtual cvk_semaphore* get_semaphore() {
+        CVK_ASSERT(false && "Should never be called");
+        return nullptr;
+    }
+    virtual uint64_t get_value() {
+        CVK_ASSERT(false && "Should never be called");
+        return 0;
+    }
+
 protected:
     cl_command_type m_command_type;
     cvk_command_queue* m_queue;
@@ -75,34 +141,54 @@ struct cvk_event_command : public cvk_event {
     cvk_event_command(cvk_context* ctx, cvk_command* cmd,
                       cvk_command_queue* queue);
 
-    void set_status(cl_int status) override final;
+    void set_status(cl_int status) override final {
+        std::unique_lock<std::mutex> lock(m_lock);
+        set_status_no_lock(status, lock);
+    }
 
     void register_callback(cl_int callback_type,
                            cvk_event_callback_pointer_type ptr,
                            void* user_data) override final {
-        std::lock_guard<std::mutex> lock(m_lock);
+        std::unique_lock<std::mutex> lock(m_lock);
 
         cvk_event_callback cb = {ptr, user_data};
 
         if (m_status <= callback_type) {
-            execute_callback(cb);
+            execute_callback(cb, lock);
         } else {
             m_callbacks[callback_type].push_back(cb);
         }
     }
 
-    cl_int get_status() const override final { return m_status; }
+    void check_completion() {
+        std::unique_lock<std::mutex> lock(m_lock);
+        if (m_cv->is_complete()) {
+            set_status_no_lock(CL_COMPLETE, lock);
+        }
+    }
+
+    cl_int get_status() override final {
+        check_completion();
+        return m_status;
+    }
 
     cl_int wait() override final {
         std::unique_lock<std::mutex> lock(m_lock);
         cvk_debug_group(loggroup::event,
                         "cvk_event::wait: event = %p, status = %d", this,
                         m_status);
-        if ((m_status != CL_COMPLETE) && (m_status >= 0)) {
+        if (m_status > 0) {
             TRACE_BEGIN_EVENT(command_type(), "queue", (uintptr_t)m_queue,
                               "command", (uintptr_t)m_cmd);
-            m_cv.wait(lock);
+            auto ret = m_cv->wait(lock);
             TRACE_END();
+            if (!ret) {
+                m_status = CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST;
+            }
+            // This is needed in case of timeline semaphore which mark the
+            // event as completed but have not update anything (not the
+            // status nor the profiling information)
+            set_status_no_lock(CL_COMPLETE, lock);
         }
 
         return m_status;
@@ -132,13 +218,22 @@ struct cvk_event_command : public cvk_event {
         set_profiling_info(pinfo, sample_clock());
     }
 
+    cvk_semaphore* get_semaphore() override final {
+        return m_cv->get_semaphore();
+    }
+    uint64_t get_value() override final { return m_cv->get_value(); }
+
 private:
-    void execute_callback(cvk_event_callback cb) {
+    void set_status_no_lock(cl_int status, std::unique_lock<std::mutex>& lock);
+    void execute_callback(cvk_event_callback cb,
+                          std::unique_lock<std::mutex>& lock) {
+        lock.unlock();
         cb.pointer(this, m_status, cb.data);
+        lock.lock();
     }
 
     std::mutex m_lock;
-    std::condition_variable m_cv;
+    std::unique_ptr<cvk_condition_variable> m_cv;
     cl_int m_status;
     cl_ulong m_profiling_data[4]{};
     cvk_command* m_cmd;
@@ -172,7 +267,7 @@ struct cvk_event_combine : public cvk_event {
         }
     }
 
-    cl_int get_status() const override final {
+    cl_int get_status() override final {
         auto start_status = m_start_event->get_status();
         auto end_status = m_end_event->get_status();
         if (start_status < 0) {

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -363,7 +363,11 @@ cl_int cvk_command_queue::wait_for_events(cl_uint num_events,
     // Now wait for all the events
     for (cl_uint i = 0; i < num_events; i++) {
         cvk_event* event = icd_downcast(event_list[i]);
-        if (event->wait() != CL_COMPLETE) {
+        bool poll = config.poll_main_thread();
+        if (!event->is_user_event()) {
+            poll = event->queue()->device()->poll_main_thread();
+        }
+        if (event->wait(poll) != CL_COMPLETE) {
             ret = CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST;
         }
     }
@@ -374,11 +378,11 @@ cl_int cvk_command_queue::wait_for_events(cl_uint num_events,
 void cvk_command_group::execute_cmds_in_executor() {
     CVK_ASSERT(commands.size() > 0);
     cvk_command_queue_holder queue = commands.front()->queue();
-    execute_cmds();
+    execute_cmds(config.poll_executor);
     queue->group_completed();
 }
 
-cl_int cvk_command_group::execute_cmds() {
+cl_int cvk_command_group::execute_cmds(bool poll) {
     TRACE_FUNCTION();
     cl_int global_status = CL_SUCCESS;
     while (!commands.empty()) {
@@ -386,7 +390,7 @@ cl_int cvk_command_group::execute_cmds() {
         cvk_debug_fn("executing command %p (%s), event %p", cmd,
                      cl_command_type_to_string(cmd->type()), cmd->event());
 
-        cl_int status = cmd->execute();
+        cl_int status = cmd->execute(poll);
         if (status != CL_COMPLETE && global_status == CL_SUCCESS)
             global_status = status;
         cvk_debug_fn("command returned %d", status);
@@ -412,7 +416,7 @@ cl_int cvk_command_queue::execute_cmds_required_by_no_lock(
 
     lock.unlock();
     auto cmds = exec->extract_cmds_required_by(true, num_events, event_list);
-    auto ret = cmds.execute_cmds();
+    auto ret = cmds.execute_cmds(m_device->poll_main_thread());
     lock.lock();
 
     return ret;
@@ -571,7 +575,7 @@ cl_int cvk_command_queue::finish() {
     if (m_finish_event != nullptr) {
         _cl_event* evt_list = (_cl_event*)&*m_finish_event;
         execute_cmds_required_by_no_lock(1, &evt_list, lock);
-        m_finish_event->wait();
+        m_finish_event->wait(m_device->poll_main_thread());
     }
 
     return CL_SUCCESS;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -37,11 +37,15 @@ cvk_command_queue::cvk_command_queue(
       m_properties_array(std::move(properties_array)), m_executor(nullptr),
       m_command_batch(nullptr), m_vulkan_queue(device->vulkan_queue_allocate()),
       m_command_pool(device, m_vulkan_queue.queue_family()),
+      m_semaphore_main_timeline(nullptr),
+      m_semaphore_image_init_timeline(nullptr),
+      m_semaphore_batch_timeline(nullptr),
       m_max_cmd_batch_size(device->get_max_cmd_batch_size()),
       m_max_first_cmd_batch_size(device->get_max_first_cmd_batch_size()),
       m_max_cmd_group_size(device->get_max_cmd_group_size()),
       m_max_first_cmd_group_size(device->get_max_first_cmd_group_size()),
-      m_nb_batch_in_flight(0), m_nb_group_in_flight(0) {
+      m_nb_batch_in_flight(0), m_nb_group_in_flight(0),
+      m_nb_synchronous_submit_command_in_flight(0) {
 
     m_groups.push_back(std::make_unique<cvk_command_group>());
 
@@ -71,6 +75,15 @@ cl_int cvk_command_queue::init() {
 }
 
 cvk_command_queue::~cvk_command_queue() {
+    if (m_semaphore_image_init_timeline != nullptr) {
+        m_semaphore_image_init_timeline->release();
+    }
+    if (m_semaphore_main_timeline != nullptr) {
+        m_semaphore_main_timeline->release();
+    }
+    if (m_semaphore_batch_timeline != nullptr) {
+        m_semaphore_batch_timeline->release();
+    }
     if (m_executor != nullptr) {
         get_thread_pool()->return_executor(m_executor);
     }
@@ -128,6 +141,9 @@ void cvk_command_queue::enqueue_command(cvk_command* cmd) {
         cmd->add_dependency(m_groups.back()->commands.back()->event());
     } else if (m_finish_event != nullptr) {
         cmd->add_dependency(m_finish_event);
+    }
+    if (cmd->is_synchronous_submit()) {
+        sync_submit_cmd_enqueued();
     }
     m_groups.back()->commands.push_back(cmd);
 }
@@ -196,6 +212,9 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
             return err;
         }
 
+        cmd->event()->set_profiling_info_from_monotonic_clock(
+            CL_PROFILING_COMMAND_QUEUED);
+
         // End command batch when size limit reached
         if (m_command_batch->batch_size() >= m_max_cmd_batch_size ||
             (m_nb_batch_in_flight == 0 &&
@@ -220,13 +239,13 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
         }
 
         enqueue_command(cmd);
+
+        cmd->event()->set_profiling_info_from_monotonic_clock(
+            CL_PROFILING_COMMAND_QUEUED);
     }
 
     cvk_debug_fn("enqueued command %p (%s), event %p", cmd,
                  cl_command_type_to_string(cmd->type()), cmd->event());
-
-    cmd->event()->set_profiling_info_from_monotonic_clock(
-        CL_PROFILING_COMMAND_QUEUED);
 
     if (event != nullptr) {
         // The event will be returned to the app, retain it for the user
@@ -292,12 +311,20 @@ cl_int cvk_command_queue::end_current_command_batch(bool from_flush) {
         }
         enqueue_command(m_command_batch);
 
+        if (use_timeline_semaphore() &&
+            m_nb_synchronous_submit_command_in_flight == 1) {
+            m_command_batch->set_event_status(CL_SUBMITTED);
+            m_command_batch->set_event_status(CL_RUNNING);
+            if (m_command_batch->submit() != CL_COMPLETE) {
+                return CL_OUT_OF_RESOURCES;
+            }
+        }
+
         for (auto& controller : m_controllers) {
             controller->update_after_end_current_command_batch(from_flush);
         }
 
         m_command_batch = nullptr;
-
         batch_enqueued();
     }
     return CL_SUCCESS;
@@ -384,7 +411,7 @@ cl_int cvk_command_queue::execute_cmds_required_by_no_lock(
     }
 
     lock.unlock();
-    auto cmds = exec->extract_cmds_required_by(false, num_events, event_list);
+    auto cmds = exec->extract_cmds_required_by(true, num_events, event_list);
     auto ret = cmds.execute_cmds();
     lock.lock();
 
@@ -550,6 +577,44 @@ cl_int cvk_command_queue::finish() {
     return CL_SUCCESS;
 }
 
+cl_int cvk_command_queue::get_next_semaphore_and_value(cvk_semaphore** sem,
+                                                       uint64_t* value,
+                                                       cl_command_type type) {
+    std::lock_guard<std::mutex> lock(m_semaphore_lock);
+    CVK_ASSERT(m_device->has_timeline_semaphore_support());
+
+    auto get_from = [this, &sem, &value](cvk_semaphore*& semaphore) {
+        if (semaphore == nullptr) {
+            cl_semaphore_type_khr sem_type = 0;
+            std::vector<cl_semaphore_properties_khr> properties;
+            std::vector<cl_device_id> devices;
+            semaphore = new cvk_semaphore(
+                m_context, sem_type, std::move(devices), std::move(properties));
+            auto status = semaphore->init();
+            if (status != CL_SUCCESS) {
+                return status;
+            }
+        }
+
+        *sem = semaphore;
+        *value = semaphore->get_next_value();
+
+        if (*value >= m_device->maxTimelineSemaphoreValueDifference()) {
+            semaphore->release();
+            semaphore = nullptr;
+        }
+        return CL_SUCCESS;
+    };
+
+    if (type == CLVK_COMMAND_IMAGE_INIT) {
+        return get_from(m_semaphore_image_init_timeline);
+    } else if (type == CLVK_COMMAND_BATCH) {
+        return get_from(m_semaphore_batch_timeline);
+    } else {
+        return get_from(m_semaphore_main_timeline);
+    }
+}
+
 VkResult cvk_command_pool::allocate_command_buffer(VkCommandBuffer* cmdbuf) {
 
     std::lock_guard<std::mutex> lock(m_lock);
@@ -584,6 +649,22 @@ bool cvk_command_buffer::begin() {
     };
 
     VkResult res = vkBeginCommandBuffer(m_command_buffer, &beginInfo);
+    if (res != VK_SUCCESS) {
+        return false;
+    }
+
+    return true;
+}
+
+bool cvk_command_buffer::submit(VkSemaphore signal_semaphore,
+                                uint64_t signal_value,
+                                std::vector<VkSemaphore>& wait_semaphores,
+                                std::vector<uint64_t>& wait_values) {
+    auto& queue = m_queue->vulkan_queue();
+
+    VkResult res = queue.submit(m_command_buffer, signal_semaphore,
+                                signal_value, wait_semaphores, wait_values);
+
     if (res != VK_SUCCESS) {
         return false;
     }
@@ -1266,12 +1347,38 @@ cl_int cvk_command_batchable::do_action() {
     return do_post_action();
 }
 
-cl_int cvk_command_batch::do_action() {
-
-    cvk_info("executing batch of %lu commands", m_commands.size());
-
-    if (!m_command_buffer->submit_and_wait()) {
+cl_int cvk_command_batch::submit() {
+    VkSemaphore signal_semaphore = event()->get_semaphore()->get_vk_semaphore();
+    uint64_t signal_value = event()->get_value();
+    std::vector<VkSemaphore> wait_semaphores;
+    std::vector<uint64_t> wait_values;
+    for (auto& dep : dependencies()) {
+        wait_semaphores.push_back(dep->get_semaphore()->get_vk_semaphore());
+        wait_values.push_back(dep->get_value());
+    }
+    if (!m_command_buffer->submit(signal_semaphore, signal_value,
+                                  wait_semaphores, wait_values)) {
         return CL_OUT_OF_RESOURCES;
+    }
+    m_submitted = true;
+    // We have consider the default case when the batch is executed
+    // synchronously. As we now know that is will be asynchronous, mark this
+    // command as completed as far as synchronous commands are concerned.
+    m_queue->sync_submit_cmd_completed();
+
+    // add ourselves in dependency so that we wait on the batch completion
+    // before calling 'cvk_command_batch::do_action' in 'cvk_command::execute'.
+    add_dependency(event());
+
+    return CL_COMPLETE;
+}
+
+cl_int cvk_command_batch::do_action() {
+    if (!m_submitted) {
+        cvk_info("executing batch of %lu commands", m_commands.size());
+        if (!m_command_buffer->submit_and_wait()) {
+            return CL_OUT_OF_RESOURCES;
+        }
     }
 
     m_queue->batch_completed();

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -147,6 +147,13 @@ struct cvk_command_queue : public _cl_command_queue,
         return (m_properties & prop) == prop;
     }
 
+    bool use_timeline_semaphore() const {
+        return m_context != nullptr &&
+               m_device->has_timeline_semaphore_support() &&
+               (!has_property(CL_QUEUE_PROFILING_ENABLE) ||
+                profiling_on_device());
+    }
+
     CHECK_RETURN cl_int enqueue_command_with_deps(cvk_command* cmd,
                                                   cl_uint num_dep_events,
                                                   _cl_event* const* dep_events,
@@ -234,6 +241,13 @@ struct cvk_command_queue : public _cl_command_queue,
         TRACE_CNT(group_in_flight_counter, group - 1);
     }
 
+    void sync_submit_cmd_enqueued() {
+        m_nb_synchronous_submit_command_in_flight++;
+    }
+    void sync_submit_cmd_completed() {
+        m_nb_synchronous_submit_command_in_flight--;
+    }
+
     cl_int execute_cmds_required_by(cl_uint num_events,
                                     _cl_event* const* event_list);
     cl_int execute_cmds_required_by_no_lock(cl_uint num_events,
@@ -241,6 +255,10 @@ struct cvk_command_queue : public _cl_command_queue,
                                             std::unique_lock<std::mutex>& lock);
 
     void detach_from_context();
+    cl_int get_next_semaphore_and_value(cvk_semaphore** sem, uint64_t* value,
+                                        cl_command_type type);
+
+    bool have_batch_in_flight() const { return m_nb_batch_in_flight > 0; }
 
     TRACE_TRACK_FCT(queue_track,
                     "clvk-queue_" + std::to_string((uintptr_t)this))
@@ -269,6 +287,11 @@ private:
     cvk_vulkan_queue_wrapper& m_vulkan_queue;
     cvk_command_pool m_command_pool;
 
+    std::mutex m_semaphore_lock;
+    cvk_semaphore* m_semaphore_main_timeline;
+    cvk_semaphore* m_semaphore_image_init_timeline;
+    cvk_semaphore* m_semaphore_batch_timeline;
+
     cl_uint m_max_cmd_batch_size;
     cl_uint m_max_first_cmd_batch_size;
     cl_uint m_max_cmd_group_size;
@@ -276,6 +299,8 @@ private:
 
     std::atomic<uint64_t> m_nb_batch_in_flight;
     std::atomic<uint64_t> m_nb_group_in_flight;
+
+    std::atomic<uint64_t> m_nb_synchronous_submit_command_in_flight;
 
     TRACE_CNT_VAR(batch_in_flight_counter);
     TRACE_CNT_VAR(group_in_flight_counter);
@@ -381,6 +406,10 @@ struct cvk_command_buffer {
         return res == VK_SUCCESS;
     }
 
+    CHECK_RETURN bool submit(VkSemaphore signal_semaphore,
+                             uint64_t signal_value,
+                             std::vector<VkSemaphore>& wait_semaphores,
+                             std::vector<uint64_t>& wait_values);
     CHECK_RETURN bool submit_and_wait();
 
     operator VkCommandBuffer() { return m_command_buffer; }
@@ -399,7 +428,12 @@ struct cvk_command {
         : m_type(type), m_queue(queue),
           m_event(new cvk_event_command(m_queue->context(), this, queue)) {}
 
-    virtual ~cvk_command() { m_event->release(); }
+    virtual ~cvk_command() {
+        for (auto& event : m_event_deps) {
+            event->release();
+        }
+        m_event->release();
+    }
 
     void set_dependencies(cl_uint num_event_deps,
                           _cl_event* const* event_deps) {
@@ -428,6 +462,15 @@ struct cvk_command {
     // never have data movement requirements of their own.
     virtual bool is_data_movement() const { return false; }
 
+    virtual bool is_synchronous_submit() const {
+        for (auto& ev : m_event_deps) {
+            if (ev->is_user_event()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     void add_dependency(cvk_event* dep) {
         dep->retain();
         m_event_deps.push_back(dep);
@@ -438,10 +481,14 @@ struct cvk_command {
         // First wait for dependencies
         cl_int status = CL_COMPLETE;
         for (auto& ev : m_event_deps) {
+            if (!ev->is_user_event() && m_queue != ev->queue()) {
+                if (ev->queue()->flush() != CL_SUCCESS) {
+                    status = CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST;
+                }
+            }
             if (ev->wait() != CL_COMPLETE) {
                 status = CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST;
             }
-            ev->release();
         }
 
         // Then execute the action if no dependencies failed
@@ -455,6 +502,9 @@ struct cvk_command {
             status = do_action();
             TRACE_END();
         }
+        if (is_synchronous_submit()) {
+            m_queue->sync_submit_cmd_completed();
+        }
 
         // When executing batch with many commands, "set_event_status" can take
         // a while. Trace it to be able to understand it easily.
@@ -464,7 +514,7 @@ struct cvk_command {
         return status;
     }
 
-    cvk_event_command* event() const { return m_event; }
+    virtual cvk_event_command* event() const { return m_event; }
 
     cl_command_type type() const { return m_type; }
 
@@ -700,6 +750,7 @@ struct cvk_command_batchable : public cvk_command {
 
     bool can_be_batched() const override;
     bool is_built_before_enqueue() const override final { return false; }
+    bool is_synchronous_submit() const override final { return true; }
 
     CHECK_RETURN cl_int get_timestamp_query_results(cl_ulong* start,
                                                     cl_ulong* end);
@@ -850,7 +901,7 @@ private:
 
 struct cvk_command_batch : public cvk_command {
     cvk_command_batch(cvk_command_queue* queue)
-        : cvk_command(CLVK_COMMAND_BATCH, queue) {}
+        : cvk_command(CLVK_COMMAND_BATCH, queue), m_submitted(false) {}
 
     cl_int add_command(cvk_command_batchable* cmd) {
         if (!m_command_buffer) {
@@ -880,6 +931,8 @@ struct cvk_command_batch : public cvk_command {
     }
 
     cl_uint batch_size() { return m_commands.size(); }
+
+    bool is_synchronous_submit() const override final { return !m_submitted; }
 
     CHECK_RETURN cl_int
     set_profiling_info(cl_profiling_info pinfo) override final {
@@ -911,14 +964,25 @@ struct cvk_command_batch : public cvk_command {
 
     void set_event_status(cl_int status) override final {
         m_event->set_status(status);
+        if (status == CL_RUNNING && m_queue->profiling_on_device()) {
+            return;
+        }
         for (auto& cmd : m_commands) {
             cmd->set_event_status(status);
         }
     }
 
+    CHECK_RETURN cl_int submit();
+
+    cvk_event_command* event() const override final {
+        CVK_ASSERT(m_commands.size() > 0);
+        return m_commands.back()->event();
+    }
+
 private:
     CHECK_RETURN cl_int do_action() override final;
 
+    bool m_submitted;
     std::vector<std::unique_ptr<cvk_command_batchable>> m_commands;
     std::unique_ptr<cvk_command_buffer> m_command_buffer;
 };

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -34,7 +34,7 @@ using cvk_command_queue_holder = refcounted_holder<cvk_command_queue>;
 
 struct cvk_command_group {
     std::deque<cvk_command*> commands;
-    cl_int execute_cmds();
+    cl_int execute_cmds(bool poll);
     void execute_cmds_in_executor();
 };
 
@@ -476,7 +476,7 @@ struct cvk_command {
         m_event_deps.push_back(dep);
     }
 
-    CHECK_RETURN cl_int execute() {
+    CHECK_RETURN cl_int execute(bool poll) {
 
         // First wait for dependencies
         cl_int status = CL_COMPLETE;
@@ -486,7 +486,7 @@ struct cvk_command {
                     status = CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST;
                 }
             }
-            if (ev->wait() != CL_COMPLETE) {
+            if (ev->wait(poll) != CL_COMPLETE) {
                 status = CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST;
             }
         }

--- a/src/semaphore.cpp
+++ b/src/semaphore.cpp
@@ -13,13 +13,20 @@
 // limitations under the License.
 
 #include "semaphore.hpp"
+#include "tracing.hpp"
 
 cl_int cvk_semaphore::init() {
 
     auto vkdev = m_context->device()->vulkan_device();
 
+    VkSemaphoreTypeCreateInfo timelineCreateInfo;
+    timelineCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
+    timelineCreateInfo.pNext = NULL;
+    timelineCreateInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+    timelineCreateInfo.initialValue = m_next_value;
+
     VkSemaphoreCreateInfo info = {
-        VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO, nullptr,
+        VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO, &timelineCreateInfo,
         0 // flags
     };
 
@@ -29,4 +36,97 @@ cl_int cvk_semaphore::init() {
     }
 
     return CL_SUCCESS;
+}
+
+void cvk_semaphore::notify(uint64_t value) {
+    std::unique_lock<std::mutex> lock(m_lock);
+    if (value <= m_current_value) {
+        return;
+    }
+
+    VkSemaphoreSignalInfo signalInfo;
+    signalInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO;
+    signalInfo.pNext = NULL;
+    signalInfo.semaphore = m_semaphore;
+    signalInfo.value = value;
+    VkResult res =
+        vkSignalSemaphore(m_context->device()->vulkan_device(), &signalInfo);
+    if (res != VK_SUCCESS) {
+        cvk_error("vkSignalSemaphore failed (%d %s)", res,
+                  vulkan_error_string(res));
+    }
+    m_current_value = value;
+}
+
+bool cvk_semaphore::wait(uint64_t value) {
+    std::unique_lock<std::mutex> lock(m_lock);
+    VkResult res = VK_SUCCESS;
+    do {
+        if (value <= m_current_value) {
+            return true;
+        }
+        VkSemaphoreWaitInfo waitInfo;
+        waitInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO;
+        waitInfo.pNext = NULL;
+        waitInfo.flags = 0;
+        waitInfo.semaphoreCount = 1;
+        waitInfo.pSemaphores = &m_semaphore;
+        waitInfo.pValues = &value;
+
+        TRACE_BEGIN("vkWaitSemaphore", "semaphore", (uintptr_t)this,
+                    "semaphore-value", value);
+        lock.unlock();
+        res = vkWaitSemaphores(m_context->device()->vulkan_device(), &waitInfo,
+                               1000000);
+        lock.lock();
+        TRACE_END();
+
+        if (res != VK_TIMEOUT && res != VK_SUCCESS) {
+            cvk_error("vkWaitSemaphores failed (%d %s)", res,
+                      vulkan_error_string(res));
+            return false;
+        }
+    } while (res != VK_SUCCESS);
+    m_current_value = std::max(m_current_value, value);
+    return true;
+}
+
+bool cvk_semaphore::poll(uint64_t value) {
+    uint64_t counter_value;
+    TRACE_BEGIN("vkPollSemaphore", "semaphore", (uintptr_t)this,
+                "semaphore-value", value);
+    do {
+        VkResult res = vkGetSemaphoreCounterValue(
+            m_context->device()->vulkan_device(), m_semaphore, &counter_value);
+        if (res != VK_SUCCESS) {
+            cvk_error("vkGetSemaphoreCounterValue failed (%d %s)", res,
+                      vulkan_error_string(res));
+            return false;
+        }
+    } while (counter_value < value);
+    m_lock.lock();
+    m_current_value = std::max(m_current_value, counter_value);
+    m_lock.unlock();
+    TRACE_END();
+
+    return true;
+}
+
+bool cvk_semaphore::poll_once(uint64_t value) {
+    uint64_t counter_value;
+    TRACE_BEGIN("vkPollOnceSemaphore", "semaphore", (uintptr_t)this,
+                "semaphore-value", value);
+    VkResult res = vkGetSemaphoreCounterValue(
+        m_context->device()->vulkan_device(), m_semaphore, &counter_value);
+    if (res != VK_SUCCESS) {
+        cvk_error("vkGetSemaphoreCounterValue failed (%d %s)", res,
+                  vulkan_error_string(res));
+        return false;
+    }
+    m_lock.lock();
+    m_current_value = std::max(m_current_value, counter_value);
+    m_lock.unlock();
+    TRACE_END();
+
+    return m_current_value >= value;
 }

--- a/tests/api/dependencies.cpp
+++ b/tests/api/dependencies.cpp
@@ -184,4 +184,6 @@ TEST_F(WithCommandQueue, InOrderQueueStopsExecutionAfterFailedCommand) {
     cl_int status;
     GetEventInfo(mapev, CL_EVENT_COMMAND_EXECUTION_STATUS, &status);
     ASSERT_NE(status, CL_COMPLETE);
+
+    clReleaseEvent(mapev);
 }

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -438,6 +438,7 @@ TEST_F(WithCommandQueue, FinishAfterFlush) {
         SetUserEventStatus(uevent, CL_COMPLETE);
         thread->join();
     }
+    clReleaseEvent(kevent);
 }
 
 #ifdef CLVK_UNIT_TESTING_ENABLED

--- a/tests/api/profiling.cpp
+++ b/tests/api/profiling.cpp
@@ -56,6 +56,8 @@ TEST_F(WithProfiledCommandQueue,
     ASSERT_LT(ts_submit - ts_queued, max_diff);
     ASSERT_LT(ts_start - ts_submit, max_diff);
     ASSERT_LT(ts_end - ts_start, max_diff);
+
+    clReleaseEvent(event);
 }
 
 TEST_F(WithProfiledCommandQueue,
@@ -110,6 +112,9 @@ TEST_F(WithProfiledCommandQueue,
         ASSERT_EQ(ts_start_1, ts_start_2);
         ASSERT_EQ(ts_end_1, ts_end_2);
     }
+
+    clReleaseEvent(ev1);
+    clReleaseEvent(ev2);
 }
 
 TEST_F(WithProfiledCommandQueue, DISABLED_APPLE(QueueProfilingVsDeviceTimer)) {
@@ -183,6 +188,8 @@ TEST_F(WithProfiledCommandQueue, DISABLED_APPLE(QueueProfilingVsDeviceTimer)) {
     ASSERT_LT(timer_after_flush, ts_start);
     ASSERT_GT(timer_after_completion, ts_start);
     ASSERT_GT(timer_after_completion, ts_end);
+
+    clReleaseEvent(kevent);
 }
 
 TEST_F(WithContext, DeviceAndHostTimerEquality) {

--- a/tests/perfetto/api_tests.EnqueueTooManyCommandWithRetry-expectation.txt
+++ b/tests/perfetto/api_tests.EnqueueTooManyCommandWithRetry-expectation.txt
@@ -40,4 +40,4 @@
 "name"
 "set_event_status"
 "vkQueueSubmit"
-"vkQueueWaitIdle"
+"vkWaitSemaphore"

--- a/tests/perfetto/simple_test-expectation.txt
+++ b/tests/perfetto/simple_test-expectation.txt
@@ -39,4 +39,4 @@
 "name"
 "set_event_status"
 "vkQueueSubmit"
-"vkQueueWaitIdle"
+"vkWaitSemaphore"


### PR DESCRIPTION
Use a `cvk_semaphore` instead of a `std::condition_variable` when `VK_KHR_timeline_semaphore` is supported.

`cvk_event` holds a `cvk_condition_variable` which can be either `cvk_std_condition_variable` (using `std::condition_variable`) or a `cvk_semaphore_condition_variable` (using `cvk_semaphore`).

When the event is created it will get a `cvk_semaphore` and a `value`. It assumes that nothing will be created between the creation of the event and its submission in the queue, thus `value`s will be allocated in order.

As this assumption is not always true, we make sure of it by using 3 timelines where we can ensure that nothing will be created between the creation of the event and its submission in the queue.

Add `notify`, `wait`, `poll`, `poll_once` implementation to `cvk_semaphore`.

When `cvk_command_queue::end_current_command_batch` is called, if we can use timeline semaphore and no synchronous command has been submitted, submit the batch.

Add config option to poll the timeline semaphore instead of waiting. Differentiate the main thread and the executors. This can be useful to understand performance issues, or driver bugs.