### PR TITLE
fix cvk_command_queue::enqueue_command_with_retry

### DIFF
--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -143,6 +143,7 @@ cl_int cvk_command_queue::enqueue_command_with_retry(cvk_command* cmd,
         return err;
     }
     if (m_nb_group_in_flight == 0) {
+        std::lock_guard<std::mutex> lock(m_lock);
         err = end_current_command_batch();
         if (err != CL_SUCCESS) {
             delete cmd;


### PR DESCRIPTION
Lock `end_current_command_batch` and `flush_no_lock` calls in `cvk_command_queue::enqueue_command_with_retry` to prevent race conditions on queue state (`m_groups` and `m_command_batch`) when enqueuing commands.