### PR TITLE
Clean uniform work-group size option

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -614,7 +614,6 @@ void cvk_device::init_compiler_options() {
     m_device_compiler_options += " -global-offset ";
     m_device_compiler_options += " -long-vector ";
     m_device_compiler_options += " -module-constants-in-storage-buffer ";
-    m_device_compiler_options += " -cl-arm-non-uniform-work-group-size ";
 }
 
 void cvk_device::build_extension_ils_list() {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -980,6 +980,11 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
 #if COMPILER_AVAILABLE
     options += " " + config.clspv_options() + " ";
 #endif
+
+    if (options_allow_split_region(options)) {
+        options += "-cl-arm-non-uniform-work-group-size";
+    }
+
     // split options into a vector
     std::istringstream iss(options);
     std::vector<std::string> vector_options;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -840,9 +840,11 @@ public:
         return m_binary.printf_buffer_info();
     }
 
-    bool options_allow_split_region(std::string options) {
-        if (options.find("-uniform-workgroup-size") != std::string::npos)
+    bool options_allow_split_region(const std::string& options) const {
+        if (options.find("-uniform-workgroup-size") != std::string::npos ||
+            options.find("-cl-uniform-work-group-size") != std::string::npos) {
             return false;
+        }
         return true;
     }
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -942,9 +942,9 @@ cl_int cvk_command_kernel::dispatch_uniform_region(
                 cvk_error_fn(
                     "Splitting this region is required, but it is not possible "
                     "because the support has been disabled (most probably by "
-                    "'-uniform-workgroup-size').");
+                    "'-cl-uniform-work-group-size').");
 
-                return CL_INVALID_WORK_ITEM_SIZE;
+                return CL_INVALID_WORK_GROUP_SIZE;
             }
         }
     }
@@ -972,6 +972,15 @@ cl_int cvk_command_kernel::dispatch_uniform_region(
 
 cl_int cvk_command_kernel::build_and_dispatch_regions(
     cvk_command_buffer& command_buffer) {
+
+    auto program = m_kernel->program();
+    if (!program->can_split_region()) {
+        for (uint32_t dim = 0; dim < m_dimensions; dim++) {
+            if ((m_ndrange.gws[dim] % m_ndrange.lws[dim]) != 0) {
+                return CL_INVALID_WORK_GROUP_SIZE;
+            }
+        }
+    }
 
     // Split non-uniform NDRange into uniform regions
     cvk_ndrange regions[8];


### PR DESCRIPTION
Only add '-cl-arm-non-uniform-work-group-size' if options allow to split regions.

options do not allow to split region if '-cl-uniform-work-group-size' is used.

Return CL_INVALID_WORK_GROUP_SIZE if we need to split the region but cannot do it because of options.