### PR TITLE
fix test_api negative_invalid_arg_mem_obj with physical_addressing

### DIFF
--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -280,6 +280,8 @@ struct cvk_kernel_argument_values {
                 auto mem_downcast = icd_downcast(mem);
                 if (!mem_downcast->is_valid()) {
                     return CL_INVALID_MEM_OBJECT;
+                } else if (size != sizeof(cl_mem)) {
+                    return CL_INVALID_ARG_SIZE;
                 }
                 auto buff = reinterpret_cast<const cvk_buffer*>(mem_downcast);
                 auto dev_addr = buff->device_address();


### PR DESCRIPTION
When physical addressing is enabled, `cl_mem` kernel arguments are lowered to pod arguments.
This adds the missing check to ensure that the provided size matches `sizeof(cl_mem)`, correctly returning `CL_INVALID_ARG_SIZE` otherwise.