### PR TITLE
Make cvk_device refcounted

### DIFF
--- a/src/context.hpp
+++ b/src/context.hpp
@@ -139,7 +139,7 @@ struct cvk_context : public _cl_context,
     void free_image_init_command_queue();
 
 private:
-    cvk_device* m_device;
+    refcounted_holder<cvk_device> m_device;
     std::mutex m_callbacks_lock;
     std::vector<cvk_context_callback> m_destuctor_callbacks;
     std::vector<cl_context_properties> m_properties;

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -48,6 +48,7 @@ struct cvk_platform;
 struct cvk_kernel;
 
 struct cvk_device : public _cl_device_id,
+                    public refcounted,
                     object_magic_header<object_magic::device> {
 
     cvk_device(cvk_platform* platform, VkPhysicalDevice pd)
@@ -896,7 +897,7 @@ struct cvk_platform : public _cl_platform_id,
     }
     ~cvk_platform() {
         for (auto dev : m_devices) {
-            delete dev;
+            dev->release();
         }
     }
 


### PR DESCRIPTION
Make cvk_device refcounted and hold a reference to it in cvk_context using refcounted_holder. This ensures cvk_device is kept alive as long as cvk_context (and transitively, all api_objects associated with it) remains alive.

The goal is to prevent crashes with some driver (swiftshader) when the platform is deleted while the context is still alive.