### PR TITLE
fix cvk_command to avoid memory leak

### DIFF
--- a/src/config.def
+++ b/src/config.def
@@ -277,6 +277,9 @@ OPTION(bool, force_descriptor_set_allocation_failure, false)
 // Force capability checks to report errors for testing purposes.
 OPTION(bool, force_check_capabilities_error, false)
 
+// Force cvk_command_buffer::end to report an error for testing purposes.
+OPTION(bool, force_cvk_command_buffer_end_error, false)
+
 // Control whether early flushing is enabled for unit tests.
 OPTION(bool, early_flush_enabled, true)
 #endif

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1143,30 +1143,6 @@ cl_int cvk_command_kernel::do_post_action() {
     return CL_SUCCESS;
 }
 
-bool cvk_command_batchable::can_be_batched() const {
-    bool unresolved_user_event_dependencies = false;
-    bool unresolved_other_queue_dependencies = false;
-
-    for (auto ev : dependencies()) {
-        if (ev->is_user_event()) {
-            if (!ev->completed()) {
-                unresolved_user_event_dependencies = true;
-                break;
-            } else {
-                continue;
-            }
-        }
-
-        if ((ev->queue() != queue()) && !ev->completed()) {
-            unresolved_other_queue_dependencies = true;
-            break;
-        }
-    }
-
-    return !unresolved_user_event_dependencies &&
-           !unresolved_other_queue_dependencies;
-}
-
 cl_int cvk_command_batchable::build() {
     m_command_buffer = std::make_unique<cvk_command_buffer>(m_queue);
     if (!m_command_buffer->begin()) {

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -377,6 +377,11 @@ struct cvk_command_buffer {
     CHECK_RETURN bool begin();
 
     CHECK_RETURN bool end() {
+#ifdef CLVK_UNIT_TESTING_ENABLED
+        if (config.force_cvk_command_buffer_end_error()) {
+            return false;
+        }
+#endif
         auto res = vkEndCommandBuffer(m_command_buffer);
         return res == VK_SUCCESS;
     }
@@ -399,7 +404,12 @@ struct cvk_command {
         : m_type(type), m_queue(queue),
           m_event(new cvk_event_command(m_queue->context(), this, queue)) {}
 
-    virtual ~cvk_command() { m_event->release(); }
+    virtual ~cvk_command() {
+        m_event->release();
+        for (auto& ev : m_event_deps) {
+            ev->release();
+        }
+    }
 
     void set_dependencies(cl_uint num_event_deps,
                           _cl_event* const* event_deps) {
@@ -443,6 +453,7 @@ struct cvk_command {
             }
             ev->release();
         }
+        m_event_deps.clear();
 
         // Then execute the action if no dependencies failed
         if (status != CL_COMPLETE) {

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -404,12 +404,7 @@ struct cvk_command {
         : m_type(type), m_queue(queue),
           m_event(new cvk_event_command(m_queue->context(), this, queue)) {}
 
-    virtual ~cvk_command() {
-        m_event->release();
-        for (auto& ev : m_event_deps) {
-            ev->release();
-        }
-    }
+    virtual ~cvk_command() { m_event->release(); }
 
     void set_dependencies(cl_uint num_event_deps,
                           _cl_event* const* event_deps) {
@@ -417,7 +412,6 @@ struct cvk_command {
 
         for (cl_uint i = 0; i < num_event_deps; i++) {
             auto evt = icd_downcast(event_deps[i]);
-            evt->retain();
             cvk_debug_fn("adding dep on event %p", evt);
             m_event_deps.push_back(evt);
         }
@@ -425,7 +419,9 @@ struct cvk_command {
 
     void set_dependencies(const std::vector<cvk_event*>& deps) {
         CVK_ASSERT(m_event_deps.size() == 0);
-        m_event_deps = deps;
+        for (auto* dep : deps) {
+            m_event_deps.push_back(dep);
+        }
     }
 
     virtual bool can_be_batched() const { return false; }
@@ -438,10 +434,7 @@ struct cvk_command {
     // never have data movement requirements of their own.
     virtual bool is_data_movement() const { return false; }
 
-    void add_dependency(cvk_event* dep) {
-        dep->retain();
-        m_event_deps.push_back(dep);
-    }
+    void add_dependency(cvk_event* dep) { m_event_deps.push_back(dep); }
 
     CHECK_RETURN cl_int execute() {
 
@@ -451,9 +444,7 @@ struct cvk_command {
             if (ev->wait() != CL_COMPLETE) {
                 status = CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST;
             }
-            ev->release();
         }
-        m_event_deps.clear();
 
         // Then execute the action if no dependencies failed
         if (status != CL_COMPLETE) {
@@ -481,7 +472,18 @@ struct cvk_command {
 
     cvk_command_queue* queue() const { return m_queue; }
 
-    const std::vector<cvk_event*>& dependencies() const { return m_event_deps; }
+    bool has_unresolved_dependencies() const {
+        for (auto& ev : m_event_deps) {
+            if (ev->is_user_event()) {
+                if (!ev->completed()) {
+                    return true;
+                }
+            } else if ((ev->queue() != queue()) && !ev->completed()) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     virtual const std::vector<cvk_mem*> memory_objects() const {
         CVK_ASSERT(false && "Should never be called");
@@ -505,7 +507,7 @@ protected:
 private:
     CHECK_RETURN virtual cl_int do_action() = 0;
 
-    std::vector<cvk_event*> m_event_deps;
+    std::vector<cvk_event_holder> m_event_deps;
 };
 
 struct cvk_command_buffer_base : public cvk_command {
@@ -709,7 +711,9 @@ struct cvk_command_batchable : public cvk_command {
         }
     }
 
-    bool can_be_batched() const override;
+    bool can_be_batched() const override {
+        return !has_unresolved_dependencies();
+    }
     bool is_built_before_enqueue() const override final { return false; }
 
     CHECK_RETURN cl_int get_timestamp_query_results(cl_ulong* start,

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -543,4 +543,23 @@ TEST_F(WithCommandQueue, EnqueueTooManyCommandsWithRetry) {
     EnqueueUnmapMemObject(buffer, data);
     Finish();
 }
+
+TEST_F(WithCommandQueue, VkEndCommandBufferError) {
+    static const char* program_source = R"(
+    kernel void test_simple() {}
+    )";
+
+    auto cfg_force_descriptor_set_allocation_failure =
+        CLVK_CONFIG_SCOPED_OVERRIDE(force_cvk_command_buffer_end_error, bool,
+                                    true, true);
+    auto kernel = CreateKernel(program_source, "test_simple");
+
+    auto user_event = CreateUserEvent();
+    size_t gws = 1;
+    size_t lws = 1;
+    cl_int err =
+        clEnqueueNDRangeKernel(m_queue, kernel, 1, nullptr, &gws, &lws, 1,
+                               (const cl_event*)&user_event, nullptr);
+    ASSERT_EQ(err, CL_OUT_OF_RESOURCES);
+}
 #endif


### PR DESCRIPTION
Without this fix, the following command returns some leaks:
```
valgrind --leak-check=full -- api_tests --gtest_filter=WithCommandQueue.VkEndCommandBufferError

...

==770374== 440 (240 direct, 200 indirect) bytes in 1 blocks are definitely lost in loss record 2,499 of 2,510
==770374==    at 0x4B41F93: operator new(unsigned long) (vg_replace_malloc.c:487)
==770374==    by 0x4FF9078: clCreateUserEvent (src/api.cpp:1291)
==770374==    by 0x4116075: WithContext::CreateUserEvent() (tests/api/testcl.hpp:426)
==770374==    by 0x411C1BE: WithCommandQueue_VkEndCommandBufferError_Test::TestBody() (tests/api/enqueue.cpp:557)
==770374==    by 0x4185FA3: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2613)
==770374==    by 0x416B18F: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2668)
==770374==    by 0x414FE56: testing::Test::Run() (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2688)
==770374==    by 0x415068B: testing::TestInfo::Run() (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2837)
==770374==    by 0x4150D3C: testing::TestSuite::Run() (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:3016)
==770374==    by 0x415CE97: testing::internal::UnitTestImpl::RunAllTests() (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:5921)
==770374==    by 0x418AAE3: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2613)
==770374==    by 0x416D12F: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2668)
```