### PR TITLE
Fix CL_IMAGE_SLICE_PITCH query for 1D Array images

### DIFF
--- a/src/memory.hpp
+++ b/src/memory.hpp
@@ -687,6 +687,8 @@ struct cvk_image : public cvk_mem {
             case CL_MEM_OBJECT_IMAGE1D_BUFFER:
             case CL_MEM_OBJECT_IMAGE2D:
                 return 0;
+            case CL_MEM_OBJECT_IMAGE1D_ARRAY:
+                return row_pitch();
             default:
                 return row_pitch() * height();
             }


### PR DESCRIPTION
The spec requires the value to be the same as what is returned for CL_IMAGE_ROW_PITCH.

Fixes test_cl_get_info

Change-Id: I1e98436cc3032dd73e0d301f89b7c7e0988101eb