### PR TITLE
fix cvk_command_queue to avoid memory leak

### DIFF
--- a/src/config.def
+++ b/src/config.def
@@ -277,6 +277,9 @@ OPTION(bool, force_descriptor_set_allocation_failure, false)
 // Force capability checks to report errors for testing purposes.
 OPTION(bool, force_check_capabilities_error, false)
 
+// Force cvk_command_buffer::begin to report an error for testing purposes.
+OPTION(bool, force_cvk_command_buffer_begin_error, false)
+
 // Force cvk_command_buffer::end to report an error for testing purposes.
 OPTION(bool, force_cvk_command_buffer_end_error, false)
 

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -187,17 +187,13 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
     if (cmd->can_be_batched()) {
         if (!m_command_batch) {
             // Create a new command batch
-            m_command_batch = new cvk_command_batch(this);
+            m_command_batch = std::make_unique<cvk_command_batch>(this);
         }
 
         // Add command to current batch
         err = m_command_batch->add_command(
             static_cast<cvk_command_batchable*>(cmd));
         if (err != CL_SUCCESS) {
-            if (m_command_batch->batch_size() == 0) {
-                delete m_command_batch;
-                m_command_batch = nullptr;
-            }
             return err;
         }
 
@@ -295,13 +291,11 @@ cl_int cvk_command_queue::end_current_command_batch(bool from_flush) {
         if (!m_command_batch->end()) {
             return CL_OUT_OF_RESOURCES;
         }
-        enqueue_command(m_command_batch);
+        enqueue_command(m_command_batch.release());
 
         for (auto& controller : m_controllers) {
             controller->update_after_end_current_command_batch(from_flush);
         }
-
-        m_command_batch = nullptr;
 
         batch_enqueued();
     }

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -194,6 +194,10 @@ cl_int cvk_command_queue::enqueue_command(cvk_command* cmd, _cl_event** event) {
         err = m_command_batch->add_command(
             static_cast<cvk_command_batchable*>(cmd));
         if (err != CL_SUCCESS) {
+            if (m_command_batch->batch_size() == 0) {
+                delete m_command_batch;
+                m_command_batch = nullptr;
+            }
             return err;
         }
 
@@ -571,6 +575,11 @@ void cvk_command_pool::free_command_buffer(VkCommandBuffer buf) {
 }
 
 bool cvk_command_buffer::begin() {
+#ifdef CLVK_UNIT_TESTING_ENABLED
+    if (config.force_cvk_command_buffer_begin_error()) {
+        return false;
+    }
+#endif
 
     if (!m_queue->allocate_command_buffer(&m_command_buffer)) {
         return false;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -35,7 +35,7 @@ cvk_command_queue::cvk_command_queue(
     std::vector<cl_queue_properties>&& properties_array)
     : api_object(ctx), m_device(device), m_properties(properties),
       m_properties_array(std::move(properties_array)), m_executor(nullptr),
-      m_command_batch(nullptr), m_vulkan_queue(device->vulkan_queue_allocate()),
+      m_vulkan_queue(device->vulkan_queue_allocate()),
       m_command_pool(device, m_vulkan_queue.queue_family()),
       m_max_cmd_batch_size(device->get_max_cmd_batch_size()),
       m_max_first_cmd_batch_size(device->get_max_first_cmd_batch_size()),
@@ -284,7 +284,7 @@ cl_int cvk_command_queue::enqueue_command_with_deps(
 }
 
 cl_int cvk_command_queue::end_current_command_batch(bool from_flush) {
-    std::unique_ptr<cvk_command_batch> cmd_batch(m_command_batch.release());
+    std::unique_ptr<cvk_command_batch> cmd_batch = std::move(m_command_batch);
     if (cmd_batch == nullptr || cmd_batch->batch_size() == 0) {
         return CL_SUCCESS;
     }

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -284,21 +284,24 @@ cl_int cvk_command_queue::enqueue_command_with_deps(
 }
 
 cl_int cvk_command_queue::end_current_command_batch(bool from_flush) {
-    if (m_command_batch && m_command_batch->batch_size() > 0) {
-        TRACE_FUNCTION("queue", (uintptr_t)this, "batch_size",
-                       m_command_batch->batch_size());
-
-        if (!m_command_batch->end()) {
-            return CL_OUT_OF_RESOURCES;
-        }
-        enqueue_command(m_command_batch.release());
-
-        for (auto& controller : m_controllers) {
-            controller->update_after_end_current_command_batch(from_flush);
-        }
-
-        batch_enqueued();
+    std::unique_ptr<cvk_command_batch> cmd_batch(m_command_batch.release());
+    if (cmd_batch == nullptr || cmd_batch->batch_size() == 0) {
+        return CL_SUCCESS;
     }
+
+    TRACE_FUNCTION("queue", (uintptr_t)this, "batch_size",
+                   cmd_batch->batch_size());
+
+    if (!cmd_batch->end()) {
+        return CL_OUT_OF_RESOURCES;
+    }
+    enqueue_command(cmd_batch.release());
+
+    for (auto& controller : m_controllers) {
+        controller->update_after_end_current_command_batch(from_flush);
+    }
+
+    batch_enqueued();
     return CL_SUCCESS;
 }
 

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -264,7 +264,7 @@ private:
     std::mutex m_lock;
     std::deque<std::unique_ptr<cvk_command_group>> m_groups;
 
-    cvk_command_batch* m_command_batch;
+    std::unique_ptr<cvk_command_batch> m_command_batch;
 
     cvk_vulkan_queue_wrapper& m_vulkan_queue;
     cvk_command_pool m_command_pool;

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -544,6 +544,23 @@ TEST_F(WithCommandQueue, EnqueueTooManyCommandsWithRetry) {
     Finish();
 }
 
+TEST_F(WithCommandQueue, VkBeginCommandBufferError) {
+    static const char* program_source = R"(
+    kernel void test_simple() {}
+    )";
+
+    auto cfg_force_descriptor_set_allocation_failure =
+        CLVK_CONFIG_SCOPED_OVERRIDE(force_cvk_command_buffer_begin_error, bool,
+                                    true, true);
+    auto kernel = CreateKernel(program_source, "test_simple");
+
+    size_t gws = 1;
+    size_t lws = 1;
+    cl_int err = clEnqueueNDRangeKernel(m_queue, kernel, 1, nullptr, &gws, &lws,
+                                        0, nullptr, nullptr);
+    ASSERT_EQ(err, CL_OUT_OF_RESOURCES);
+}
+
 TEST_F(WithCommandQueue, VkEndCommandBufferError) {
     static const char* program_source = R"(
     kernel void test_simple() {}

--- a/tests/api/enqueue.cpp
+++ b/tests/api/enqueue.cpp
@@ -549,9 +549,8 @@ TEST_F(WithCommandQueue, VkBeginCommandBufferError) {
     kernel void test_simple() {}
     )";
 
-    auto cfg_force_descriptor_set_allocation_failure =
-        CLVK_CONFIG_SCOPED_OVERRIDE(force_cvk_command_buffer_begin_error, bool,
-                                    true, true);
+    auto cfg = CLVK_CONFIG_SCOPED_OVERRIDE(force_cvk_command_buffer_begin_error,
+                                           bool, true, true);
     auto kernel = CreateKernel(program_source, "test_simple");
 
     size_t gws = 1;
@@ -566,9 +565,8 @@ TEST_F(WithCommandQueue, VkEndCommandBufferError) {
     kernel void test_simple() {}
     )";
 
-    auto cfg_force_descriptor_set_allocation_failure =
-        CLVK_CONFIG_SCOPED_OVERRIDE(force_cvk_command_buffer_end_error, bool,
-                                    true, true);
+    auto cfg = CLVK_CONFIG_SCOPED_OVERRIDE(force_cvk_command_buffer_end_error,
+                                           bool, true, true);
     auto kernel = CreateKernel(program_source, "test_simple");
 
     auto user_event = CreateUserEvent();


### PR DESCRIPTION
Without this fix, the following command returns some leaks:
```
$ valgrind --leak-check=full -- api_tests --gtest_filter=WithCommandQueue.VkBeginCommandBufferError

...

==785609== 2,615 (464 direct, 2,151 indirect) bytes in 1 blocks are definitely lost in loss record 2,514 of 2,522
==785609==    at 0x4B41F93: operator new(unsigned long) (vg_replace_malloc.c:487)
==785609==    by 0x503DA70: std::__detail::_MakeUniq<cvk_command_queue>::__single_object std::make_unique<cvk_command_queue, cvk_context*, cvk_device*, unsigned long&, std::vector<unsigned long, std::allocator<unsigned long> > >(cvk_context*&&, cvk_device*&&, unsigned long&, std::vector<unsigned long, std::allocator<unsigned long> >&&) (lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bits/unique_ptr.h:1084)
==785609==    by 0x4FFB181: cvk_create_command_queue(_cl_context*, _cl_device_id*, unsigned long, std::vector<unsigned long, std::allocator<unsigned long> >&&, int*) (src/api.cpp:1554)
==785609==    by 0x4FFB33D: clCreateCommandQueue (src/api.cpp:1580)
==785609==    by 0x41115EE: WithContext::CreateCommandQueue(_cl_device_id*, unsigned long) (tests/api/testcl.hpp:409)
==785609==    by 0x4111564: WithCommandQueue::SetUpQueue(unsigned long) (tests/api/testcl.hpp:535)
==785609==    by 0x4111529: WithCommandQueue::SetUpWithProperties(long const*, unsigned long, void*) (tests/api/testcl.hpp:543)
==785609==    by 0x410D34E: WithCommandQueue::SetUp() (tests/api/testcl.hpp:551)
==785609==    by 0x4185F73: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2613)
==785609==    by 0x416B15F: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2668)
==785609==    by 0x414FDD7: testing::Test::Run() (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2683)
==785609==    by 0x415065B: testing::TestInfo::Run() (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2837)
```