### PR TITLE
Use a valid default compiler_temp_dir instead of invalid empty

### DIFF
--- a/src/config.def
+++ b/src/config.def
@@ -16,7 +16,7 @@
 // Compiler
 //
 OPTION(std::string, cache_dir, "")
-OPTION(std::string, compiler_temp_dir, "")
+OPTION(std::string, compiler_temp_dir, (std::filesystem::temp_directory_path().string().c_str()))
 OPTION(bool, skip_spirv_capability_check, false)
 OPTION(bool, keep_temporaries, false)
 OPTION(std::string, spirv_arch, "spir")

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
 #include <string>
 
 enum class config_option_type


### PR DESCRIPTION
default invalid always require apps to customize which a valid temp does not. 