### PR TITLE
Fix subgroup support

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -3270,23 +3270,45 @@ cl_int CLVK_API_CALL clGetKernelSubGroupInfo(
         return CL_INVALID_DEVICE;
     }
 
-    switch (param_name) {
-    case CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE:
-        val_sizet = kernel->max_sub_group_size_for_ndrange(device);
-        copy_ptr = &val_sizet;
-        ret_size = sizeof(val_sizet);
-        break;
-    case CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE: {
-        std::array<uint32_t, 3> lws = {1, 1, 1};
+    auto parse_lws = [&](std::array<uint32_t, 3>& lws) -> bool {
         unsigned num_dims = input_value_size / sizeof(size_t);
-        if (input_value_size % sizeof(size_t) != 0) {
-            ret = CL_INVALID_VALUE;
-            break;
+        if ((input_value_size % sizeof(size_t) != 0) || num_dims > 3 ||
+            num_dims == 0 || input_value == nullptr) {
+            return false;
         }
         for (unsigned dim = 0; dim < num_dims; dim++) {
             lws[dim] = static_cast<const size_t*>(input_value)[dim];
         }
+        return true;
+    };
+
+    switch (param_name) {
+    case CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE: {
+        std::array<uint32_t, 3> lws = {1, 1, 1};
+        if (!parse_lws(lws)) {
+            ret = CL_INVALID_VALUE;
+            break;
+        }
+        val_sizet = kernel->subgroup_size_for_ndrange(device, lws);
+        if (val_sizet == 0) {
+            ret = CL_INVALID_WORK_GROUP_SIZE;
+            break;
+        }
+        copy_ptr = &val_sizet;
+        ret_size = sizeof(val_sizet);
+        break;
+    }
+    case CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE: {
+        std::array<uint32_t, 3> lws = {1, 1, 1};
+        if (!parse_lws(lws)) {
+            ret = CL_INVALID_VALUE;
+            break;
+        }
         val_sizet = kernel->sub_group_count_for_ndrange(device, lws);
+        if (val_sizet == 0) {
+            ret = CL_INVALID_WORK_GROUP_SIZE;
+            break;
+        }
         copy_ptr = &val_sizet;
         ret_size = sizeof(val_sizet);
         break;
@@ -4125,14 +4147,6 @@ cl_int cvk_enqueue_ndrange_kernel(cvk_command_queue* command_queue,
     // + the corresponding values in global_work_offset for any dimensions is
     // greater than the maximum value representable by size t on the device on
     // which the kernel-instance will be enqueued.
-    // TODO CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified and is
-    // not consistent with the required number of sub-groups for kernel in the
-    // program source.
-    // TODO CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified and the
-    // total number of work-items in the work-group computed as
-    // local_work_size[0] × … local_work_size[work_dim - 1] is greater than the
-    // value specified by CL_KERNEL_WORK_GROUP_SIZE in the Kernel Object Device
-    // Queries table.
     // TODO CL_INVALID_WORK_GROUP_SIZE if the program was compiled with
     // cl-uniform-work-group-size and the number of work-items specified by
     // global_work_size is not evenly divisible by size of work-group given by

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <optional>
 
 #include "clspv/Sampler.h"
 
+#include "device.hpp"
 #include "kernel.hpp"
 #include "memory.hpp"
 
@@ -60,8 +62,79 @@ cl_int cvk_kernel::init() {
 }
 
 VkPipeline
-cvk_kernel::create_pipeline(const cvk_spec_constant_map& spec_constants) {
-    return m_entry_point->create_pipeline(spec_constants);
+cvk_kernel::create_pipeline(const cvk_spec_constant_map& spec_constants,
+                            const std::optional<uint32_t>& subgroup_size) {
+    return m_entry_point->create_pipeline(spec_constants, subgroup_size);
+}
+
+size_t cvk_kernel::subgroup_size_for_ndrange(
+    const cvk_device* device, const std::array<uint32_t, 3>& lws) const {
+    uint32_t wgs = lws[0] * lws[1] * lws[2];
+    if (wgs == 0 || wgs > max_work_group_size(device)) {
+        return 0;
+    }
+    uint32_t reqd = m_program->required_sub_group_size(m_name);
+    uint32_t default_size = device->sub_group_size();
+    if (default_size == 0) {
+        return 0;
+    }
+    uint32_t max_num_sub_groups = device->max_num_sub_groups();
+    cvk_debug_fn("wgs %u reqd %u default_size %u max_num_sub_groups %u", wgs,
+                 reqd, default_size, max_num_sub_groups);
+    auto too_many_subgroups = [wgs, max_num_sub_groups](uint32_t size) {
+        return max_num_sub_groups != 0 &&
+               ceil_div(wgs, size) > max_num_sub_groups;
+    };
+
+    if (reqd != 0) {
+        if (too_many_subgroups(reqd)) {
+            cvk_error_fn("Required subgroup size (%u) generates more subgroups "
+                         "than what the device supports (%u)",
+                         reqd, max_num_sub_groups);
+            return 0;
+        }
+        if (device->supports_subgroup_size_selection()) {
+            uint32_t min_size = device->min_sub_group_size();
+            uint32_t max_size = device->max_sub_group_size();
+            if ((reqd > max_size || reqd < min_size)) {
+                cvk_error_fn(
+                    "Required subgroup size (%u) is out of the range of "
+                    "supported subgroup sizes [ %u, %u ]",
+                    reqd, min_size, max_size);
+                return 0;
+            }
+        } else if (reqd != default_size) {
+            cvk_error_fn("Required subgroup size (%u) does not match the "
+                         "default subgroup size (%u), and the device does not "
+                         "support subgroup size selection",
+                         reqd, default_size);
+            return 0;
+        }
+        return reqd;
+    } else {
+        if (device->supports_subgroup_size_selection()) {
+            uint32_t max_size = device->max_sub_group_size();
+            while (((default_size * 2) <= max_size) &&
+                   too_many_subgroups(default_size)) {
+                default_size *= 2;
+            }
+        }
+        if (too_many_subgroups(default_size)) {
+            cvk_error_fn("Invalid subgroup size");
+            return 0;
+        }
+        return default_size;
+    }
+}
+
+size_t cvk_kernel::sub_group_count_for_ndrange(
+    const cvk_device* device, const std::array<uint32_t, 3>& lws) const {
+    uint32_t work_items_per_work_group = lws[0] * lws[1] * lws[2];
+    size_t size = subgroup_size_for_ndrange(device, lws);
+    if (size == 0) {
+        return 0;
+    }
+    return ceil_div<size_t>(work_items_per_work_group, size);
 }
 
 std::unique_ptr<cvk_kernel> cvk_kernel::clone(cl_int* errcode_ret) const {

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -57,7 +58,8 @@ struct cvk_kernel : public _cl_kernel, api_object<object_magic::kernel> {
 
     CHECK_RETURN cl_int set_arg(cl_uint index, size_t size, const void* value);
     CHECK_RETURN VkPipeline
-    create_pipeline(const cvk_spec_constant_map& spec_constants);
+    create_pipeline(const cvk_spec_constant_map& spec_constants,
+                    const std::optional<uint32_t>& subgroup_size);
 
     bool has_pod_arguments() const {
         return m_entry_point->has_pod_arguments();
@@ -89,19 +91,34 @@ struct cvk_kernel : public _cl_kernel, api_object<object_magic::kernel> {
     cl_ulong local_mem_size() const;
 
     size_t max_work_group_size(const cvk_device* device) const {
-        return device->max_work_group_size();
+        size_t val = device->max_work_group_size();
+        if (device->supports_subgroups() &&
+            (m_program->uses_subgroups() ||
+             m_program->required_sub_group_size(m_name) != 0)) {
+            size_t max_subgroup_size =
+                device->supports_subgroup_size_selection()
+                    ? device->max_sub_group_size()
+                    : device->sub_group_size();
+            uint32_t reqd = m_program->required_sub_group_size(m_name);
+            if (reqd != 0) {
+                max_subgroup_size = reqd;
+            }
+            size_t subgroup_limit =
+                device->max_num_sub_groups() * max_subgroup_size;
+            if (subgroup_limit != 0) {
+                val = std::min(val, subgroup_limit);
+            }
+        }
+        return val;
     }
 
-    size_t max_sub_group_size_for_ndrange(const cvk_device* device) const {
-        return device->sub_group_size();
-    }
+    // Returns 0 when the workgroup size (lws) is invalid
+    size_t subgroup_size_for_ndrange(const cvk_device* device,
+                                     const std::array<uint32_t, 3>& lws) const;
 
     size_t
     sub_group_count_for_ndrange(const cvk_device* device,
-                                const std::array<uint32_t, 3>& lws) const {
-        uint32_t work_items_per_work_group = lws[0] * lws[1] * lws[2];
-        return ceil_div(work_items_per_work_group, device->sub_group_size());
-    }
+                                const std::array<uint32_t, 3>& lws) const;
     std::array<size_t, 3>
     local_size_for_sub_group_count(const cvk_device* device,
                                    size_t num_sub_groups) const {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1617,7 +1617,10 @@ void cvk_program::prepare_push_constant_range() {
                              max_end - min_offset};
 }
 
-bool cvk_program::check_capabilities(const cvk_device* device) {
+bool cvk_program::parse_spirv_capabilities(const cvk_device* device,
+                                           bool check_support) {
+    m_uses_subgroups = false;
+
     // Get list of required SPIR-V capabilities.
     std::vector<spv::Capability> capabilities;
     if (!m_binary.get_capabilities(capabilities)) {
@@ -1629,7 +1632,22 @@ bool cvk_program::check_capabilities(const cvk_device* device) {
     for (auto c : capabilities) {
         cvk_info_fn("Program requires SPIR-V capability %d (%s).", c,
                     spirv_capability_to_string(c));
-        if (!device->supports_capability(c)
+        switch (c) {
+        case spv::CapabilityGroupNonUniform:
+        case spv::CapabilityGroupNonUniformVote:
+        case spv::CapabilityGroupNonUniformBallot:
+        case spv::CapabilityGroupNonUniformShuffle:
+        case spv::CapabilityGroupNonUniformShuffleRelative:
+        case spv::CapabilityGroupNonUniformArithmetic:
+        case spv::CapabilityGroupNonUniformClustered:
+        case spv::CapabilityGroupNonUniformQuad:
+        case spv::CapabilityGroupNonUniformRotateKHR:
+            m_uses_subgroups = true;
+            break;
+        default:
+            break;
+        }
+        if ((check_support && !device->supports_capability(c))
 #ifdef CLVK_UNIT_TESTING_ENABLED
             || config.force_check_capabilities_error()
 #endif
@@ -1698,7 +1716,8 @@ void cvk_program::do_build() {
 
     // Check capabilities against the device.
     if ((m_binary_type == CL_PROGRAM_BINARY_TYPE_EXECUTABLE) &&
-        !config.skip_spirv_capability_check && !check_capabilities(device)) {
+        !parse_spirv_capabilities(device,
+                                  !config.skip_spirv_capability_check())) {
         cvk_error("Missing support for required SPIR-V capabilities.");
         complete_operation(device, CL_BUILD_ERROR);
         return;
@@ -2211,7 +2230,8 @@ cl_int cvk_entry_point::init() {
 }
 
 VkPipeline
-cvk_entry_point::create_pipeline(const cvk_spec_constant_map& spec_constants) {
+cvk_entry_point::create_pipeline(const cvk_spec_constant_map& spec_constants,
+                                 const std::optional<uint32_t>& subgroup_size) {
     std::lock_guard<std::mutex> lock(m_pipeline_cache_lock);
 
     // Check for a cached pipeline using the same specialization constants
@@ -2242,24 +2262,12 @@ cvk_entry_point::create_pipeline(const cvk_spec_constant_map& spec_constants) {
     void* pipelineShaderStageCreateInfoPNext = nullptr;
     VkPipelineShaderStageRequiredSubgroupSizeCreateInfo
         reqdSubgroupSizeCreateInfo;
-    if (m_device->supports_subgroup_size_selection()) {
-        auto reqdSubgroupSize = m_program->required_sub_group_size(m_name);
-        if (reqdSubgroupSize > m_device->max_sub_group_size() ||
-            reqdSubgroupSize < m_device->min_sub_group_size()) {
-            if (reqdSubgroupSize != 0) {
-                cvk_error_fn("required subgroup size '%u' for '%s' is out of "
-                             "the supported range [%u, %u]",
-                             reqdSubgroupSize, m_name.c_str(),
-                             m_device->min_sub_group_size(),
-                             m_device->max_sub_group_size());
-                return VK_NULL_HANDLE;
-            }
-            reqdSubgroupSize = m_device->sub_group_size();
-        }
+    if (m_device->supports_subgroup_size_selection() &&
+        subgroup_size.has_value()) {
         reqdSubgroupSizeCreateInfo.sType =
             VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO;
         reqdSubgroupSizeCreateInfo.pNext = nullptr;
-        reqdSubgroupSizeCreateInfo.requiredSubgroupSize = reqdSubgroupSize;
+        reqdSubgroupSizeCreateInfo.requiredSubgroupSize = subgroup_size.value();
         pipelineShaderStageCreateInfoPNext = &reqdSubgroupSizeCreateInfo;
     }
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <fstream>
 #include <map>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -644,7 +645,8 @@ public:
     CHECK_RETURN cl_int init();
 
     CHECK_RETURN VkPipeline
-    create_pipeline(const cvk_spec_constant_map& spec_constants);
+    create_pipeline(const cvk_spec_constant_map& spec_constants,
+                    const std::optional<uint32_t>& subgroup_size);
 
     CHECK_RETURN bool allocate_descriptor_sets(VkDescriptorSet* ds);
 
@@ -784,7 +786,8 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
         : api_object(ctx), m_num_devices(1U),
           m_binary_type(CL_PROGRAM_BINARY_TYPE_NONE),
           m_shader_module(VK_NULL_HANDLE), m_build_options(""),
-          m_binary(m_context->device()->vulkan_spirv_env()) {
+          m_binary(m_context->device()->vulkan_spirv_env()),
+          m_uses_subgroups(false) {
         m_dev_status[m_context->device()] = CL_BUILD_NONE;
     }
 
@@ -973,7 +976,7 @@ public:
         return m_binary.required_work_group_size(kernel);
     }
 
-    uint32_t required_sub_group_size(std::string& kernel) const {
+    uint32_t required_sub_group_size(const std::string& kernel) const {
         auto forced_subgroup_size_or_zero = []() {
             if (config.force_subgroup_size.set) {
                 return config.force_subgroup_size();
@@ -1009,6 +1012,8 @@ public:
 
         return kernel_subgroup_size;
     }
+
+    bool uses_subgroups() const { return m_uses_subgroups; }
 
     const VkPipelineCache& pipeline_cache() const { return m_pipeline_cache; }
 
@@ -1094,9 +1099,9 @@ private:
 
     void prepare_push_constant_range();
 
-    /// Check if all of the capabilities required by the SPIR-V module are
-    /// supported by `device`.
-    CHECK_RETURN bool check_capabilities(const cvk_device* device);
+    /// Parse all capabilities required by the SPIR-V module
+    CHECK_RETURN bool parse_spirv_capabilities(const cvk_device* device,
+                                               bool check_support);
 
     uint32_t m_num_devices;
     cl_uint m_num_input_programs;
@@ -1125,6 +1130,7 @@ private:
     VkPipelineCache m_pipeline_cache;
     std::unique_ptr<cvk_buffer> m_module_constant_data_buffer;
     std::unordered_map<uint32_t, user_spec_constant_data> m_user_spec_constants;
+    bool m_uses_subgroups;
 };
 
 static inline cvk_program* icd_downcast(cl_program program) {

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -799,10 +799,21 @@ cl_int cvk_command_kernel::dispatch_uniform_region_within_vklimits(
         specConstants[dim_id] = m_dimensions;
     }
 
+    std::optional<uint32_t> subgroup_size = std::nullopt;
+    if (m_kernel->program()->uses_subgroups() ||
+        m_kernel->program()->required_sub_group_size(m_kernel->name()) != 0 ||
+        constants.count(spec_constant::subgroup_max_size) > 0) {
+        subgroup_size = m_kernel->subgroup_size_for_ndrange(m_queue->device(),
+                                                            m_ndrange.lws);
+        if (subgroup_size.value() == 0) {
+            return CL_INVALID_WORK_GROUP_SIZE;
+        }
+    }
     where = constants.find(spec_constant::subgroup_max_size);
     if (where != constants.end()) {
         uint32_t size_id = where->second;
-        specConstants[size_id] = m_queue->device()->sub_group_size();
+        CVK_ASSERT(subgroup_size.has_value());
+        specConstants[size_id] = subgroup_size.value();
     }
 
     // Clspv can allocate spec constants for global offset.
@@ -822,7 +833,7 @@ cl_int cvk_command_kernel::dispatch_uniform_region_within_vklimits(
         specConstants[offset_id] = m_ndrange.offset[2];
     }
 
-    m_pipeline = m_kernel->create_pipeline(specConstants);
+    m_pipeline = m_kernel->create_pipeline(specConstants, subgroup_size);
 
     if (m_pipeline == VK_NULL_HANDLE) {
         return CL_OUT_OF_RESOURCES;


### PR DESCRIPTION
For shaders using subgroups, dynamically choose a subgroup size that does not exceed the device's limit on the number of subgroups per workgroup. This is done by doubling the default subgroup size until the workgroup fits within the subgroup limit. Also, clamp the reported maximum workgroup size to respect these subgroup limits.

For shaders that do not use subgroups, stop requesting a specific subgroup size. This allows the driver to choose the best size and avoids forcing a default size that could limit the maximum workgroup size.