### PR TITLE
fix cvk_create_context

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1044,15 +1044,15 @@ cvk_context* cvk_create_context(
         return nullptr;
     }
 
-    auto context =
-        new cvk_context(icd_downcast(devices[0]), properties, user_data);
+    auto context = std::make_unique<cvk_context>(icd_downcast(devices[0]),
+                                                 properties, user_data);
 
     *errcode_ret = context->init();
     if (*errcode_ret != CL_SUCCESS) {
         return nullptr;
     }
 
-    return context;
+    return context.release();
 }
 
 // Context APIs

--- a/tests/api/platform.cpp
+++ b/tests/api/platform.cpp
@@ -43,3 +43,11 @@ TEST(Platform, DeviceQueryWithMultipleTypes) {
         ASSERT_EQ(err, CL_SUCCESS);
     }
 }
+
+TEST(Platform, InvalidContext) {
+    cl_int err;
+    const cl_context_properties properties[] = {CL_CONTEXT_INTEROP_USER_SYNC, 0,
+                                                0};
+    clCreateContext(properties, 1, &gDevice, nullptr, nullptr, &err);
+    ASSERT_EQ(err, CL_INVALID_PROPERTY);
+}


### PR DESCRIPTION
Without this fix, the following command returns some leaks:
```
$ valgrind --leak-check=full -- api_tests --gtest_filter=Platform.InvalidContext

...

==808279== 328 (200 direct, 128 indirect) bytes in 1 blocks are definitely lost in loss record 2,497 of 2,510
==808279==    at 0x4B41F93: operator new(unsigned long) (vg_replace_malloc.c:487)
==808279==    by 0x4FF6A03: cvk_create_context(long const*, unsigned int, _cl_device_id* const*, void (*)(char const*, void const*, unsigned long, void*), void*, int*) (src/api.cpp:1048)
==808279==    by 0x4FF6B9A: clCreateContext (src/api.cpp:1071)
==808279==    by 0x412EDCE: Platform_InvalidContext_Test::TestBody() (tests/api/platform.cpp:51)
==808279==    by 0x4185E03: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2613)
==808279==    by 0x416AFEF: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2668)
==808279==    by 0x414FCB6: testing::Test::Run() (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2688)
==808279==    by 0x41504EB: testing::TestInfo::Run() (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2837)
==808279==    by 0x4150B9C: testing::TestSuite::Run() (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:3016)
==808279==    by 0x415CCF7: testing::internal::UnitTestImpl::RunAllTests() (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:5921)
==808279==    by 0x418A943: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2613)
==808279==    by 0x416CF8F: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (external/clspv/third_party/llvm/third-party/unittest/googletest/src/gtest.cc:2668)
```