### PR TITLE
Update build options in cvk_program

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -2753,8 +2753,9 @@ cl_int CLVK_API_CALL clGetProgramBuildInfo(cl_program prog, cl_device_id dev,
         ret_size = program->build_log(device).size() + 1;
         break;
     case CL_PROGRAM_BUILD_OPTIONS:
-        copy_ptr = program->build_options().c_str();
-        ret_size = program->build_options().size() + 1;
+        val_string = program->build_options();
+        copy_ptr = val_string.c_str();
+        ret_size = val_string.size_with_null();
         break;
     case CL_PROGRAM_BINARY_TYPE:
         val_binarytype = program->binary_type(device);

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -798,11 +798,31 @@ bool validate_binary(spir_binary const& binary,
 
 const uint32_t clvk_binary_magic =
     0x6B766C63; // "clvk" in ASCII in little-endian
-const uint32_t clvk_binary_version = 1;
+const uint32_t clvk_binary_version = 2;
+
+// CLVK Binary Format Layout:
+//
+// +----------------------------------+
+// | clvk_binary_header               |
+// | - magic (0x6B766C63)             |
+// | - version                        |
+// | - binary_type                    |
+// | - build_options_size             |
+// +----------------------------------+
+// | Build Options (variable size)    |
+// | - string of length               |
+// |   build_options_size             |
+// +----------------------------------+
+// | Program Code                     |
+// | - LLVM IR (for library/object)   |
+// |   OR                             |
+// | - SPIR-V (for executable)        |
+// +----------------------------------+
 struct clvk_binary_header {
     uint32_t magic;
     uint32_t version;
     uint32_t binary_type;
+    uint32_t build_options_size;
 };
 #define COPY_WORD(dst, src)                                                    \
     do {                                                                       \
@@ -827,15 +847,18 @@ bool cvk_program::read_llvm_bitcode(const unsigned char* src, size_t size) {
 
 void cvk_program::write_binary_header(unsigned char* dst) const {
     struct clvk_binary_header* header = (struct clvk_binary_header*)dst;
+    uint32_t options_size = m_build_options.preserved_options().size();
     COPY_WORD(&header->magic, &clvk_binary_magic);
     COPY_WORD(&header->version, &clvk_binary_version);
     COPY_WORD(&header->binary_type, &m_binary_type);
+    COPY_WORD(&header->build_options_size, &options_size);
 }
 
 cl_program_binary_type cvk_program::read_binary_header(const unsigned char* src,
-                                                       size_t size) {
+                                                       size_t size,
+                                                       uint32_t& options_size) {
     struct clvk_binary_header* header = (struct clvk_binary_header*)src;
-    if (size < sizeof(header)) {
+    if (size < sizeof(struct clvk_binary_header)) {
         return CL_PROGRAM_BINARY_TYPE_NONE;
     }
     uint32_t magic, version, binary_type;
@@ -850,12 +873,14 @@ cl_program_binary_type cvk_program::read_binary_header(const unsigned char* src,
         cvk_warn_fn("wrong version");
         return CL_PROGRAM_BINARY_TYPE_NONE;
     }
+    COPY_WORD(&options_size, &header->build_options_size);
     return binary_type;
 }
 
 bool cvk_program::read(const unsigned char* src, size_t size) {
     bool success = false;
-    auto binary_type = read_binary_header(src, size);
+    uint32_t options_size = 0;
+    auto binary_type = read_binary_header(src, size, options_size);
     // if the binary does not have a clvk binary header, let's try to read
     // it first as a llvm ir buffer, then as a vulkan spirv buffer.
     if (binary_type == CL_PROGRAM_BINARY_TYPE_NONE) {
@@ -874,10 +899,22 @@ bool cvk_program::read(const unsigned char* src, size_t size) {
         cvk_error_fn("unable to read binary");
         return success;
     }
-
     auto header_size = sizeof(struct clvk_binary_header);
     src += header_size;
     size -= header_size;
+
+    if (options_size > size) {
+        cvk_error_fn(
+            "options_size is bigger than the remaining size of the program");
+        return false;
+    }
+
+    std::string build_options;
+    build_options.resize(options_size);
+    memcpy(build_options.data(), src, options_size);
+    m_build_options = cvk_build_options(build_options);
+    src += options_size;
+    size -= options_size;
 
     switch (binary_type) {
     case CL_PROGRAM_BINARY_TYPE_LIBRARY:
@@ -898,6 +935,10 @@ bool cvk_program::write(unsigned char* dst) const {
     write_binary_header(dst);
     dst += sizeof(struct clvk_binary_header);
 
+    auto build_options = m_build_options.preserved_options();
+    memcpy(dst, build_options.data(), build_options.size());
+    dst += build_options.size();
+
     switch (m_binary_type) {
     case CL_PROGRAM_BINARY_TYPE_LIBRARY:
     case CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT:
@@ -910,13 +951,14 @@ bool cvk_program::write(unsigned char* dst) const {
 }
 
 size_t cvk_program::binary_size() const {
-    auto header_size = sizeof(struct clvk_binary_header);
+    auto header_and_options_size = sizeof(struct clvk_binary_header) +
+                                   m_build_options.preserved_options().size();
     switch (m_binary_type) {
     case CL_PROGRAM_BINARY_TYPE_LIBRARY:
     case CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT:
-        return header_size + m_ir.size();
+        return header_and_options_size + m_ir.size();
     case CL_PROGRAM_BINARY_TYPE_EXECUTABLE:
-        return header_size + m_binary.size();
+        return header_and_options_size + m_binary.size();
     }
     return 0;
 }
@@ -926,7 +968,7 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
     std::string options;
     if (m_build_options.size() > 0) {
         options += " ";
-        options += m_build_options;
+        options += m_build_options.str();
     }
     const bool denorms_are_zero =
         options.find("-cl-denorms-are-zero") != std::string::npos ||
@@ -1739,13 +1781,23 @@ cl_int cvk_program::build(build_operation operation, cl_uint num_devices,
 
     retain();
 
-    for (cl_uint i = 0; i < num_input_programs; i++) {
-        cvk_program* iprog =
-            const_cast<cvk_program*>(icd_downcast(input_programs[i]));
-        m_input_programs.push_back(iprog);
-        if (header_include_names != nullptr) {
-            m_header_include_names.push_back(header_include_names[i]);
+    if (num_input_programs > 0) {
+        std::vector<cvk_preserved_options> input_preserved;
+        for (cl_uint i = 0; i < num_input_programs; i++) {
+            cvk_program* iprog =
+                const_cast<cvk_program*>(icd_downcast(input_programs[i]));
+            m_input_programs.push_back(iprog);
+            if (header_include_names != nullptr) {
+                m_header_include_names.push_back(header_include_names[i]);
+            }
+            input_preserved.push_back(
+                cvk_preserved_options::from_string(iprog->build_options()));
         }
+        auto merged_preserved = cvk_preserved_options::merge(input_preserved);
+        m_build_options = cvk_build_options(options != nullptr ? options : "",
+                                            merged_preserved);
+    } else if (options != nullptr) {
+        m_build_options = cvk_build_options(options);
     }
 
     // Mark build in-progress and save devices
@@ -1759,9 +1811,6 @@ cl_int cvk_program::build(build_operation operation, cl_uint num_devices,
         }
     }
 
-    if (options != nullptr) {
-        m_build_options = options;
-    }
     m_num_input_programs = num_input_programs;
     m_operation = operation;
     m_operation_callback = cb;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <map>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <vulkan/vulkan.h>
@@ -427,6 +428,182 @@ enum class build_operation
     link
 };
 
+/**
+ * Preserved OpenCL build options that need to be tracked across compilation
+ * units and saved in the program binary header.
+ *
+ * - "all" options (e.g. -cl-fast-relaxed-math) are retained only if present in
+ *   ALL merged options.
+ * - "one" options (e.g. -g, -cl-kernel-arg-info) are retained if present in AT
+ *   LEAST ONE of the merged options.
+ * - The OpenCL C version (-cl-std) is resolved to the maximum version among all
+ *   merged options.
+ */
+struct cvk_preserved_options {
+    std::set<std::string> options_all;
+    std::set<std::string> options_one;
+    unsigned source_language{0};
+
+    static constexpr std::array<const char*, 8> source_languages = {
+        "Unknown", "CL1.0", "CL1.1", "CL1.2",
+        "CL2.0",   "CL3.0", "CLC++", "CLC++2021",
+    };
+
+    static cvk_preserved_options from_string(const std::string& options) {
+        cvk_preserved_options result;
+        auto options_set = split_by_whitespace(options);
+        result.options_all = parse_preserved_options_all(options_set);
+        result.options_one = parse_preserved_options_one(options_set);
+        result.source_language = parse_source_language(options);
+        return result;
+    }
+
+    static cvk_preserved_options
+    merge(const std::vector<cvk_preserved_options>& input_options) {
+        cvk_preserved_options result;
+        if (input_options.empty()) {
+            return result;
+        }
+
+        result.options_all = input_options[0].options_all;
+        result.options_one = input_options[0].options_one;
+        result.source_language = input_options[0].source_language;
+
+        for (size_t i = 1; i < input_options.size(); ++i) {
+            const auto& input = input_options[i];
+            std::unordered_set<std::string> to_remove;
+            for (const auto& option : result.options_all) {
+                if (input.options_all.count(option) == 0) {
+                    to_remove.insert(option);
+                }
+            }
+            for (const auto& option : to_remove) {
+                result.options_all.erase(option);
+            }
+            for (const auto& option : input.options_one) {
+                result.options_one.insert(option);
+            }
+            result.source_language =
+                std::max(result.source_language, input.source_language);
+        }
+
+        return result;
+    }
+
+    std::string str() const {
+        std::string build_options;
+        for (const auto& option : options_all) {
+            build_options += " ";
+            build_options += option;
+        }
+        for (const auto& option : options_one) {
+            build_options += " ";
+            build_options += option;
+        }
+        if (source_language > 0) {
+            build_options += " -cl-std=";
+            build_options += source_languages[source_language];
+        }
+        return build_options;
+    }
+
+    size_t size() const { return str().size(); }
+
+private:
+    static unsigned parse_source_language(const std::string& options) {
+        std::string cl_std = "-cl-std=";
+        auto pos = options.find(cl_std);
+        if (pos == std::string::npos) {
+            return 0;
+        }
+        std::string substr = options.substr(pos);
+        for (unsigned source_language = 1;
+             source_language < source_languages.size(); source_language++) {
+            std::string match = cl_std + source_languages[source_language];
+            if (strncmp(substr.data(), match.data(), match.size()) == 0) {
+                return source_language;
+            }
+        }
+        return 0;
+    }
+
+    static std::set<std::string> split_by_whitespace(std::string_view str) {
+        std::set<std::string> result;
+        std::size_t start = 0;
+        while (start < str.size()) {
+            while (start < str.size() &&
+                   std::isspace(static_cast<unsigned char>(str[start]))) {
+                ++start;
+            }
+            if (start >= str.size()) {
+                break;
+            }
+            std::size_t end = start;
+            while (end < str.size() &&
+                   !std::isspace(static_cast<unsigned char>(str[end]))) {
+                ++end;
+            }
+            result.emplace(str.substr(start, end - start));
+            start = end;
+        }
+        return result;
+    }
+
+#define PARSE(option)                                                          \
+    do {                                                                       \
+        if (options.count(option) > 0) {                                       \
+            set.insert(option);                                                \
+        }                                                                      \
+    } while (0)
+    static std::set<std::string>
+    parse_preserved_options_all(const std::set<std::string>& options) {
+        std::set<std::string> set;
+        PARSE("-cl-single-precision-constant");
+        PARSE("-cl-denorms-are-zero");
+        PARSE("-cl-mad-enable");
+        PARSE("-cl-no-signed-zeros");
+        PARSE("-cl-unsafe-math-optimizations");
+        PARSE("-cl-finite-math-only");
+        PARSE("-cl-fast-relaxed-math");
+        return set;
+    }
+    static std::set<std::string>
+    parse_preserved_options_one(const std::set<std::string>& options) {
+        std::set<std::string> set;
+        PARSE("-cl-fp32-correctly-rounded-divide-sqrt");
+        PARSE("-cl-opt-disable");
+        PARSE("-cl-kernel-arg-info");
+        PARSE("-g");
+        return set;
+    }
+#undef PARSE
+};
+
+/**
+ * Manages OpenCL build options for a program.
+ */
+class cvk_build_options {
+public:
+    cvk_build_options(const std::string& options = "")
+        : m_build_options(options),
+          m_preserved_options(cvk_preserved_options::from_string(options)) {}
+
+    cvk_build_options(const std::string& link_options,
+                      const cvk_preserved_options& preserved_options)
+        : m_build_options(link_options + preserved_options.str()),
+          m_preserved_options(preserved_options) {}
+
+    const std::string& str() const { return m_build_options; }
+    std::string::size_type find(const char* s) const { return str().find(s); }
+    std::string::size_type size() const { return str().size(); }
+
+    std::string preserved_options() const { return m_preserved_options.str(); }
+
+private:
+    std::string m_build_options;
+    cvk_preserved_options m_preserved_options;
+};
+
 using cvk_program_callback = void(CL_CALLBACK*)(cl_program, void*);
 
 using cvk_spec_constant_map = std::map<uint32_t, uint32_t>;
@@ -606,7 +783,7 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
     cvk_program(cvk_context* ctx)
         : api_object(ctx), m_num_devices(1U),
           m_binary_type(CL_PROGRAM_BINARY_TYPE_NONE),
-          m_shader_module(VK_NULL_HANDLE),
+          m_shader_module(VK_NULL_HANDLE), m_build_options(""),
           m_binary(m_context->device()->vulkan_spirv_env()) {
         m_dev_status[m_context->device()] = CL_BUILD_NONE;
     }
@@ -672,7 +849,7 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
         return CL_SUCCESS;
     }
 
-    const std::string& build_options() const { return m_build_options; }
+    std::string build_options() const { return m_build_options.str(); }
 
     cl_build_status build_status(const cvk_device* device) const {
         return m_dev_status.at(device);
@@ -752,9 +929,8 @@ private:
     bool read_llvm_bitcode(const unsigned char* src, size_t size);
 
     void write_binary_header(unsigned char* dst) const;
-    CHECK_RETURN cl_program_binary_type
-
-    read_binary_header(const unsigned char* src, size_t size);
+    CHECK_RETURN cl_program_binary_type read_binary_header(
+        const unsigned char* src, size_t size, uint32_t& options_size);
 
 public:
     CHECK_RETURN bool read(const unsigned char* src, size_t size);
@@ -876,7 +1052,7 @@ public:
     }
 
     bool can_split_region() {
-        int status = options_allow_split_region(m_build_options);
+        int status = options_allow_split_region(m_build_options.str());
         status &= options_allow_split_region(config.clspv_options);
         return status;
     }
@@ -938,7 +1114,7 @@ private:
     VkShaderModule m_shader_module;
     std::unordered_map<const cvk_device*, std::atomic<cl_build_status>>
         m_dev_status;
-    std::string m_build_options;
+    cvk_build_options m_build_options;
     spir_binary m_binary;
     std::string m_build_log;
     std::vector<cvk_sampler_holder> m_literal_samplers;

--- a/tests/api/compiler.cpp
+++ b/tests/api/compiler.cpp
@@ -377,6 +377,94 @@ TEST_F(WithCommandQueue, ProgramBinaryExecutable) {
     ASSERT_EQ(result[3], 3);
 }
 
+TEST_F(WithCommandQueue, ProgramBinaryPreservedBuildOptions) {
+    static const char* sourceA = R"(
+      extern void bar(global uint *dst, global uint *src);
+
+      kernel void foo(global uint *dst, global uint *src) {
+        bar(dst, src);
+      }
+    )";
+    static const char* sourceB = R"(
+      void bar(global uint *dst, global uint *src) {
+        int gid = get_global_id(0);
+        dst[gid] = src[gid];
+      }
+    )";
+
+    auto programA = CreateProgram(sourceA);
+    CompileProgram(programA,
+                   "-cl-fast-relaxed-math -cl-opt-disable -cl-std=CL1.2");
+    auto binaryA = GetProgramBinary(programA);
+    auto reloaded_programA = CreateProgramWithBinary(binaryA);
+    auto optsA = GetProgramBuildOptions(reloaded_programA);
+    EXPECT_TRUE(optsA.find("-cl-fast-relaxed-math") != std::string::npos);
+    EXPECT_TRUE(optsA.find("-cl-opt-disable") != std::string::npos);
+    EXPECT_TRUE(optsA.find("-cl-std=CL1.2") != std::string::npos);
+
+    auto programB = CreateProgram(sourceB);
+    CompileProgram(programB,
+                   "-cl-fast-relaxed-math -cl-kernel-arg-info -cl-std=CL2.0");
+    auto binaryB = GetProgramBinary(programB);
+    auto reloaded_programB = CreateProgramWithBinary(binaryB);
+    auto optsB = GetProgramBuildOptions(reloaded_programB);
+    EXPECT_TRUE(optsB.find("-cl-fast-relaxed-math") != std::string::npos);
+    EXPECT_TRUE(optsB.find("-cl-kernel-arg-info") != std::string::npos);
+    EXPECT_TRUE(optsB.find("-cl-std=CL2.0") != std::string::npos);
+
+    cl_program program_list[2] = {reloaded_programA, reloaded_programB};
+    auto linked_program = LinkProgram(2, program_list);
+
+    auto linked_opts = GetProgramBuildOptions(linked_program);
+    EXPECT_TRUE(linked_opts.find("-cl-fast-relaxed-math") != std::string::npos);
+    EXPECT_TRUE(linked_opts.find("-cl-opt-disable") != std::string::npos);
+    EXPECT_TRUE(linked_opts.find("-cl-kernel-arg-info") != std::string::npos);
+    EXPECT_TRUE(linked_opts.find("-cl-std=CL2.0") != std::string::npos);
+
+    auto linked_binary = GetProgramBinary(linked_program);
+    auto reloaded_linked_program = CreateProgramWithBinary(linked_binary);
+    BuildProgram(reloaded_linked_program);
+
+    const size_t gws = 4;
+    const size_t buffer_size = gws * sizeof(cl_uint);
+    cl_uint source[gws] = {10, 20, 30, 40};
+    cl_uint result[gws] = {0};
+    auto buffer_src = CreateBuffer(CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+                                   buffer_size, source);
+    auto buffer_dst = CreateBuffer(CL_MEM_WRITE_ONLY, buffer_size);
+    auto kernel = CreateKernel(reloaded_linked_program, "foo");
+    SetKernelArg(kernel, 0, buffer_dst);
+    SetKernelArg(kernel, 1, buffer_src);
+
+    EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, nullptr);
+    EnqueueReadBuffer(buffer_dst, CL_BLOCKING, 0, buffer_size, result);
+
+    EXPECT_EQ(result[0], source[0]);
+    EXPECT_EQ(result[1], source[1]);
+    EXPECT_EQ(result[2], source[2]);
+    EXPECT_EQ(result[3], source[3]);
+}
+
+TEST_F(WithContext, ProgramBinaryMergeBuildOptionsDropped) {
+    static const char* sourceA = "void kernel foo() {}";
+    static const char* sourceB = "void kernel bar() {}";
+
+    auto programA = CreateProgram(sourceA);
+    CompileProgram(programA,
+                   "-cl-fast-relaxed-math -cl-opt-disable -cl-std=CL1.1");
+
+    auto programB = CreateProgram(sourceB);
+    CompileProgram(programB, "-cl-opt-disable -cl-std=CL1.2");
+
+    cl_program program_list[2] = {programA, programB};
+    auto linked_program = LinkProgram(2, program_list, "-create-library");
+
+    auto linked_opts = GetProgramBuildOptions(linked_program);
+    EXPECT_TRUE(linked_opts.find("-cl-fast-relaxed-math") == std::string::npos);
+    EXPECT_TRUE(linked_opts.find("-cl-opt-disable") != std::string::npos);
+    EXPECT_TRUE(linked_opts.find("-cl-std=CL1.2") != std::string::npos);
+}
+
 TEST_F(WithCommandQueue, LinkPrograms) {
     static const char* sourceA = R"(
       extern void bar(global uint *dst, global uint *src);

--- a/tests/api/testcl.hpp
+++ b/tests/api/testcl.hpp
@@ -366,6 +366,24 @@ protected:
         return build_log;
     }
 
+    std::string GetProgramBuildOptions(cl_program program) {
+        size_t options_size;
+        cl_int err =
+            clGetProgramBuildInfo(program, gDevice, CL_PROGRAM_BUILD_OPTIONS, 0,
+                                  nullptr, &options_size);
+        EXPECT_CL_SUCCESS(err);
+        std::string build_options;
+        build_options.resize(options_size);
+        auto data_ptr = const_cast<char*>(build_options.c_str());
+        err = clGetProgramBuildInfo(program, gDevice, CL_PROGRAM_BUILD_OPTIONS,
+                                    options_size, data_ptr, nullptr);
+        EXPECT_CL_SUCCESS(err);
+        if (!build_options.empty() && build_options.back() == '\0') {
+            build_options.pop_back();
+        }
+        return build_options;
+    }
+
     holder<cl_kernel> CreateKernel(const char* source, const char* name) {
         auto program = CreateAndBuildProgram(source);
 


### PR DESCRIPTION
OpenCL requires certain compiler options and language standards to be
retained across compilation units (compiled objects and libraries) and
carried forward when linking programs with clLinkProgram or saving/loading
binaries with clGetProgramInfo / clCreateProgramWithBinary.

This commit updates the CLVK binary format and build options handling:
* Bump CLVK binary format version to 2 and add `build_options_size` to
  `clvk_binary_header` to serialize preserved build options directly in
  the binary.
* Introduce `cvk_preserved_options` and `cvk_build_options` to parse,
  format, and merge compiler options according to OpenCL linking rules:
  - Preserves options that must be in all inputs ("all", e.g.,
    `-cl-fast-relaxed-math`, `-cl-denorms-are-zero`, etc.).
  - Preserves options that can be in at least one input ("one", e.g.,
    `-g`, `-cl-opt-disable`, `-cl-kernel-arg-info`, etc.).
  - Selects the maximum OpenCL C standard version (`-cl-std=`) across
    all inputs.
* Update `cvk_program` binary serialization (`read`, `write`,
  `binary_size`) to read and write preserved build options.
* Update `cvk_program::build()` to merge preserved options from input
  programs when linking.
* Fix `sizeof(header)` to `sizeof(struct clvk_binary_header)` in
  `read_binary_header()`.
* Update `clGetProgramBuildInfo(CL_PROGRAM_BUILD_OPTIONS)` in `src/api.cpp`
  to safely handle value returns from `program->build_options()`

Ref #822