### PR TITLE
fix cvk_program to avoid memory leak

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1238,9 +1238,9 @@ cl_build_status cvk_program::do_build_inner_offline(bool build_to_ir,
                     CL_PROGRAM_BINARY_TYPE_LIBRARY) {
                 return CL_BUILD_ERROR;
             }
-            std::string input_file = clspv_input_file + "_" +
-                                     std::to_string((uintptr_t)input_program) +
-                                     ".bc";
+            std::string input_file =
+                clspv_input_file + "_" +
+                std::to_string((uintptr_t)(cvk_program*)input_program) + ".bc";
             if (!save_il_to_file(input_file, input_program->m_ir)) {
                 cvk_error_fn("Couldn't save source to file!");
                 return CL_BUILD_ERROR;
@@ -1707,7 +1707,6 @@ cl_int cvk_program::build(build_operation operation, cl_uint num_devices,
     for (cl_uint i = 0; i < num_input_programs; i++) {
         cvk_program* iprog =
             const_cast<cvk_program*>(icd_downcast(input_programs[i]));
-        iprog->retain();
         m_input_programs.push_back(iprog);
         if (header_include_names != nullptr) {
             m_header_include_names.push_back(header_include_names[i]);

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -593,6 +593,9 @@ private:
     std::vector<cvk_descriptor_set_array> m_descriptor_sets_array;
 };
 
+struct cvk_program;
+using cvk_program_holder = refcounted_holder<cvk_program>;
+
 struct cvk_program : public _cl_program, api_object<object_magic::program> {
 
     cvk_program(cvk_context* ctx)
@@ -916,7 +919,7 @@ private:
 
     uint32_t m_num_devices;
     cl_uint m_num_input_programs;
-    std::vector<const cvk_program*> m_input_programs;
+    std::vector<cvk_program_holder> m_input_programs;
     std::vector<const char*> m_header_include_names;
     build_operation m_operation;
     cl_program_binary_type m_binary_type;
@@ -946,5 +949,3 @@ private:
 static inline cvk_program* icd_downcast(cl_program program) {
     return static_cast<cvk_program*>(program);
 }
-
-using cvk_program_holder = refcounted_holder<cvk_program>;


### PR DESCRIPTION
Without this fix the following command returns some leaks:
```
$ valgrind --leak-check=full -- test_compiler multiple_embedded_headers`

...

==685477== 9,670 (104 direct, 9,566 indirect) bytes in 1 blocks are definitely lost in loss record 2,598 of 2,607
==685477==    at 0x490FF93: operator new(unsigned long) (vg_replace_malloc.c:487)
==685477==    by 0x4E1A6A5: std::__new_allocator<std::__detail::_Hash_node_base*>::allocate(unsigned long, void const*) (lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bits/new_allocator.h:151)
==685477==    by 0x4E2444C: allocate (lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bits/alloc_traits.h:614)
==685477==    by 0x4E2444C: std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<cvk_device const* const, std::atomic<int> >, false> > >::_M_allocate_buckets(unsigned long) (lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bits/hashtable_policy.h:1605)
==685477==    by 0x4E243A1: std::_Hashtable<cvk_device const*, std::pair<cvk_device const* const, std::atomic<int> >, std::allocator<std::pair<cvk_device const* const, std::atomic<int> > >, std::__detail::_Select1st, std::equal_to<cvk_device const*>, std::hash<cvk_device const*>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_allocate_buckets(unsigned long) (lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bits/hashtable.h:413)
==685477==    by 0x4E24130: std::_Hashtable<cvk_device const*, std::pair<cvk_device const* const, std::atomic<int> >, std::allocator<std::pair<cvk_device const* const, std::atomic<int> > >, std::__detail::_Select1st, std::equal_to<cvk_device const*>, std::hash<cvk_device const*>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_rehash(unsigned long, std::integral_constant<bool, true>) (lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bits/hashtable.h:2754)
==685477==    by 0x4E2382A: std::_Hashtable<cvk_device const*, std::pair<cvk_device const* const, std::atomic<int> >, std::allocator<std::pair<cvk_device const* const, std::atomic<int> > >, std::__detail::_Select1st, std::equal_to<cvk_device const*>, std::hash<cvk_device const*>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_insert_unique_node(unsigned long, unsigned long, std::__detail::_Hash_node<std::pair<cvk_device const* const, std::atomic<int> >, false>*, unsigned long) (lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bits/hashtable.h:2479)
==685477==    by 0x4E235F2: std::__detail::_Map_base<cvk_device const*, std::pair<cvk_device const* const, std::atomic<int> >, std::allocator<std::pair<cvk_device const* const, std::atomic<int> > >, std::__detail::_Select1st, std::equal_to<cvk_device const*>, std::hash<cvk_device const*>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true>, true>::operator[](cvk_device const*&&) (lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bits/hashtable_policy.h:925)
==685477==    by 0x4E1E95C: std::unordered_map<cvk_device const*, std::atomic<int>, std::hash<cvk_device const*>, std::equal_to<cvk_device const*>, std::allocator<std::pair<cvk_device const* const, std::atomic<int> > > >::operator[](cvk_device const*&&) (lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bits/unordered_map.h:1062)
==685477==    by 0x4E0C1F8: cvk_program::cvk_program(cvk_context*) (src/program.hpp:603)
==685477==    by 0x4DCDEC2: clCreateProgramWithSource (src/api.cpp:2223)
==685477==    by 0x409B3C5: create_single_kernel_helper_create_program(_cl_context*, _cl_program**, unsigned int, char const**, char const*) (external/OpenCL-CTS/test_common/harness/kernelHelpers.cpp:709)
==685477==    by 0x4052BC7: test_large_multiple_embedded_headers(_cl_context*, _cl_device_id*, _cl_command_queue*, unsigned int) (external/OpenCL-CTS/test_conformance/compiler/test_compile.cpp:580)
==685477==
==685477== 12,895 (1,168 direct, 11,727 indirect) bytes in 1 blocks are definitely lost in loss record 2,599 of 2,607
==685477==    at 0x490FF93: operator new(unsigned long) (vg_replace_malloc.c:487)
==685477==    by 0x4DCDE91: clCreateProgramWithSource (src/api.cpp:2223)
==685477==    by 0x409B3C5: create_single_kernel_helper_create_program(_cl_context*, _cl_program**, unsigned int, char const**, char const*) (external/OpenCL-CTS/test_common/harness/kernelHelpers.cpp:709)
==685477==    by 0x4052A8A: test_large_multiple_embedded_headers(_cl_context*, _cl_device_id*, _cl_command_queue*, unsigned int) (external/OpenCL-CTS/test_conformance/compiler/test_compile.cpp:560)
==685477==    by 0x40526CE: test_multiple_embedded_headers(_cl_device_id*, _cl_context*, _cl_command_queue*, int) (external/OpenCL-CTS/test_conformance/compiler/test_compile.cpp:679)
==685477==    by 0x40A981B: callSingleTestFunction(test_definition, _cl_device_id*, test_harness_config const&) (external/OpenCL-CTS/test_common/harness/testHarness.cpp:1075)
==685477==    by 0x40A8FCC: callTestFunctions(test_definition*, unsigned char*, test_status*, int, _cl_device_id*, test_harness_config const&) (external/OpenCL-CTS/test_common/harness/testHarness.cpp:954)
==685477==    by 0x40A8C31: parseAndCallCommandLineTests(int, char const**, char const*, _cl_device_id*, int, test_definition*, test_harness_config const&) (external/OpenCL-CTS/test_common/harness/testHarness.cpp:866)
==685477==    by 0x40A7AC4: runTestHarnessWithCheckAndParse(int, char const**, int, test_definition*, int, unsigned long, test_status (*)(_cl_device_id*), test_status (*)(int&, char const**, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&)) (external/OpenCL-CTS/test_common/harness/testHarness.cpp:728)
==685477==    by 0x4042012: main (external/OpenCL-CTS/test_conformance/compiler/main.cpp:119)
==685477==
==685477== 19,214 (1,168 direct, 18,046 indirect) bytes in 1 blocks are definitely lost in loss record 2,602 of 2,607
==685477==    at 0x490FF93: operator new(unsigned long) (vg_replace_malloc.c:487)
==685477==    by 0x4DCFF93: clLinkProgram (src/api.cpp:2546)
==685477==    by 0x4052D04: test_large_multiple_embedded_headers(_cl_context*, _cl_device_id*, _cl_command_queue*, unsigned int) (external/OpenCL-CTS/test_conformance/compiler/test_compile.cpp:600)
==685477==    by 0x40526CE: test_multiple_embedded_headers(_cl_device_id*, _cl_context*, _cl_command_queue*, int) (external/OpenCL-CTS/test_conformance/compiler/test_compile.cpp:679)
==685477==    by 0x40A981B: callSingleTestFunction(test_definition, _cl_device_id*, test_harness_config const&) (external/OpenCL-CTS/test_common/harness/testHarness.cpp:1075)
==685477==    by 0x40A8FCC: callTestFunctions(test_definition*, unsigned char*, test_status*, int, _cl_device_id*, test_harness_config const&) (external/OpenCL-CTS/test_common/harness/testHarness.cpp:954)
==685477==    by 0x40A8C31: parseAndCallCommandLineTests(int, char const**, char const*, _cl_device_id*, int, test_definition*, test_harness_config const&) (external/OpenCL-CTS/test_common/harness/testHarness.cpp:866)
==685477==    by 0x40A7AC4: runTestHarnessWithCheckAndParse(int, char const**, int, test_definition*, int, unsigned long, test_status (*)(_cl_device_id*), test_status (*)(int&, char const**, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&)) (external/OpenCL-CTS/test_common/harness/testHarness.cpp:728)
==685477==    by 0x4042012: main (external/OpenCL-CTS/test_conformance/compiler/main.cpp:119)
```