### PR TITLE
recalibrate timestamps when drift is dectected

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -1366,19 +1366,10 @@ cl_int cvk_device::get_device_host_timer(cl_ulong* device_timestamp,
     return CL_SUCCESS;
 }
 
-cl_int cvk_device::update_device_host_timer_no_lock() {
-    return get_device_host_timer(&m_sync_dev, &m_sync_host);
-}
-
-cl_int cvk_device::update_device_host_timer() {
-    std::lock_guard<std::mutex> lock(m_sync_mutex);
-    return update_device_host_timer_no_lock();
-}
-
 cl_int cvk_device::device_timer_to_host(cl_ulong dev, cl_ulong& host) {
     std::lock_guard<std::mutex> lock(m_sync_mutex);
     if (dev > m_sync_dev) {
-        cl_int err = update_device_host_timer_no_lock();
+        cl_int err = get_device_host_timer(&m_sync_dev, &m_sync_host);
         if (err != CL_SUCCESS) {
             return err;
         }

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -623,7 +623,6 @@ struct cvk_device : public _cl_device_id,
 
     CHECK_RETURN cl_int get_device_host_timer(cl_ulong* dev_ts,
                                               cl_ulong* host_ts) const;
-    CHECK_RETURN cl_int update_device_host_timer();
     cl_int device_timer_to_host(cl_ulong dev, cl_ulong& host);
 
     uint64_t timestamp_to_ns(uint64_t ts) const {
@@ -826,7 +825,6 @@ private:
 
     cl_uint m_preferred_subgroup_size{};
 
-    CHECK_RETURN cl_int update_device_host_timer_no_lock();
     std::mutex m_sync_mutex;
     cl_ulong m_sync_host{};
     cl_ulong m_sync_dev{};


### PR DESCRIPTION
Because of device clock drift, we can end up with uncoherent submit/start/end timestamps.
When such case is dectected, recalibrate start/end time using the device timestamps.

For start time, consider that end time is correct and put start time before end time of the same offset we have seen on the device domain. Make sure that submit is still happening before start time.

For end time, we can only rely on submit time.