### PR TITLE
move CLVK_CONFIG_FILE to config

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -316,13 +316,10 @@ void parse_config_file(bool early_option) {
     config_file_paths.push_back("~/.config/clvk.conf");
     config_file_paths.push_back(
         (std::filesystem::current_path() / conf_file).string());
-    // First check if env var has file
-    std::string conv_file_env_var = "CLVK_CONFIG_FILE";
-    const char* conf_file_env_path = getenv(conv_file_env_var.c_str());
-
-    if (conf_file_env_path != nullptr) {
-        config_file_paths.push_back(conf_file_env_path);
+    if (!config.config_file().empty()) {
+        config_file_paths.push_back(config.config_file());
     }
+
     for (auto& curr_path : config_file_paths) {
         if (!std::filesystem::exists(curr_path)) {
             continue;
@@ -341,6 +338,9 @@ void parse_config_file(bool early_option) {
             continue;
         }
         if (file_config_values.find(opt.name) == file_config_values.end()) {
+            continue;
+        }
+        if (opt.set) { // means already set by 'parse_env'
             continue;
         }
         CVK_ASSERT(file_config_values[opt.name].length() > 0);
@@ -418,12 +418,12 @@ char* print_option(config_option_type type, void* val) {
 }
 
 void init_config() {
-    parse_config_file(false);
     parse_env(false);
+    parse_config_file(false);
     print_config();
 }
 
 void init_early_config() {
-    parse_config_file(true);
     parse_env(true);
+    parse_config_file(true);
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -82,7 +82,7 @@ void parse_string_set(void* value_ptr, const char* txt) {
         val = X;                                                               \
         return true;                                                           \
     }
-bool channel_order_from_string(std::string s, cl_channel_order& val) {
+bool channel_order_from_string(std::string& s, cl_channel_order& val) {
     CASE(CL_R)
     CASE(CL_A)
     CASE(CL_DEPTH)
@@ -104,7 +104,7 @@ bool channel_order_from_string(std::string s, cl_channel_order& val) {
     CASE(CL_sRGBx)
     return false;
 }
-bool channel_type_from_string(std::string s, cl_channel_type& val) {
+bool channel_type_from_string(std::string& s, cl_channel_type& val) {
     CASE(CL_SNORM_INT8)
     CASE(CL_SNORM_INT16)
     CASE(CL_UNORM_INT8)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -104,7 +104,7 @@ bool channel_order_from_string(std::string& s, cl_channel_order& val) {
     CASE(CL_sRGBx)
     return false;
 }
-bool channel_type_from_string(std::string& s, cl_channel_type& val) {
+bool channel_type_from_string(const std::string& s, cl_channel_type& val) {
     CASE(CL_SNORM_INT8)
     CASE(CL_SNORM_INT16)
     CASE(CL_UNORM_INT8)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -82,7 +82,7 @@ void parse_string_set(void* value_ptr, const char* txt) {
         val = X;                                                               \
         return true;                                                           \
     }
-bool channel_order_from_string(std::string& s, cl_channel_order& val) {
+bool channel_order_from_string(const std::string& s, cl_channel_order& val) {
     CASE(CL_R)
     CASE(CL_A)
     CASE(CL_DEPTH)

--- a/src/config.def
+++ b/src/config.def
@@ -246,6 +246,9 @@ EARLY_OPTION(std::string, log_groups, "")
 // should still be printed out or not.
 EARLY_OPTION(bool, log_groups_only, false)
 
+// Specify the path to an additional configuration file
+EARLY_OPTION(std::string, config_file, "")
+
 // Allow enabling Vulkan validation layers:
 //  * 0: disabled (default)
 //  * 1: enabled


### PR DESCRIPTION
run parse_env before parse_config_file to be able to set
CLVK_CONFIG_FILE with 'log' set inside it and still have it set before
'init_logging' which happens between 'init_early_config' and
'init_config'.

Make sure not to override env value with config file ones