### PR TITLE
Fix clvk printf element size mismatch for vectors

### DIFF
--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -246,11 +246,10 @@ void process_printf(char*& data, const printf_descriptor_map_t& descs,
             }
             auto* data_start = data;
             for (int i = 0; i < vec_len - 1; i++) {
-                printf_out << print_part(part_fmt, data, size / vec_len) << ",";
+                printf_out << print_part(part_fmt, data, el_size) << ",";
                 data += el_size;
             }
-            printf_out << print_part(part_fmt, data, size / vec_len)
-                       << remaining_str;
+            printf_out << print_part(part_fmt, data, el_size) << remaining_str;
             data = data_start + size;
         }
 


### PR DESCRIPTION
When processing printf arguments, clvk was using the element size derived from the format string (el_size) to advance the data pointer, but was using size/vec_len (derived from clspv compiler metadata) to determine what type to read in print_part.

For vectors smaller than 4 bytes (e.g. uchar2, which is 2 bytes), clspv pads the argument to 4 bytes in the buffer. This results in size=4 in metadata.
For uchar2, vec_len=2, so size/vec_len is 2.
But the format string %#v2hhx has hh modifier, so el_size is 1.

This mismatch caused clvk to read 2 bytes (uint16_t) for each element, but advance the pointer by only 1 byte. On the second element, this led to a misaligned read (offset 1) which can triggered a compiler-inserted alignment check trap (SIGILL) in print_part.

Fixed by passing el_size (which is the actual element size we want to read based on format string, or fallback to size/vec_len if format has no modifier) to print_part instead of size/vec_len.