### PR TITLE
Fix lifetime issues and thread safety in resource management

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1049,6 +1049,7 @@ cvk_context* cvk_create_context(
 
     *errcode_ret = context->init();
     if (*errcode_ret != CL_SUCCESS) {
+        context->release();
         return nullptr;
     }
 

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -139,7 +139,7 @@ struct cvk_context : public _cl_context,
     void free_image_init_command_queue();
 
 private:
-    cvk_device* m_device;
+    refcounted_holder<cvk_device> m_device;
     std::mutex m_callbacks_lock;
     std::vector<cvk_context_callback> m_destuctor_callbacks;
     std::vector<cl_context_properties> m_properties;

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -48,6 +48,7 @@ struct cvk_platform;
 struct cvk_kernel;
 
 struct cvk_device : public _cl_device_id,
+                    public refcounted,
                     object_magic_header<object_magic::device> {
 
     cvk_device(cvk_platform* platform, VkPhysicalDevice pd)
@@ -867,7 +868,7 @@ struct cvk_platform : public _cl_platform_id,
     }
     ~cvk_platform() {
         for (auto dev : m_devices) {
-            delete dev;
+            dev->release();
         }
     }
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -617,6 +617,9 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
         for (auto& s : m_literal_samplers) {
             s->release();
         }
+        for (auto iprog : m_input_programs) {
+            iprog->release();
+        }
     }
 
     void append_source(const char* src, size_t len) {
@@ -916,7 +919,7 @@ private:
 
     uint32_t m_num_devices;
     cl_uint m_num_input_programs;
-    std::vector<const cvk_program*> m_input_programs;
+    std::vector<cvk_program*> m_input_programs;
     std::vector<const char*> m_header_include_names;
     build_operation m_operation;
     cl_program_binary_type m_binary_type;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -143,6 +143,7 @@ cl_int cvk_command_queue::enqueue_command_with_retry(cvk_command* cmd,
         return err;
     }
     if (m_nb_group_in_flight == 0) {
+        std::lock_guard<std::mutex> lock(m_lock);
         err = end_current_command_batch();
         if (err != CL_SUCCESS) {
             delete cmd;
@@ -193,6 +194,10 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
         err = m_command_batch->add_command(
             static_cast<cvk_command_batchable*>(cmd));
         if (err != CL_SUCCESS) {
+            if (m_command_batch->batch_size() == 0) {
+                delete m_command_batch;
+                m_command_batch = nullptr;
+            }
             return err;
         }
 

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -399,7 +399,12 @@ struct cvk_command {
         : m_type(type), m_queue(queue),
           m_event(new cvk_event_command(m_queue->context(), this, queue)) {}
 
-    virtual ~cvk_command() { m_event->release(); }
+    virtual ~cvk_command() {
+        m_event->release();
+        for (auto& ev : m_event_deps) {
+            ev->release();
+        }
+    }
 
     void set_dependencies(cl_uint num_event_deps,
                           _cl_event* const* event_deps) {
@@ -443,6 +448,7 @@ struct cvk_command {
             }
             ev->release();
         }
+        m_event_deps.clear();
 
         // Then execute the action if no dependencies failed
         if (status != CL_COMPLETE) {


### PR DESCRIPTION
- Make cvk_device refcounted and hold a reference to it in cvk_context using refcounted_holder. This ensures cvk_device is kept alive as long as cvk_context (and transitively, all api_objects associated with it) remains alive.
- Release input programs in cvk_program destructor to fix memory leaks. Changed m_input_programs to store non-const pointers to allow calling release().
- Lock end_current_command_batch and flush_no_lock calls in cvk_command_queue::enqueue_command_with_retry to prevent race conditions on queue state (m_groups and m_command_batch) when enqueuing commands.
- Release remaining event dependencies in cvk_command destructor to prevent leaks if commands are destroyed before they are executed. Clear m_event_deps in cvk_command::execute after they are released.
- Properly clean command batch when first call to add_command fails.
  It prevents having a batch (hold by a queue) keeping and handle on
  the queue while having no command. Leading to a leak that can lead
  to crashes on some platform.