### PR TITLE
Add option to fill images on device

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -5458,12 +5458,11 @@ cl_int CLVK_API_CALL clEnqueueFillImage(
 
     auto img = static_cast<cvk_image*>(image);
 
-    // Fill
-    cvk_image::fill_pattern_array pattern;
-    size_t pattern_size;
-    img->prepare_fill_pattern(fill_color, pattern, &pattern_size);
-
     if (img->is_backed_by_buffer_view()) {
+        cvk_image::fill_pattern_array pattern;
+        size_t pattern_size;
+        img->prepare_fill_pattern(fill_color, pattern, &pattern_size);
+
         auto cmd = new cvk_command_fill_buffer(
             command_queue, static_cast<cvk_buffer*>(img->buffer()),
             origin[0] * img->element_size(), region[0] * img->element_size(),
@@ -5475,6 +5474,23 @@ cl_int CLVK_API_CALL clEnqueueFillImage(
 
     // Create image map command
     std::array<size_t, 3> reg = {region[0], region[1], region[2]};
+
+    if (config.fill_image_on_device()) {
+        std::array<size_t, 3> org = {origin[0], origin[1], origin[2]};
+        cvk_image::fill_pattern_array pattern;
+        memcpy(pattern.data(), fill_color, sizeof(pattern));
+
+        auto cmd_fill_on_device = new cvk_command_fill_image_on_device(
+            command_queue, img, pattern, org, reg);
+        return command_queue->enqueue_command_with_deps(cmd_fill_on_device,
+                                                        num_events_in_wait_list,
+                                                        event_wait_list, event);
+    }
+
+    // Fill
+    cvk_image::fill_pattern_array pattern;
+    size_t pattern_size;
+    img->prepare_fill_pattern(fill_color, pattern, &pattern_size);
 
     void* map_ptr;
     _cl_event* evt_map;

--- a/src/config.def
+++ b/src/config.def
@@ -225,6 +225,10 @@ OPTION(std::string, perfetto_trace_dest, "clvk.perfetto-trace")
 // the application point of view.
 PROPERTY(bool, reuse_descriptor_set, false)
 
+// Use a kernel to implement clEnqueueFillImage, so that the operation is
+// performed on device (Not through a host-to-device transfer).
+OPTION(bool, fill_image_on_device, false)
+
 
 ////////////////////////////////////////////////////////////
 // LOGGING & VALIDATION ////////////////////////////////////

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -323,7 +323,21 @@ cvk_image* cvk_image::create(cvk_context* ctx, cl_mem_flags flags,
     return *errcode_ret == CL_SUCCESS ? image.release() : nullptr;
 }
 
-cl_int cvk_image::init_vulkan_image() {
+cvk_image* cvk_image::create_write_enabled_image_from(cvk_image* image) {
+    auto properties = image->properties();
+    auto image_write_enabled =
+        std::make_unique<cvk_image>(image->m_context, CL_MEM_WRITE_ONLY,
+                                    (const cl_image_desc*)&(image->m_desc),
+                                    (const cl_image_format*)&(image->m_format),
+                                    nullptr, std::move(properties));
+    if (image_write_enabled->init(image->m_memory) != CL_SUCCESS) {
+        return nullptr;
+    }
+    return image_write_enabled.release();
+}
+
+cl_int
+cvk_image::init_vulkan_image(std::shared_ptr<cvk_memory_allocation> memory) {
     // Translate image type and size
     VkImageType image_type;
     VkImageViewType view_type;
@@ -405,10 +419,14 @@ cl_int cvk_image::init_vulkan_image() {
     // Create Image
     VkImageTiling tiling = VK_IMAGE_TILING_OPTIMAL;
     VkImageUsageFlags usage = prepare_usage_flags();
+    VkImageCreateFlags create_flags = 0;
+    if (memory != nullptr) {
+        create_flags |= VK_IMAGE_CREATE_ALIAS_BIT;
+    }
     VkImageCreateInfo imageCreateInfo = {
         VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
         nullptr,                   // pNext
-        0,                         // flags
+        create_flags,              // flags
         image_type,                // imageType
         fmt.vkfmt,                 // format
         extent,                    // extent
@@ -454,25 +472,29 @@ cl_int cvk_image::init_vulkan_image() {
         return CL_MEM_OBJECT_ALLOCATION_FAILURE;
     }
 
-    CVK_ASSERT(m_desc.image_type != CL_MEM_OBJECT_IMAGE1D_BUFFER);
-    // Select memory type
-    cvk_device::allocation_parameters params =
-        device->select_memory_for(m_image);
-    if (params.memory_type_index == VK_MAX_MEMORY_TYPES) {
-        cvk_error_fn("Could not get memory type!");
-        return CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    }
+    if (memory != nullptr) {
+        m_memory = memory;
+    } else {
+        CVK_ASSERT(m_desc.image_type != CL_MEM_OBJECT_IMAGE1D_BUFFER);
+        // Select memory type
+        cvk_device::allocation_parameters params =
+            device->select_memory_for(m_image);
+        if (params.memory_type_index == VK_MAX_MEMORY_TYPES) {
+            cvk_error_fn("Could not get memory type!");
+            return CL_MEM_OBJECT_ALLOCATION_FAILURE;
+        }
 
-    // Allocate memory
-    m_memory = std::make_unique<cvk_memory_allocation>(
-        vkdev, params.size, params.memory_type_index, params.memory_coherent,
-        device->keep_memory_allocations_mapped());
+        // Allocate memory
+        m_memory = std::make_unique<cvk_memory_allocation>(
+            vkdev, params.size, params.memory_type_index,
+            params.memory_coherent, device->keep_memory_allocations_mapped());
 
-    res = m_memory->allocate(device->uses_physical_addressing());
+        res = m_memory->allocate(device->uses_physical_addressing());
 
-    if (res != VK_SUCCESS) {
-        cvk_error_fn("Could not allocate memory!");
-        return CL_MEM_OBJECT_ALLOCATION_FAILURE;
+        if (res != VK_SUCCESS) {
+            cvk_error_fn("Could not allocate memory!");
+            return CL_MEM_OBJECT_ALLOCATION_FAILURE;
+        }
     }
 
     // Bind the image to memory
@@ -605,11 +627,11 @@ cl_int cvk_image::init_vulkan_texel_buffer() {
     return CL_SUCCESS;
 }
 
-cl_int cvk_image::init() {
+cl_int cvk_image::init(std::shared_ptr<cvk_memory_allocation> memory) {
     if (is_backed_by_buffer_view()) {
         return init_vulkan_texel_buffer();
     } else {
-        return init_vulkan_image();
+        return init_vulkan_image(memory);
     }
 }
 

--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -640,6 +640,8 @@ struct cvk_image : public cvk_mem {
                              std::vector<cl_mem_properties>&& properties,
                              cl_int* errcode_ret);
 
+    static cvk_image* create_write_enabled_image_from(cvk_image* image);
+
     bool is_backed_by_buffer_view() const {
         return type() == CL_MEM_OBJECT_IMAGE1D_BUFFER;
     }
@@ -831,9 +833,9 @@ struct cvk_image : public cvk_mem {
                               size_t* size_ret) const;
 
 private:
-    cl_int init_vulkan_image();
+    cl_int init_vulkan_image(std::shared_ptr<cvk_memory_allocation> memory);
     cl_int init_vulkan_texel_buffer();
-    cl_int init();
+    cl_int init(std::shared_ptr<cvk_memory_allocation> memory = nullptr);
 
     size_t num_channels() const {
         switch (m_format.image_channel_order) {

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1883,3 +1883,211 @@ cvk_command_image_init::build_batchable_inner(cvk_command_buffer& cmdbuf) {
 
     return CL_SUCCESS;
 }
+
+cl_int cvk_command_fill_image_on_device::build_batchable_inner(
+    cvk_command_buffer& cmdbuf) {
+    if (m_image_write_enabled != nullptr) {
+        VkImageSubresourceRange subresourceRange = {
+            VK_IMAGE_ASPECT_COLOR_BIT, // aspectMask
+            0,                         // baseMipLevel
+            VK_REMAINING_MIP_LEVELS,   // levelCount
+            0,                         // baseArrayLayer
+            VK_REMAINING_ARRAY_LAYERS, // layerCount
+        };
+
+        VkImageMemoryBarrier imageBarrier = {
+            VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            nullptr,
+            0, // srcAccessMask
+            VK_ACCESS_MEMORY_READ_BIT |
+                VK_ACCESS_MEMORY_WRITE_BIT,        // dstAccessMask
+            VK_IMAGE_LAYOUT_UNDEFINED,             // oldLayout
+            VK_IMAGE_LAYOUT_GENERAL,               // newLayout
+            0,                                     // srcQueueFamilyIndex
+            0,                                     // dstQueueFamilyIndex
+            m_image_write_enabled->vulkan_image(), // image
+            subresourceRange,                      // subresourceRange
+        };
+
+        vkCmdPipelineBarrier(cmdbuf, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                             VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                             0,              // dependencyFlags
+                             0,              // memoryBarrierCount
+                             nullptr,        // pMemoryBarriers
+                             0,              // bufferMemoryBarrierCount
+                             nullptr,        // pBufferMemoryBarriers
+                             1,              // imageMemoryBarrierCount
+                             &imageBarrier); // pImageMemoryBarriers
+    }
+
+    if (m_cmd_kernel != nullptr) {
+        return m_cmd_kernel->build_batchable_inner(cmdbuf);
+    }
+    if (m_mem == nullptr) {
+        return CL_OUT_OF_RESOURCES;
+    }
+    char source[1024];
+    char color[512];
+    const char* kernel_name = "fill_image";
+    const char* type = get_image_type();
+    const char* access_qualifier = get_image_access_qualifier();
+    const char* coord = get_image_coord();
+    get_image_color(color);
+    sprintf(source,
+            "kernel void %s(write_only %s image) { write_image%s(image, "
+            "%s, %s); }",
+            kernel_name, type, access_qualifier, coord, color);
+
+    auto program = std::make_unique<cvk_program>(m_queue->context());
+    program->append_source(source, strlen(source));
+    const cl_device_id device = static_cast<cl_device_id>(m_queue->device());
+    auto err = program->build(build_operation::build, 1, &device, nullptr, 0,
+                              nullptr, nullptr, nullptr, nullptr);
+    if (err != CL_SUCCESS) {
+        cvk_error_fn("fail to build program (%u)", err);
+        return CL_OUT_OF_RESOURCES;
+    }
+
+    auto prog = program.release();
+    auto kernel = std::make_unique<cvk_kernel>(prog, kernel_name);
+    prog->release();
+    err = kernel->init();
+    if (err != CL_SUCCESS) {
+        cvk_error_fn("fail to init kernel (%u)", err);
+        return err;
+    }
+    err = kernel->set_arg(0, sizeof(m_mem), &m_mem);
+    if (err != CL_SUCCESS) {
+        cvk_error_fn("fail to set arg (%u)", err);
+        return err;
+    }
+
+    cl_uint work_dim = dimensions();
+    cvk_ndrange ndrange(work_dim, m_work_offset.data(), m_work_size.data(),
+                        nullptr);
+    auto kern = kernel.release();
+    m_cmd_kernel =
+        std::make_unique<cvk_command_kernel>(m_queue, kern, work_dim, ndrange);
+    kern->release();
+    return m_cmd_kernel->build_batchable_inner(cmdbuf);
+}
+
+cl_uint cvk_command_fill_image_on_device::dimensions() const {
+    switch (m_image->type()) {
+    default:
+        CVK_ASSERT(false);
+        return 0;
+    case CL_MEM_OBJECT_IMAGE1D:
+    case CL_MEM_OBJECT_IMAGE1D_BUFFER:
+        return 1;
+    case CL_MEM_OBJECT_IMAGE1D_ARRAY:
+    case CL_MEM_OBJECT_IMAGE2D:
+        return 2;
+    case CL_MEM_OBJECT_IMAGE2D_ARRAY:
+    case CL_MEM_OBJECT_IMAGE3D:
+        return 3;
+    }
+}
+
+const char*
+cvk_command_fill_image_on_device::get_image_access_qualifier() const {
+    switch (m_image->format().image_channel_data_type) {
+    default:
+        CVK_ASSERT(false);
+        return nullptr;
+    case CL_SNORM_INT8:
+    case CL_SNORM_INT16:
+    case CL_UNORM_SHORT_565:
+    case CL_UNORM_SHORT_555:
+    case CL_UNORM_INT_101010:
+    case CL_UNORM_INT_101010_2:
+    case CL_UNORM_INT8:
+    case CL_UNORM_INT16:
+    case CL_FLOAT:
+    case CL_HALF_FLOAT:
+        return "f";
+    case CL_UNSIGNED_INT8:
+    case CL_UNSIGNED_INT16:
+    case CL_UNSIGNED_INT32:
+        return "ui";
+    case CL_SIGNED_INT8:
+    case CL_SIGNED_INT16:
+    case CL_SIGNED_INT32:
+        return "i";
+    }
+}
+
+const char* cvk_command_fill_image_on_device::get_image_type() const {
+    switch (m_image->type()) {
+    default:
+        CVK_ASSERT(false);
+        return nullptr;
+    case CL_MEM_OBJECT_IMAGE1D:
+        return "image1d_t";
+    case CL_MEM_OBJECT_IMAGE1D_BUFFER:
+        return "image1d_buffer_t";
+    case CL_MEM_OBJECT_IMAGE1D_ARRAY:
+        return "image1d_array_t";
+    case CL_MEM_OBJECT_IMAGE2D:
+        return "image2d_t";
+    case CL_MEM_OBJECT_IMAGE2D_ARRAY:
+        return "image2d_array_t";
+    case CL_MEM_OBJECT_IMAGE3D:
+        return "image3d_t";
+    }
+}
+
+const char* cvk_command_fill_image_on_device::get_image_coord() const {
+    switch (m_image->type()) {
+    default:
+        CVK_ASSERT(false);
+        return nullptr;
+    case CL_MEM_OBJECT_IMAGE1D:
+    case CL_MEM_OBJECT_IMAGE1D_BUFFER:
+        return "get_global_id(0)";
+    case CL_MEM_OBJECT_IMAGE1D_ARRAY:
+    case CL_MEM_OBJECT_IMAGE2D:
+        return "(int2)(get_global_id(0), get_global_id(1))";
+    case CL_MEM_OBJECT_IMAGE2D_ARRAY:
+    case CL_MEM_OBJECT_IMAGE3D:
+        return "(int4)(get_global_id(0), get_global_id(1), "
+               "get_global_id(2), 0)";
+    }
+}
+
+void cvk_command_fill_image_on_device::get_image_color(char* color) const {
+    auto fill_color = static_cast<const uint32_t*>(
+        static_cast<const void*>(m_fill_color.data()));
+    switch (m_image->format().image_channel_data_type) {
+    default:
+        CVK_ASSERT(false);
+        break;
+    case CL_SNORM_INT8:
+    case CL_SNORM_INT16:
+    case CL_UNORM_SHORT_565:
+    case CL_UNORM_SHORT_555:
+    case CL_UNORM_INT_101010:
+    case CL_UNORM_INT_101010_2:
+    case CL_UNORM_INT8:
+    case CL_UNORM_INT16:
+    case CL_FLOAT:
+    case CL_HALF_FLOAT:
+        sprintf(color,
+                "(float4)(as_float(0x%x), as_float(0x%x), as_float(0x%x), "
+                "as_float(0x%x))",
+                fill_color[0], fill_color[1], fill_color[2], fill_color[3]);
+        break;
+    case CL_UNSIGNED_INT8:
+    case CL_UNSIGNED_INT16:
+    case CL_UNSIGNED_INT32:
+        sprintf(color, "(uint4)(%u, %u, %u, %u)", fill_color[0], fill_color[1],
+                fill_color[2], fill_color[3]);
+        break;
+    case CL_SIGNED_INT8:
+    case CL_SIGNED_INT16:
+    case CL_SIGNED_INT32:
+        sprintf(color, "(int4)(%i, %i, %i, %i)", fill_color[0], fill_color[1],
+                fill_color[2], fill_color[3]);
+        break;
+    }
+}

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -1130,3 +1130,48 @@ struct cvk_command_image_init final : public cvk_command_batchable {
 private:
     cvk_image_holder m_image;
 };
+
+struct cvk_command_fill_image_on_device final : public cvk_command_batchable {
+    cvk_command_fill_image_on_device(
+        cvk_command_queue* queue, cvk_image* image,
+        const cvk_image::fill_pattern_array& fill_color,
+        const std::array<size_t, 3>& work_offset,
+        const std::array<size_t, 3>& work_size)
+        : cvk_command_batchable(CL_COMMAND_FILL_IMAGE, queue), m_image(image),
+          m_fill_color(fill_color), m_work_offset(work_offset),
+          m_work_size(work_size) {
+
+        if (!m_image->has_any_flag(CL_MEM_WRITE_ONLY | CL_MEM_READ_WRITE)) {
+            auto img = cvk_image::create_write_enabled_image_from(m_image);
+            m_image_write_enabled.reset(img);
+            if (img != nullptr) {
+                img->release();
+            }
+            m_mem = m_image_write_enabled;
+        } else {
+            m_mem = image;
+        }
+    }
+
+    CHECK_RETURN cl_int
+    build_batchable_inner(cvk_command_buffer& cmdbuf) override final;
+
+    const std::vector<cvk_mem*> memory_objects() const override {
+        return {m_image};
+    }
+
+private:
+    cl_uint dimensions() const;
+    const char* get_image_access_qualifier() const;
+    const char* get_image_type() const;
+    const char* get_image_coord() const;
+    void get_image_color(char* color) const;
+
+    cl_mem m_mem;
+    cvk_image_holder m_image;
+    cvk_image_holder m_image_write_enabled;
+    cvk_image::fill_pattern_array m_fill_color;
+    std::array<size_t, 3> m_work_offset;
+    std::array<size_t, 3> m_work_size;
+    std::unique_ptr<cvk_command_kernel> m_cmd_kernel;
+};

--- a/tests/api/images.cpp
+++ b/tests/api/images.cpp
@@ -852,4 +852,85 @@ TEST_F(WithCommandQueue, ImageInitAtCreation) {
     EXPECT_TRUE(success);
 }
 
+TEST_F(WithCommandQueue, FillImageOnDevice) {
+    auto cfg =
+        CLVK_CONFIG_SCOPED_OVERRIDE(fill_image_on_device, bool, true, true);
+
+    const size_t IMAGE_WIDTH = 8;
+    const size_t IMAGE_HEIGHT = 8;
+    const cl_uchar fill_value = 0x5A;
+    std::vector<cl_uchar> read_data(IMAGE_WIDTH * IMAGE_HEIGHT, 0);
+
+    cl_image_format format = {CL_R, CL_UNSIGNED_INT8};
+    cl_image_desc desc = {
+        CL_MEM_OBJECT_IMAGE2D, // image_type
+        IMAGE_WIDTH,           // image_width
+        IMAGE_HEIGHT,          // image_height
+        1,                     // image_depth
+        1,                     // image_array_size
+        0,                     // image_row_pitch
+        0,                     // image_slice_pitch
+        0,                     // num_mip_levels
+        0,                     // num_samples
+        nullptr,               // buffer
+    };
+
+    // Test with CL_MEM_READ_WRITE image
+    auto image_rw = CreateImage(CL_MEM_READ_WRITE, &format, &desc, nullptr);
+
+    cl_uint pattern[4] = {fill_value, fill_value, fill_value, fill_value};
+    size_t origin[3] = {0, 0, 0};
+    size_t region[3] = {IMAGE_WIDTH, IMAGE_HEIGHT, 1};
+
+    EnqueueFillImage(image_rw, &pattern, origin, region);
+    EnqueueReadImage(image_rw, CL_TRUE, origin, region, 0, 0, read_data.data());
+
+    for (size_t i = 0; i < IMAGE_WIDTH * IMAGE_HEIGHT; ++i) {
+        EXPECT_EQ(read_data[i], fill_value);
+    }
+
+    // Test with CL_MEM_READ_ONLY image
+    auto image_ro = CreateImage(CL_MEM_READ_ONLY, &format, &desc, nullptr);
+    std::vector<cl_uchar> read_ro(IMAGE_WIDTH * IMAGE_HEIGHT, 0);
+    const cl_uchar fill_value_ro = 0xA5;
+    cl_uint pattern_ro[4] = {fill_value_ro, fill_value_ro, fill_value_ro,
+                             fill_value_ro};
+    EnqueueFillImage(image_ro, &pattern_ro, origin, region);
+    EnqueueReadImage(image_ro, CL_TRUE, origin, region, 0, 0, read_ro.data());
+
+    for (size_t i = 0; i < IMAGE_WIDTH * IMAGE_HEIGHT; ++i) {
+        EXPECT_EQ(read_ro[i], fill_value_ro);
+    }
+
+    // Test with 3D image and float format
+    const size_t DEPTH = 4;
+    cl_image_format format_float = {CL_R, CL_FLOAT};
+    cl_image_desc desc_3d = {
+        CL_MEM_OBJECT_IMAGE3D, // image_type
+        IMAGE_WIDTH,           // image_width
+        IMAGE_HEIGHT,          // image_height
+        DEPTH,                 // image_depth
+        1,                     // image_array_size
+        0,                     // image_row_pitch
+        0,                     // image_slice_pitch
+        0,                     // num_mip_levels
+        0,                     // num_samples
+        nullptr,               // buffer
+    };
+
+    auto image_3d =
+        CreateImage(CL_MEM_READ_WRITE, &format_float, &desc_3d, nullptr);
+    cl_float fill_float[4] = {3.14f, 0.0f, 0.0f, 0.0f};
+    size_t region_3d[3] = {IMAGE_WIDTH, IMAGE_HEIGHT, DEPTH};
+    std::vector<cl_float> read_float(IMAGE_WIDTH * IMAGE_HEIGHT * DEPTH, 0.0f);
+
+    EnqueueFillImage(image_3d, fill_float, origin, region_3d);
+    EnqueueReadImage(image_3d, CL_TRUE, origin, region_3d, 0, 0,
+                     read_float.data());
+
+    for (size_t i = 0; i < IMAGE_WIDTH * IMAGE_HEIGHT * DEPTH; ++i) {
+        EXPECT_FLOAT_EQ(read_float[i], 3.14f);
+    }
+}
+
 #endif


### PR DESCRIPTION
Introduce a new configuration option `fill_image_on_device` to perform
`clEnqueueFillImage` operations on the device using a runtime-generated
compute kernel.

To support filling `CL_MEM_READ_ONLY` images (which cannot be written to
by kernels), implement a workaround that creates a temporary "write-enabled"
`cvk_image` alias (with `CL_MEM_WRITE_ONLY` flag) sharing the same
`VkDeviceMemory` allocation as the original image.

Implementation details:
- Added `fill_image_on_device` option to `src/config.def`.
- Intercepted `clEnqueueFillImage` in `src/api.cpp` to enqueue the new
  `cvk_command_fill_image_on_device` command when the option is enabled.
- Implemented `cvk_command_fill_image_on_device` in `src/queue.cpp` and
  `src/queue.hpp`. It dynamically generates OpenCL C source for the fill
  operation based on image type, coordinate type, and format, compiles
  it at runtime, and dispatches it.
- Added `cvk_image::create_write_enable_image_from` to support creating
  aliased images sharing the same memory allocation.
- Modified `cvk_image::init_vulkan_image` to accept an optional pre-allocated
  memory block.
- Updated `cvk_device::select_work_group_size` to support a null kernel
  argument, as it is called during command construction before the internal
  kernel is compiled.