### PR TITLE
fix test_api negative_invalid_arg_size_local

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -2923,6 +2923,11 @@ cl_int CLVK_API_CALL clSetKernelArg(cl_kernel kern, cl_uint arg_index,
         return CL_INVALID_ARG_VALUE;
     }
 
+    if (arg_size == 0 &&
+        (kernel->arg_kind(arg_index) == kernel_argument_kind::local)) {
+        return CL_INVALID_ARG_SIZE;
+    }
+
     return kernel->set_arg(arg_index, arg_size, arg_value);
 }
 


### PR DESCRIPTION
clSetKernelArg is supposed to fail with CL_INVALID_ARG_SIZE when 0 is passed to a local qualifier kernel argument! (Got CL_SUCCESS, expected CL_INVALID_ARG_SIZE from <OpenCL-CTS>/test_conformance/api/test_kernels.cpp:794)