### PR TITLE
Move clspv_options PROPERTY out of COMPILER_AVAILABLE flag

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -377,7 +377,8 @@ void print_config() {
                            });
     for (const auto& opt : options) {
         void* optval = const_cast<void*>(opt.value);
-        char* txt = print_option(opt.type, optval);
+        std::string print = print_option(opt.type, optval);
+        const char* txt = print.c_str();
         if (opt.set) {
             cvk_info_group(loggroup::cfg, "  *%s: %s", opt.name.c_str(), txt);
         } else {
@@ -402,7 +403,7 @@ bool operator==(const image_format_set& a, const image_format_set& b) {
     return true;
 }
 
-char* print_option(config_option_type type, void* val) {
+std::string print_option(config_option_type type, void* val) {
     switch (type) {
     case config_option_type::string:
         return print_string(val);

--- a/src/config.def
+++ b/src/config.def
@@ -47,11 +47,10 @@ OPTION(uint32_t, printf_buffer_size, 1024*1024u)
 // Indicate whether the non-uniform decoration is broken or unsupported.
 PROPERTY(bool, non_uniform_decoration_broken, false)
 
-#if COMPILER_AVAILABLE
-
 // Provide additional options to pass to clspv.
 PROPERTY(std::string, clspv_options, "")
 
+#if COMPILER_AVAILABLE
 #if !CLSPV_ONLINE_COMPILER
 
 // Provide a path to the clspv binary to use.

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -91,4 +91,4 @@ DEFINE_OPTION_TYPE_GETTER(std::set<std::string>, config_option_type::string_set)
 DEFINE_OPTION_TYPE_GETTER(image_format_set,
                           config_option_type::image_format_set)
 
-char* print_option(config_option_type type, void* val);
+std::string print_option(config_option_type type, void* val);

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -506,12 +506,9 @@ void cvk_device::init_compiler_options() {
         m_device_compiler_options += " -decorate-nonuniform ";
     }
 
-#if COMPILER_AVAILABLE
     // Device specific options
-    m_device_compiler_options += " " + m_clvk_properties->clspv_options() + " ";
-#endif
-
-    m_device_compiler_options += " -arch=" + config.spirv_arch() + " ";
+    m_device_compiler_options += " " + m_clvk_properties->clspv_options() +
+                                 " -arch=" + config.spirv_arch() + " ";
 
     if (config.physical_addressing()) {
         m_device_compiler_options += " -physical-storage-buffers ";

--- a/src/device_properties.cpp
+++ b/src/device_properties.cpp
@@ -112,12 +112,10 @@ struct cvk_device_properties_intel : public cvk_device_properties_virtual {
             "rsqrt",       "signbit",   "sqrt",        "trunc",
         });
     }
-#if COMPILER_AVAILABLE
     std::string clspv_options() const override final {
         return "-hack-mul-extended -hack-convert-to-float "
                "-hack-image1d-buffer-bgra";
     }
-#endif
     uint32_t preferred_subgroup_size() const override final { return 16; }
     bool bgra_format_not_supported_for_image1d_buffer() const override final {
         return true;
@@ -154,11 +152,9 @@ struct cvk_device_properties_amd : public cvk_device_properties_virtual {
             "trunc",
         });
     }
-#if COMPILER_AVAILABLE
     std::string clspv_options() const override final {
         return "-hack-convert-to-float";
     }
-#endif
 };
 
 static bool isAMDDevice(const char* name, const uint32_t vendorID) {
@@ -226,11 +222,9 @@ struct cvk_device_properties_llvmpipe : public cvk_device_properties_virtual {
             "half_sin", "half_sqrt",   "half_tan",
         });
     }
-#if COMPILER_AVAILABLE
     std::string clspv_options() const override final {
         return "-hack-convert-to-float";
     }
-#endif
 };
 
 static bool isllvmpipeDevice(const uint32_t vendorID) {

--- a/src/device_properties.hpp
+++ b/src/device_properties.hpp
@@ -67,19 +67,33 @@ struct cvk_device_properties {
         std::unique_ptr<cvk_device_properties_virtual> properties) {
         cvk_info_group_fn(loggroup::cfg, "");
 #define PROPERTY(type, name, valdef)                                           \
-    if (config.name.set) {                                                     \
-        m_##name = cvk_device_properties_virtual::init(config.name(),          \
-                                                       properties->name());    \
-    } else {                                                                   \
-        m_##name = properties->name();                                         \
-    };                                                                         \
     {                                                                          \
+        const config_value<type> prop(properties->name());                     \
+        const config_value<type>& cfg = config.name;                           \
+        const config_option_type ty = option_type<type>();                     \
+        bool prop_overwritten = false;                                         \
+        m_##name = prop.value;                                                 \
+        if (cfg.set) {                                                         \
+            bool type_overwrites = ty == config_option_type::string ||         \
+                                   ty == config_option_type::uint32 ||         \
+                                   ty == config_option_type::boolean;          \
+            prop_overwritten = cfg.value != prop.value && type_overwrites;     \
+            m_##name =                                                         \
+                cvk_device_properties_virtual::init(cfg.value, prop.value);    \
+        }                                                                      \
         config_value<type> val(m_##name);                                      \
-        char* txt = print_option(option_type<type>(), &val);                   \
-        if (m_##name != config.name()) {                                       \
-            cvk_info_group(loggroup::cfg, "  *" #name ": %s", txt);            \
+        std::string opt = print_option(ty, &val);                              \
+        if (val.value != cfg.value) {                                          \
+            cvk_info_group(loggroup::cfg, "  *" #name ": %s", opt.c_str());    \
+        } else if (prop_overwritten) {                                         \
+            std::string prop_str = print_option(ty, (void*)&prop);             \
+            cvk_warn_group(                                                    \
+                loggroup::cfg,                                                 \
+                "  " #name                                                     \
+                ": device property (%s) overwritten by config (%s)",           \
+                prop_str.c_str(), opt.c_str());                                \
         } else {                                                               \
-            cvk_debug_group(loggroup::cfg, "  " #name ": %s", txt);            \
+            cvk_debug_group(loggroup::cfg, "  " #name ": %s", opt.c_str());    \
         }                                                                      \
     }
 #include "config.def"

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -977,10 +977,6 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
     options += " -enable-printf ";
     options += " -printf-buffer-size=" + std::to_string(buff_size) + " ";
 
-#if COMPILER_AVAILABLE
-    options += " " + config.clspv_options() + " ";
-#endif
-
     if (options_allow_split_region(options)) {
         options += "-cl-arm-non-uniform-work-group-size";
     }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -869,9 +869,7 @@ public:
 
     bool can_split_region() {
         int status = options_allow_split_region(m_build_options);
-#if COMPILER_AVAILABLE
         status &= options_allow_split_region(config.clspv_options);
-#endif
         return status;
     }
 


### PR DESCRIPTION
As other flags regarding clspv options like
non_uniform_decoration_broken, we can keep them defined even if the
compiler is not available.

It cleans device_properties a bit by removing the preprocessor macros.
I think config PROPERTY should be always defined to avoid having to
deal with macro in device_properties.

Also it makes me realize that since we refactor the config management,
we were adding the clspv_options twice without good reason, thus I
removed once instance of it to avoid duplicate options.

This patch also adds a warning message when a device property is
explicitly overwritten by a configuration value.

The warning is restricted to string, uint32, and boolean types because
these types perform a direct replacement. Other types are excluded from
this warning as they merge the configuration with the device property
rather than overwritting it entirely.

Additionally, `print_option()` now returns a `std::string` instead of a
`char*`. This refactor simplifies string management and improves memory
safety across the configuration logging logic.