### PR TITLE
Add config option to reuse descriptor_set

### DIFF
--- a/src/config.def
+++ b/src/config.def
@@ -212,6 +212,11 @@ OPTION(uint32_t, perfetto_trace_max_size, 1024u)
 OPTION(std::string, perfetto_trace_dest, "clvk.perfetto-trace")
 #endif // CLVK_PERFETTO_BACKEND_INPROCESS
 
+// Do not free descriptor set before the kernel is completely released. When it
+// is not possible to allocate new ones, reuse ones that have been released from
+// the application point of view.
+PROPERTY(bool, reuse_descriptor_set, false)
+
 
 ////////////////////////////////////////////////////////////
 // LOGGING & VALIDATION ////////////////////////////////////

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -725,6 +725,10 @@ struct cvk_device : public _cl_device_id,
         return m_clvk_properties->keep_memory_allocations_mapped();
     }
 
+    bool reuse_descriptor_set() const {
+        return m_clvk_properties->reuse_descriptor_set();
+    }
+
     TRACE_TRACK_FCT(device_track,
                     "clvk-device_" + std::to_string((uintptr_t)this))
 

--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -27,8 +27,9 @@ struct cvk_device_properties_mali : public cvk_device_properties_virtual {
     uint32_t max_first_cmd_batch_size() const override final { return 10; }
     uint32_t max_cmd_group_size() const override final { return 1; }
 
-    cvk_device_properties_mali(const uint32_t deviceID)
-        : m_deviceID(deviceID) {}
+    cvk_device_properties_mali(const uint32_t deviceID,
+                               const VkDriverId driverID)
+        : m_deviceID(deviceID), m_driverID(driverID) {}
 
     bool non_uniform_decoration_broken() const override final {
 #define GPU_ID2_ARCH_MAJOR_SHIFT 28
@@ -38,24 +39,31 @@ struct cvk_device_properties_mali : public cvk_device_properties_virtual {
         return (m_deviceID & GPU_ID2_ARCH_MAJOR) <= bifrost_arch_major;
     }
 
+    bool reuse_descriptor_set() const override final {
+        return m_driverID == VK_DRIVER_ID_ARM_PROPRIETARY;
+    }
+
 private:
     const uint32_t m_deviceID;
+    const VkDriverId m_driverID;
 };
 
 struct cvk_device_properties_mali_exynos9820
     : public cvk_device_properties_mali {
     uint32_t global_mem_cache_size() const override final { return 262144; }
     uint32_t max_compute_units() const override final { return 12; }
-    cvk_device_properties_mali_exynos9820(const uint32_t deviceID)
-        : cvk_device_properties_mali(deviceID) {}
+    cvk_device_properties_mali_exynos9820(const uint32_t deviceID,
+                                          const VkDriverId driverID)
+        : cvk_device_properties_mali(deviceID, driverID) {}
 };
 
 struct cvk_device_properties_mali_exynos990
     : public cvk_device_properties_mali {
     uint32_t global_mem_cache_size() const override final { return 262144; }
     uint32_t max_compute_units() const override final { return 11; }
-    cvk_device_properties_mali_exynos990(const uint32_t deviceID)
-        : cvk_device_properties_mali(deviceID) {}
+    cvk_device_properties_mali_exynos990(const uint32_t deviceID,
+                                         const VkDriverId driverID)
+        : cvk_device_properties_mali(deviceID, driverID) {}
 };
 
 static bool isMaliDevice(const char* name, const uint32_t vendorID) {
@@ -270,9 +278,9 @@ std::unique_ptr<cvk_device_properties> create_cvk_device_properties(
             cvk_warn("Unable to query 'ro.hardware' system property, some "
                      "device properties will be incorrect.");
         } else if (strcmp(soc, "exynos9820") == 0) {
-            RETURN(cvk_device_properties_mali_exynos9820, deviceID);
+            RETURN(cvk_device_properties_mali_exynos9820, deviceID, driverID);
         } else if (strcmp(soc, "exynos990") == 0) {
-            RETURN(cvk_device_properties_mali_exynos990, deviceID);
+            RETURN(cvk_device_properties_mali_exynos990, deviceID, driverID);
         } else {
             cvk_warn("Unrecognized 'ro.hardware' value '%s', some device "
                      "properties will be incorrect.",
@@ -282,7 +290,7 @@ std::unique_ptr<cvk_device_properties> create_cvk_device_properties(
         cvk_warn("Unrecognized Mali device, some device properties will be "
                  "incorrect.");
 #endif
-        RETURN(cvk_device_properties_mali, deviceID);
+        RETURN(cvk_device_properties_mali, deviceID, driverID);
     } else if (strcmp(name, "Adreno (TM) 615") == 0) {
         RETURN(cvk_device_properties_adreno_615);
     } else if (strcmp(name, "Adreno (TM) 620") == 0) {

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -194,11 +194,7 @@ struct cvk_kernel_argument_values {
           m_descriptor_sets_refcount(0) {}
 
     ~cvk_kernel_argument_values() {
-        for (auto ds : m_descriptor_sets) {
-            if (ds != VK_NULL_HANDLE) {
-                m_entry_point->free_descriptor_set(ds);
-            }
-        }
+        m_entry_point->free_descriptor_sets(m_descriptor_sets);
     }
 
     static std::shared_ptr<cvk_kernel_argument_values>
@@ -387,12 +383,7 @@ struct cvk_kernel_argument_values {
         std::lock_guard<std::mutex> lock(m_lock);
         if (--m_descriptor_sets_refcount == 0) {
             m_is_enqueued = false;
-            for (auto& ds : m_descriptor_sets) {
-                if (ds != VK_NULL_HANDLE) {
-                    m_entry_point->free_descriptor_set(ds);
-                    ds = VK_NULL_HANDLE;
-                }
-            }
+            m_entry_point->free_descriptor_sets(m_descriptor_sets);
         }
     }
 
@@ -439,7 +430,6 @@ private:
     std::vector<bool> m_args_set;
 
     std::unique_ptr<cvk_buffer> m_pod_buffer;
-    std::array<VkDescriptorSet, spir_binary::MAX_DESCRIPTOR_SETS>
-        m_descriptor_sets;
+    cvk_descriptor_set_array m_descriptor_sets;
     uint32_t m_descriptor_sets_refcount;
 };

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -2277,6 +2277,16 @@ bool cvk_entry_point::allocate_descriptor_sets(VkDescriptorSet* ds) {
 
     std::lock_guard<std::mutex> lock(m_descriptor_pool_lock);
 
+    if (m_device->reuse_descriptor_set() && !m_descriptor_sets_array.empty()) {
+        cvk_descriptor_set_array descriptor_sets =
+            m_descriptor_sets_array.back();
+        m_descriptor_sets_array.pop_back();
+        for (unsigned i = 0; i < descriptor_sets.size(); i++) {
+            ds[i] = descriptor_sets[i];
+        }
+        return true;
+    }
+
 #if CLVK_UNIT_TESTING_ENABLED
     if (config.force_descriptor_set_allocation_failure() &&
         m_nb_descriptor_set_allocated + m_descriptor_set_layouts.size() >

--- a/tests/perfetto/api_tests.EnqueueTooManyCommandWithRetry-expectation.txt
+++ b/tests/perfetto/api_tests.EnqueueTooManyCommandWithRetry-expectation.txt
@@ -36,7 +36,7 @@
 "execute_cmds"
 "extract_cmds_required_by"
 "flush_no_lock"
-"free_descriptor_set"
+"free_descriptor_sets"
 "name"
 "set_event_status"
 "vkQueueSubmit"

--- a/tests/perfetto/simple_test-expectation.txt
+++ b/tests/perfetto/simple_test-expectation.txt
@@ -35,7 +35,7 @@
 "execute_cmds"
 "extract_cmds_required_by"
 "flush_no_lock"
-"free_descriptor_set"
+"free_descriptor_sets"
 "name"
 "set_event_status"
 "vkQueueSubmit"


### PR DESCRIPTION
On Mali devices, using the ARM DDK, some application quickly get to a point where the driver consider the memory as fragemented and it not capable of allocated new descriptor_set anymore.

To avoid that, do not free descriptor_set, and when it is not possible to allocate new ones, reuse ones that have been release from the application point of view.