### PR TITLE
refactor device_properties to use config.def as the reference

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -588,7 +588,7 @@ cl_int CLVK_API_CALL clGetDeviceInfo(cl_device_id dev,
         size_ret = sizeof(val_sizet);
         break;
     case CL_DEVICE_MAX_COMPUTE_UNITS:
-        val_uint = device->num_compute_units();
+        val_uint = device->max_compute_units();
         copy_ptr = &val_uint;
         size_ret = sizeof(val_uint);
         break;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -28,26 +28,142 @@ const config_struct config;
 
 namespace {
 
-template <typename T> constexpr config_option_type option_type() = delete;
-
-#define DEFINE_OPTION_TYPE_GETTER(ctype, type)                                 \
-    template <> constexpr config_option_type option_type<ctype>() {            \
-        return type;                                                           \
-    }
-
-DEFINE_OPTION_TYPE_GETTER(std::string, config_option_type::string)
-DEFINE_OPTION_TYPE_GETTER(uint32_t, config_option_type::uint32)
-DEFINE_OPTION_TYPE_GETTER(bool, config_option_type::boolean)
-
 std::vector<config_option> gConfigOptions = {
 #define OPTION(type, name, valdef)                                             \
-    {option_type<type>(), #name, &config.name, false},
+    {option_type<type>(), #name, &config.name, false, false},
 #define EARLY_OPTION(type, name, valdef)                                       \
-    {option_type<type>(), #name, &config.name, true},
+    {option_type<type>(), #name, &config.name, true, false},
+#define PROPERTY OPTION
 #include "config.def"
+#undef PROPERTY
 #undef EARLY_OPTION
 #undef OPTION
 };
+
+// Helper function to trim whitespace.
+std::string trim(const std::string& str) {
+    size_t first = str.find_first_not_of(" \t\n");
+    size_t last = str.find_last_not_of(" \t\n");
+
+    // Check for valid range
+    if (first == std::string::npos || last == std::string::npos) {
+        return str; // Empty or only whitespace
+    }
+
+    // Extract the trimmed string
+    std::string trimmed = str.substr(first, (last - first + 1));
+    return trimmed;
+}
+
+void parse_string_set(void* value_ptr, const char* txt) {
+    auto cfgval = static_cast<config_value<std::set<std::string>>*>(value_ptr);
+
+    size_t pos = 0;
+    std::string s(txt);
+    size_t comma = s.find(',', pos);
+    while (comma != std::string::npos) {
+        std::string s_substr = trim(s.substr(pos, comma - pos));
+        if (!s_substr.empty()) {
+            cfgval->value.insert(s_substr);
+        }
+        pos = comma + 1;
+        comma = s.find(',', pos);
+    }
+    std::string s_substr = trim(s.substr(pos));
+    if (!s_substr.empty()) {
+        cfgval->value.insert(s_substr);
+    }
+
+    cfgval->set = true;
+}
+
+#define CASE(X)                                                                \
+    if (s == std::string(#X)) {                                                \
+        val = X;                                                               \
+        return true;                                                           \
+    }
+bool channel_order_from_string(std::string s, cl_channel_order& val) {
+    CASE(CL_R)
+    CASE(CL_A)
+    CASE(CL_DEPTH)
+    CASE(CL_LUMINANCE)
+    CASE(CL_INTENSITY)
+    CASE(CL_RG)
+    CASE(CL_RA)
+    CASE(CL_Rx)
+    CASE(CL_RGB)
+    CASE(CL_RGx)
+    CASE(CL_RGBA)
+    CASE(CL_ARGB)
+    CASE(CL_BGRA)
+    CASE(CL_ABGR)
+    CASE(CL_RGBx)
+    CASE(CL_sRGB)
+    CASE(CL_sRGBA)
+    CASE(CL_sBGRA)
+    CASE(CL_sRGBx)
+    return false;
+}
+bool channel_type_from_string(std::string s, cl_channel_type& val) {
+    CASE(CL_SNORM_INT8)
+    CASE(CL_SNORM_INT16)
+    CASE(CL_UNORM_INT8)
+    CASE(CL_UNORM_INT16)
+    CASE(CL_UNORM_SHORT_565)
+    CASE(CL_UNORM_SHORT_555)
+    CASE(CL_UNORM_INT_101010)
+    CASE(CL_UNORM_INT_101010_2)
+    CASE(CL_SIGNED_INT8)
+    CASE(CL_SIGNED_INT16)
+    CASE(CL_SIGNED_INT32)
+    CASE(CL_UNSIGNED_INT8)
+    CASE(CL_UNSIGNED_INT16)
+    CASE(CL_UNSIGNED_INT32)
+    CASE(CL_HALF_FLOAT)
+    CASE(CL_FLOAT)
+    return false;
+}
+#undef CASE
+
+void parse_image_format_set(void* value_ptr, const char* txt) {
+    auto cfgval = static_cast<config_value<image_format_set>*>(value_ptr);
+
+    std::string s(txt);
+    size_t bracket = s.find('{', 0);
+    while (bracket != std::string::npos) {
+        size_t comma = s.find(',', bracket);
+        if (comma == std::string::npos) {
+            cvk_warn_fn("Could not find expected ',' after '{' in '%s'",
+                        s.c_str());
+            return;
+        }
+        cl_image_format format;
+        auto order = trim(s.substr(bracket + 1, comma - bracket - 1));
+        if (!channel_order_from_string(order, format.image_channel_order)) {
+            cvk_warn_fn("Could not parse order '%s' from '%s'", order.c_str(),
+                        s.c_str());
+            return;
+        }
+        bracket = s.find('}', comma);
+        if (bracket == std::string::npos) {
+            cvk_warn_fn("Could not find expected '}' after ',' in '%s'",
+                        s.c_str());
+            return;
+        }
+        auto data_type = trim(s.substr(comma + 1, bracket - comma - 1));
+        if (!channel_type_from_string(data_type,
+                                      format.image_channel_data_type)) {
+            cvk_warn_fn("Could not parse data_type '%s' from '%s'",
+                        data_type.c_str(), s.c_str());
+            return;
+        }
+        cfgval->value.insert(format);
+
+        bracket = s.find("{", bracket);
+    }
+
+    cfgval->set = true;
+}
 
 void parse_string(void* value_ptr, const char* txt) {
     auto cfgval = static_cast<config_value<std::string>*>(value_ptr);
@@ -71,38 +187,52 @@ void parse_uint32(void* value_ptr, const char* txt) {
     cfgval->set = true;
 }
 
-#define TXT_SIZE FILENAME_MAX
-bool print_string(char* txt, void* value_ptr) {
-    auto cfgval = static_cast<config_value<std::string>*>(value_ptr);
-    snprintf(txt, TXT_SIZE, "'%s'", cfgval->value.c_str());
-    return cfgval->set;
-}
+static constexpr size_t txt_size = 4096;
+char gTxt[txt_size];
 
-bool print_boolean(char* txt, void* value_ptr) {
-    auto cfgval = static_cast<config_value<bool>*>(value_ptr);
-    snprintf(txt, TXT_SIZE, "%s", cfgval->value ? "true" : "false");
-    return cfgval->set;
-}
-
-bool print_uint32(char* txt, void* value_ptr) {
-    auto cfgval = static_cast<config_value<uint32_t>*>(value_ptr);
-    snprintf(txt, TXT_SIZE, "%u (0x%x)", cfgval->value, cfgval->value);
-    return cfgval->set;
-}
-
-// Helper function to trim whitespace.
-std::string trim(const std::string& str) {
-    size_t first = str.find_first_not_of(" \t\n");
-    size_t last = str.find_last_not_of(" \t\n");
-
-    // Check for valid range
-    if (first == std::string::npos || last == std::string::npos) {
-        return str; // Empty or only whitespace
+char* print_string_set(void* value_ptr) {
+    auto cfgval = static_cast<config_value<std::set<std::string>>*>(value_ptr);
+    size_t pos = 1;
+    gTxt[0] = '\'';
+    for (auto& s : cfgval->value) {
+        pos += snprintf(&gTxt[pos], txt_size - pos, "%s, ", s.c_str());
     }
+    gTxt[pos - 2] = '\'';
+    gTxt[pos - 1] = '\0';
+    return gTxt;
+}
 
-    // Extract the trimmed string
-    std::string trimmed = str.substr(first, (last - first + 1));
-    return trimmed;
+char* print_image_format_set(void* value_ptr) {
+    auto cfgval = static_cast<config_value<image_format_set>*>(value_ptr);
+    size_t pos = 1;
+    gTxt[0] = '\'';
+    for (auto& format : cfgval->value) {
+        pos += snprintf(
+            &gTxt[pos], txt_size - pos, "{%s, %s}, ",
+            cl_channel_order_to_string(format.image_channel_order).c_str(),
+            cl_channel_type_to_string(format.image_channel_data_type).c_str());
+    }
+    gTxt[pos - 2] = '\'';
+    gTxt[pos - 1] = '\0';
+    return gTxt;
+}
+
+char* print_string(void* value_ptr) {
+    auto cfgval = static_cast<config_value<std::string>*>(value_ptr);
+    snprintf(gTxt, txt_size, "'%s'", cfgval->value.c_str());
+    return gTxt;
+}
+
+char* print_boolean(void* value_ptr) {
+    auto cfgval = static_cast<config_value<bool>*>(value_ptr);
+    snprintf(gTxt, txt_size, "%s", cfgval->value ? "true" : "false");
+    return gTxt;
+}
+
+char* print_uint32(void* value_ptr) {
+    auto cfgval = static_cast<config_value<uint32_t>*>(value_ptr);
+    snprintf(gTxt, txt_size, "%u (0x%x)", cfgval->value, cfgval->value);
+    return gTxt;
 }
 
 std::string get_clvk_env_name(const std::string& name) {
@@ -142,6 +272,27 @@ void read_config_file(std::unordered_map<std::string, std::string>& umap,
         }
     }
     config_stream.close();
+}
+
+void parse_option(void* val, config_option& opt, const char* txt) {
+    switch (opt.type) {
+    case config_option_type::string:
+        parse_string(val, txt);
+        break;
+    case config_option_type::boolean:
+        parse_boolean(val, txt);
+        break;
+    case config_option_type::uint32:
+        parse_uint32(val, txt);
+        break;
+    case config_option_type::string_set:
+        parse_string_set(val, txt);
+        break;
+    case config_option_type::image_format_set:
+        parse_image_format_set(val, txt);
+        break;
+    }
+    opt.set = true;
 }
 
 void parse_config_file(bool early_option) {
@@ -189,17 +340,7 @@ void parse_config_file(bool early_option) {
         CVK_ASSERT(file_config_values[opt.name].length() > 0);
         auto curr_conf = (file_config_values[opt.name]).c_str();
         void* optval = const_cast<void*>(opt.value);
-        switch (opt.type) {
-        case config_option_type::string:
-            parse_string(optval, curr_conf);
-            break;
-        case config_option_type::boolean:
-            parse_boolean(optval, curr_conf);
-            break;
-        case config_option_type::uint32:
-            parse_uint32(optval, curr_conf);
-            break;
-        }
+        parse_option(optval, opt, curr_conf);
     }
     return;
 }
@@ -216,42 +357,22 @@ void parse_env(bool early_option) {
         }
         cvk_debug_group_fn(loggroup::cfg, "'%s' = '%s'", var_name.c_str(), txt);
         void* optval = const_cast<void*>(opt.value);
-        switch (opt.type) {
-        case config_option_type::string:
-            parse_string(optval, txt);
-            break;
-        case config_option_type::boolean:
-            parse_boolean(optval, txt);
-            break;
-        case config_option_type::uint32:
-            parse_uint32(optval, txt);
-            break;
-        }
+        parse_option(optval, opt, txt);
     }
 }
 
 void print_config() {
     cvk_info_group_fn(loggroup::cfg, "");
-    std::sort(gConfigOptions.begin(), gConfigOptions.end(),
-              [](const config_option& a, const config_option& b) {
-                  return a.name < b.name;
-              });
-    for (auto& opt : gConfigOptions) {
-        char txt[TXT_SIZE];
+    std::vector<config_option> options(gConfigOptions.size());
+    std::partial_sort_copy(gConfigOptions.begin(), gConfigOptions.end(),
+                           options.begin(), options.end(),
+                           [](const config_option& a, const config_option& b) {
+                               return a.name < b.name;
+                           });
+    for (const auto& opt : options) {
         void* optval = const_cast<void*>(opt.value);
-        int set;
-        switch (opt.type) {
-        case config_option_type::string:
-            set = print_string(txt, optval);
-            break;
-        case config_option_type::boolean:
-            set = print_boolean(txt, optval);
-            break;
-        case config_option_type::uint32:
-            set = print_uint32(txt, optval);
-            break;
-        }
-        if (set) {
+        char* txt = print_option(opt.type, optval);
+        if (opt.set) {
             cvk_info_group(loggroup::cfg, "  *%s: %s", opt.name.c_str(), txt);
         } else {
             cvk_debug_group(loggroup::cfg, "  %s: %s", opt.name.c_str(), txt);
@@ -260,6 +381,35 @@ void print_config() {
 }
 
 } // namespace
+
+bool operator==(const image_format_set& a, const image_format_set& b) {
+    for (auto& elema : a) {
+        if (b.count(elema) == 0) {
+            return false;
+        }
+    }
+    for (auto& elemb : b) {
+        if (a.count(elemb) == 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+char* print_option(config_option_type type, void* val) {
+    switch (type) {
+    case config_option_type::string:
+        return print_string(val);
+    case config_option_type::boolean:
+        return print_boolean(val);
+    case config_option_type::uint32:
+        return print_uint32(val);
+    case config_option_type::string_set:
+        return print_string_set(val);
+    case config_option_type::image_format_set:
+        return print_image_format_set(val);
+    }
+}
 
 void init_config() {
     parse_config_file(false);

--- a/src/config.def
+++ b/src/config.def
@@ -22,8 +22,8 @@ OPTION(bool, keep_temporaries, false)
 OPTION(std::string, spirv_arch, "spir")
 OPTION(bool, physical_addressing, false)
 
-OPTION(std::string, clspv_native_builtins, "")
-OPTION(std::string, clspv_library_builtins, "")
+PROPERTY(std::set<std::string>, clspv_native_builtins, std::set<std::string>())
+OPTION(std::set<std::string>, clspv_library_builtins, std::set<std::string>())
 
 OPTION(uint32_t, printf_buffer_size, 1024*1024u)
 
@@ -34,7 +34,7 @@ OPTION(bool, build_in_separate_thread, false)
 OPTION(bool, init_image_at_creation, false)
 
 #if COMPILER_AVAILABLE
-OPTION(std::string, clspv_options, "")
+PROPERTY(std::string, clspv_options, "")
 #if !CLSPV_ONLINE_COMPILER
 OPTION(std::string, clspv_path, DEFAULT_CLSPV_BINARY_PATH)
 #if ENABLE_SPIRV_IL
@@ -43,19 +43,28 @@ OPTION(std::string, llvmspirv_bin, DEFAULT_LLVMSPIRV_BINARY_PATH)
 #endif // !CLSPV_ONLINE_COMPILER
 #endif // COMPILER_AVAILABLE
 
+//
+// Device properties
+//
+PROPERTY(std::string, vendor, "Unknown vendor")
 OPTION(uint32_t, force_subgroup_size, 0u) // 0 meaning not forced
-OPTION(uint32_t, preferred_subgroup_size, 0u) // 0 meaning no preference
+PROPERTY(uint32_t, preferred_subgroup_size, 0u) // 0 meaning no preference
 
-OPTION(uint32_t, max_compute_units, 1u)
+PROPERTY(uint32_t, max_compute_units, 1u)
+PROPERTY(uint32_t, global_mem_cache_size, 0u)
+PROPERTY(bool, non_uniform_decoration_broken, false)
+PROPERTY(bool, bgra_format_not_supported_for_image1d_buffer, false)
+PROPERTY(image_format_set, disabled_image_formats, image_format_set())
+PROPERTY(image_format_set, enabled_image_formats, image_format_set())
 
 //
 // Command execution
 //
 OPTION(uint32_t, queue_global_priority, 1u)
-OPTION(uint32_t, max_cmd_batch_size, 10000u)
-OPTION(uint32_t, max_first_cmd_batch_size, 10000u)
-OPTION(uint32_t, max_cmd_group_size, UINT32_MAX)
-OPTION(uint32_t, max_first_cmd_group_size, UINT32_MAX)
+PROPERTY(uint32_t, max_cmd_batch_size, 10000u)
+PROPERTY(uint32_t, max_first_cmd_batch_size, 10000u)
+PROPERTY(uint32_t, max_cmd_group_size, UINT32_MAX)
+PROPERTY(uint32_t, max_first_cmd_group_size, UINT32_MAX)
 OPTION(bool, ignore_out_of_order_execution, false) // false meaning dont ignore
 
 // experimental
@@ -66,10 +75,10 @@ OPTION(uint32_t, enqueue_command_retry_sleep_us, UINT32_MAX) // UINT32_MAX meani
 
 OPTION(bool, supports_filter_linear, true)
 
-OPTION(bool, keep_memory_allocations_mapped, false)
+PROPERTY(bool, keep_memory_allocations_mapped, false)
 
-OPTION(std::string, device_extensions, "")
-OPTION(std::string, device_extensions_masked, "")
+OPTION(std::set<std::string>, device_extensions, std::set<std::string>())
+OPTION(std::set<std::string>, device_extensions_masked, std::set<std::string>())
 
 //
 // Logging

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -15,19 +15,24 @@
 #pragma once
 
 #include "cl_headers.hpp"
+#include "image_format.hpp"
 
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
+#include <set>
 #include <string>
+#include <unordered_set>
 
 enum class config_option_type
 {
     string,
     uint32,
     boolean,
+    string_set,
+    image_format_set,
 };
 
 struct config_option {
@@ -35,12 +40,20 @@ struct config_option {
     std::string name;
     const void* value;
     bool early_option;
+    bool set;
 };
+
+using image_format_set =
+    std::unordered_set<cl_image_format, ClFormatHash, ClFormatEqual>;
+bool operator==(const image_format_set& a, const image_format_set& b);
 
 template <typename T> struct config_value {
     explicit config_value(const char* val) : value(val) {}
     explicit config_value(uint32_t val) : value(val) {}
     explicit config_value(bool val) : value(val) {}
+    explicit config_value(std::string val) : value(val) {}
+    explicit config_value(std::set<std::string> val) : value(val) {}
+    explicit config_value(image_format_set val) : value(val) {}
     bool set;
     T value;
     operator T() const { return value; }
@@ -51,7 +64,9 @@ template <typename T> struct config_value {
 struct config_struct {
 #define OPTION(type, name, valdef) const config_value<type> name{valdef};
 #define EARLY_OPTION OPTION
+#define PROPERTY OPTION
 #include "config.def"
+#undef PROPERTY
 #undef EARLY_OPTION
 #undef OPTION
 };
@@ -61,3 +76,19 @@ extern const config_struct config;
 extern void init_config();
 
 extern void init_early_config();
+
+template <typename T> constexpr config_option_type option_type() = delete;
+
+#define DEFINE_OPTION_TYPE_GETTER(ctype, type)                                 \
+    template <> constexpr config_option_type option_type<ctype>() {            \
+        return type;                                                           \
+    }
+
+DEFINE_OPTION_TYPE_GETTER(std::string, config_option_type::string)
+DEFINE_OPTION_TYPE_GETTER(uint32_t, config_option_type::uint32)
+DEFINE_OPTION_TYPE_GETTER(bool, config_option_type::boolean)
+DEFINE_OPTION_TYPE_GETTER(std::set<std::string>, config_option_type::string_set)
+DEFINE_OPTION_TYPE_GETTER(image_format_set,
+                          config_option_type::image_format_set)
+
+char* print_option(config_option_type type, void* val);

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -121,37 +121,6 @@ void cvk_device::init_clvk_runtime_behaviors() {
     m_clvk_properties = create_cvk_device_properties(
         m_properties.deviceName, m_properties.vendorID, m_properties.deviceID,
         m_properties.driverVersion, m_driver_properties.driverID);
-#define SET_DEVICE_PROPERTY(option, print)                                     \
-    do {                                                                       \
-        if (config.option.set) {                                               \
-            m_##option = config.option;                                        \
-        } else {                                                               \
-            m_##option = m_clvk_properties->get_##option();                    \
-        }                                                                      \
-        print(option);                                                         \
-    } while (0)
-
-#define PRINT_U(option) cvk_info_fn(#option ": %u", m_##option);
-#define SET_DEVICE_PROPERTY_U(option) SET_DEVICE_PROPERTY(option, PRINT_U)
-
-#define PRINT_S(option) cvk_info_fn(#option ": %s", m_##option.c_str());
-#define SET_DEVICE_PROPERTY_S(option) SET_DEVICE_PROPERTY(option, PRINT_S)
-
-    SET_DEVICE_PROPERTY_U(max_cmd_batch_size);
-    SET_DEVICE_PROPERTY_U(max_first_cmd_batch_size);
-    SET_DEVICE_PROPERTY_U(max_cmd_group_size);
-    SET_DEVICE_PROPERTY_U(max_first_cmd_group_size);
-
-    SET_DEVICE_PROPERTY_U(physical_addressing);
-    SET_DEVICE_PROPERTY_S(spirv_arch);
-
-    SET_DEVICE_PROPERTY_U(preferred_subgroup_size);
-
-#undef PRINT_U
-#undef PRINT_S
-#undef SET_DEVICE_PROPERTY_U
-#undef SET_DEVICE_PROPERTY_S
-#undef SET_DEVICE_PROPERTY
 }
 
 void cvk_device::init_driver_behaviors() {
@@ -537,13 +506,14 @@ void cvk_device::init_compiler_options() {
         m_device_compiler_options += " -decorate-nonuniform ";
     }
 
+#if COMPILER_AVAILABLE
     // Device specific options
-    m_device_compiler_options +=
-        " " + m_clvk_properties->get_compile_options() + " ";
+    m_device_compiler_options += " " + m_clvk_properties->clspv_options() + " ";
+#endif
 
-    m_device_compiler_options += " -arch=" + m_spirv_arch + " ";
+    m_device_compiler_options += " -arch=" + config.spirv_arch() + " ";
 
-    if (m_physical_addressing) {
+    if (config.physical_addressing()) {
         m_device_compiler_options += " -physical-storage-buffers ";
     }
 
@@ -552,24 +522,8 @@ void cvk_device::init_compiler_options() {
     }
 
     // Builtin options
-    auto parse_builtins = [](std::string s) {
-        std::set<std::string> builtins;
-        size_t pos = 0;
-        size_t comma = s.find(',', pos);
-        while (comma != std::string::npos) {
-            builtins.insert(s.substr(pos, comma - pos));
-            pos = comma + 1;
-            comma = s.find(',', pos);
-        }
-        builtins.insert(s.substr(pos));
-        return builtins;
-    };
-    auto clspv_library_builtins =
-        parse_builtins(config.clspv_library_builtins());
-    auto native_builtins = m_clvk_properties->get_native_builtins();
-    auto clspv_native_builtins = parse_builtins(config.clspv_native_builtins());
-    native_builtins.insert(clspv_native_builtins.begin(),
-                           clspv_native_builtins.end());
+    auto clspv_library_builtins = config.clspv_library_builtins();
+    auto native_builtins = m_clvk_properties->clspv_native_builtins();
 
     std::string builtin_list = "";
     for (const auto& builtin : native_builtins) {
@@ -729,19 +683,7 @@ void cvk_device::build_extension_ils_list() {
             1, 0, 0, "cl_arm_integer_dot_product_accumulate_int16"));
     }
 
-    auto split_string = [](std::string input, char delimiter) {
-        std::vector<std::string> outputs;
-        size_t pos = 0;
-        while ((pos = input.find(delimiter)) != std::string::npos) {
-            outputs.push_back(input.substr(0, pos));
-            input.erase(0, pos + 1);
-        }
-        if (input.size() > 0) {
-            outputs.push_back(input);
-        }
-        return outputs;
-    };
-    auto config_extensions = split_string(config.device_extensions(), ',');
+    auto config_extensions = config.device_extensions();
     for (auto& config_extension : config_extensions) {
         cl_name_version extension;
         extension.version = CL_MAKE_VERSION(0, 0, 0);
@@ -751,8 +693,7 @@ void cvk_device::build_extension_ils_list() {
         m_extensions.push_back(extension);
     }
 
-    auto config_extensions_masked =
-        split_string(config.device_extensions_masked(), ',');
+    auto config_extensions_masked = config.device_extensions_masked();
     for (auto& config_extension_masked : config_extensions_masked) {
         for (auto it = m_extensions.begin(); it != m_extensions.end(); it++) {
             if (strcmp(config_extension_masked.c_str(),

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -25,6 +25,7 @@
 #include <vulkan/vulkan.h>
 
 #include "cl_headers.hpp"
+#include "config.hpp"
 #include "device_properties.hpp"
 #include "icd.hpp"
 #include "objects.hpp"
@@ -294,11 +295,11 @@ struct cvk_device : public _cl_device_id,
     }
 
     cl_ulong global_mem_cache_size() const {
-        return m_clvk_properties->get_global_mem_cache_size();
+        return m_clvk_properties->global_mem_cache_size();
     }
 
-    cl_uint num_compute_units() const {
-        return m_clvk_properties->get_num_compute_units();
+    cl_uint max_compute_units() const {
+        return m_clvk_properties->max_compute_units();
     }
 
     cl_uint max_samplers() const {
@@ -328,6 +329,8 @@ struct cvk_device : public _cl_device_id,
                             config.force_subgroup_size(), min_sub_group_size(),
                             max_sub_group_size());
             }
+            auto m_preferred_subgroup_size =
+                m_clvk_properties->preferred_subgroup_size();
             if (m_preferred_subgroup_size != 0 &&
                 m_preferred_subgroup_size >= min_sub_group_size() &&
                 m_preferred_subgroup_size <= max_sub_group_size()) {
@@ -461,7 +464,7 @@ struct cvk_device : public _cl_device_id,
         return (m_properties.apiVersion >= VK_MAKE_VERSION(1, 2, 0) ||
                 is_vulkan_extension_enabled(
                     VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)) &&
-               !m_clvk_properties->is_non_uniform_decoration_broken();
+               !m_clvk_properties->non_uniform_decoration_broken();
     }
 
     bool supports_atomic_order_acq_rel() const {
@@ -682,17 +685,25 @@ struct cvk_device : public _cl_device_id,
         };
     }
 
-    cl_uint get_max_cmd_batch_size() const { return m_max_cmd_batch_size; }
-    cl_uint get_max_first_cmd_batch_size() const {
-        return m_max_first_cmd_batch_size;
+    cl_uint get_max_cmd_batch_size() const {
+        return m_clvk_properties->max_cmd_batch_size();
     }
-    cl_uint get_max_cmd_group_size() const { return m_max_cmd_group_size; }
+    cl_uint get_max_first_cmd_batch_size() const {
+        return m_clvk_properties->max_first_cmd_batch_size();
+    }
+    cl_uint get_max_cmd_group_size() const {
+        return m_clvk_properties->max_cmd_group_size();
+    }
     cl_uint get_max_first_cmd_group_size() const {
-        return m_max_first_cmd_group_size;
+        return m_clvk_properties->max_first_cmd_group_size();
     }
 
-    cl_uint address_bits() const { return m_spirv_arch == "spir64" ? 64 : 32; }
-    bool uses_physical_addressing() const { return m_physical_addressing; }
+    cl_uint address_bits() const {
+        return config.spirv_arch() == "spir64" ? 64 : 32;
+    }
+    bool uses_physical_addressing() const {
+        return config.physical_addressing();
+    }
 
     const std::string& get_device_specific_compile_options() const {
         return m_device_compiler_options;
@@ -702,12 +713,12 @@ struct cvk_device : public _cl_device_id,
 
     bool is_bgra_format_not_supported_for_image1d_buffer() const {
         return m_clvk_properties
-            ->is_bgra_format_not_supported_for_image1d_buffer();
+            ->bgra_format_not_supported_for_image1d_buffer();
     }
 
     bool is_image_format_disabled(cl_image_format format) const {
-        return m_clvk_properties->get_disabled_image_formats().count(format) !=
-               0;
+        return m_clvk_properties->disabled_image_formats().count(format) != 0 &&
+               config.enabled_image_formats().count(format) == 0;
     }
 
     bool keep_memory_allocations_mapped() const {
@@ -820,16 +831,6 @@ private:
     bool m_has_int8_support{};
     bool m_has_subgroups_support{};
     bool m_has_subgroup_size_selection{};
-
-    cl_uint m_max_cmd_batch_size;
-    cl_uint m_max_first_cmd_batch_size;
-    cl_uint m_max_cmd_group_size;
-    cl_uint m_max_first_cmd_group_size;
-
-    std::string m_spirv_arch;
-    bool m_physical_addressing;
-
-    cl_uint m_preferred_subgroup_size{};
 
     CHECK_RETURN cl_int update_device_host_timer_no_lock();
     std::mutex m_sync_mutex;


### PR DESCRIPTION
- remove sections in device.{cpp,hpp} that were hard to maintain
- improve printing of relevant device_propeties
- support more data type in config.def for better parsing/printing
