### PR TITLE
Support denormal modes based on device capabilities

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -24,6 +24,7 @@
 #include "kernel.hpp"
 #include "log.hpp"
 #include "memory.hpp"
+#include "utils.hpp"
 
 constexpr VkMemoryPropertyFlags cvk_device::buffer_supported_memory_types[];
 constexpr VkMemoryPropertyFlags cvk_device::image_supported_memory_types[];
@@ -477,14 +478,8 @@ void cvk_device::init_compiler_options() {
         roundingModeRTE.push_back("64");
     }
     if (roundingModeRTE.size() > 0) {
-        m_device_compiler_options += " -rounding-mode-rte=";
-        for (unsigned i = 0; i < roundingModeRTE.size(); i++) {
-            if (i != 0) {
-                m_device_compiler_options += ",";
-            }
-            m_device_compiler_options += roundingModeRTE[i];
-        }
-        m_device_compiler_options += " ";
+        m_device_compiler_options +=
+            " -rounding-mode-rte=" + join(',', roundingModeRTE) + " ";
     }
 
     // Types support
@@ -1210,6 +1205,14 @@ bool cvk_device::supports_capability(spv::Capability capability) const {
         return m_float_controls_properties.shaderRoundingModeRTEFloat32 ||
                m_float_controls_properties.shaderRoundingModeRTEFloat16 ||
                m_float_controls_properties.shaderRoundingModeRTEFloat64;
+    case spv::CapabilityDenormPreserve:
+        return m_float_controls_properties.shaderDenormPreserveFloat32 ||
+               m_float_controls_properties.shaderDenormPreserveFloat16 ||
+               m_float_controls_properties.shaderDenormPreserveFloat64;
+    case spv::CapabilityDenormFlushToZero:
+        return m_float_controls_properties.shaderDenormFlushToZeroFloat32 ||
+               m_float_controls_properties.shaderDenormFlushToZeroFloat16 ||
+               m_float_controls_properties.shaderDenormFlushToZeroFloat64;
     case spv::CapabilityDotProduct:
     case spv::CapabilityDotProductInput4x8BitPacked:
         return supports_dot_product();

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -563,17 +563,27 @@ struct cvk_device : public _cl_device_id,
     }
 
     cl_device_fp_config fp_config(cl_device_info fptype) const {
+        cl_device_fp_config config =
+            CL_FP_ROUND_TO_NEAREST | CL_FP_INF_NAN | CL_FP_FMA;
         if ((fptype == CL_DEVICE_HALF_FP_CONFIG) && supports_fp16()) {
-            return CL_FP_ROUND_TO_NEAREST | CL_FP_INF_NAN | CL_FP_FMA;
+            if (supports_denorm_preserve_16()) {
+                config |= CL_FP_DENORM;
+            }
+            return config;
         }
         if (fptype == CL_DEVICE_SINGLE_FP_CONFIG) {
-            return CL_FP_ROUND_TO_NEAREST | CL_FP_INF_NAN | CL_FP_FMA;
+            if (supports_denorm_preserve_32()) {
+                config |= CL_FP_DENORM;
+            }
+            return config;
         }
 
         if ((fptype == CL_DEVICE_DOUBLE_FP_CONFIG) && supports_fp64()) {
-            return CL_FP_ROUND_TO_NEAREST | CL_FP_ROUND_TO_ZERO |
-                   CL_FP_ROUND_TO_INF | CL_FP_INF_NAN | CL_FP_FMA |
-                   CL_FP_DENORM;
+            config |= CL_FP_ROUND_TO_ZERO | CL_FP_ROUND_TO_INF;
+            if (supports_denorm_preserve_64()) {
+                config |= CL_FP_DENORM;
+            }
+            return config;
         }
 
         return 0;
@@ -703,6 +713,25 @@ struct cvk_device : public _cl_device_id,
     }
     bool uses_physical_addressing() const {
         return config.physical_addressing();
+    }
+
+    bool supports_denorm_preserve_16() const {
+        return m_float_controls_properties.shaderDenormPreserveFloat16;
+    }
+    bool supports_denorm_preserve_32() const {
+        return m_float_controls_properties.shaderDenormPreserveFloat32;
+    }
+    bool supports_denorm_preserve_64() const {
+        return m_float_controls_properties.shaderDenormPreserveFloat64;
+    }
+    bool supports_denorm_ftz_16() const {
+        return m_float_controls_properties.shaderDenormFlushToZeroFloat16;
+    }
+    bool supports_denorm_ftz_32() const {
+        return m_float_controls_properties.shaderDenormFlushToZeroFloat32;
+    }
+    bool supports_denorm_ftz_64() const {
+        return m_float_controls_properties.shaderDenormFlushToZeroFloat64;
     }
 
     const std::string& get_device_specific_compile_options() const {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -47,6 +47,7 @@
 #include "log.hpp"
 #include "program.hpp"
 #include "tracing.hpp"
+#include "utils.hpp"
 
 struct membuf : public std::streambuf {
     membuf(const unsigned char* begin, const unsigned char* end) {
@@ -927,6 +928,10 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
         options += " ";
         options += m_build_options;
     }
+    const bool denorms_are_zero =
+        options.find("-cl-denorms-are-zero") != std::string::npos ||
+        options.find("-cl-unsafe-math-optimizations") != std::string::npos ||
+        options.find("-cl-fast-relaxed-math") != std::string::npos;
     std::vector<std::pair<std::string, std::string>> option_substitutions = {
         // FIXME The 1.2 conformance tests shouldn't pass this option.
         //       It doesn't exist after OpenCL 1.0.
@@ -958,6 +963,41 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
 
     // The device sets up some compiler options based on its capabilities.
     options += " " + device->get_device_specific_compile_options() + " ";
+
+    // Denorm options
+    std::vector<std::string> denormPreserve;
+    std::vector<std::string> denormFlushToZero;
+    if (device->supports_fp16() && !denorms_are_zero &&
+        device->supports_denorm_preserve_16()) {
+        denormPreserve.push_back("16");
+    } else if (device->supports_fp16() && denorms_are_zero &&
+               device->supports_denorm_ftz_16()) {
+        denormFlushToZero.push_back("16");
+    }
+    if (!denorms_are_zero && device->supports_denorm_preserve_32()) {
+        denormPreserve.push_back("32");
+    } else if (denorms_are_zero && device->supports_denorm_ftz_32()) {
+        denormFlushToZero.push_back("32");
+    }
+    if (device->supports_fp64() && !denorms_are_zero &&
+        device->supports_denorm_preserve_64()) {
+        denormPreserve.push_back("64");
+    } else if (device->supports_fp64() && denorms_are_zero &&
+               device->supports_denorm_ftz_64()) {
+        denormFlushToZero.push_back("64");
+    }
+    // If those options are already specified, let the user choose its
+    // configuration
+    if ((options.find("-denorm-preserve=") == std::string::npos) &&
+        (options.find("-denorm-flush-to-zero=") == std::string::npos)) {
+        if (!denormPreserve.empty()) {
+            options += " -denorm-preserve=" + join(',', denormPreserve) + " ";
+        }
+        if (!denormFlushToZero.empty()) {
+            options +=
+                " -denorm-flush-to-zero=" + join(',', denormFlushToZero) + " ";
+        }
+    }
 
     // Features
     if (options.find("-cl-std=CL3.0") != std::string::npos) {

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <filesystem>
 #include <thread>
+#include <vector>
 
 #include <vulkan/vulkan.h>
 
@@ -88,4 +89,14 @@ static inline std::string append_paths(const std::string& prefix,
                                        const std::string& suffix) {
     return (std::filesystem::path{prefix} / std::filesystem::path{suffix})
         .string();
+}
+
+static inline std::string join(const char deliminator,
+                               const std::vector<std::string>& strings) {
+    std::string delim, joined_strings;
+    for (const auto& string : strings) {
+        joined_strings += delim + string;
+        delim = deliminator;
+    }
+    return joined_strings;
 }


### PR DESCRIPTION
Update device configuration and compiler option preparation to support preserving or flushing denormals based on Vulkan driver support.

- Update `cvk_device::fp_config` to report `CL_FP_DENORM` for a given precision only if the Vulkan driver supports preserving denormals for that width.
- Add `supports_denorm_preserve_*` and `supports_denorm_ftz_*` helpers to `cvk_device`.
- Update `cvk_device::supports_capability` to handle `spv::CapabilityDenormPreserve` and `spv::CapabilityDenormFlushToZero`.
- In `cvk_program::prepare_build_options` translate OpenCL options (`-cl-denorms-are-zero`, `-cl-unsafe-math-optimizations`, and `-cl-fast-relaxed-math`) and device capabilities into clspv options.