### PR TITLE
Support rebuilding programs and enforce attached kernels check

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -3336,7 +3336,7 @@ cl_int CLVK_API_CALL clRetainKernel(cl_kernel kernel) {
         return CL_INVALID_KERNEL;
     }
 
-    icd_downcast(kernel)->retain();
+    icd_downcast(kernel)->retain_host();
 
     return CL_SUCCESS;
 }
@@ -3349,7 +3349,7 @@ cl_int CLVK_API_CALL clReleaseKernel(cl_kernel kernel) {
         return CL_INVALID_KERNEL;
     }
 
-    icd_downcast(kernel)->release();
+    icd_downcast(kernel)->release_host();
 
     return CL_SUCCESS;
 }

--- a/src/kernel.hpp
+++ b/src/kernel.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <algorithm>
+#include <atomic>
 #include <limits>
 #include <unordered_map>
 #include <vector>
@@ -32,12 +33,28 @@ struct cvk_kernel : public _cl_kernel, api_object<object_magic::kernel> {
     cvk_kernel(cvk_program* program, const char* name)
         : api_object(program->context()), m_program(program),
           m_entry_point(nullptr), m_name(name), m_sampler_metadata(nullptr),
-          m_image_metadata(nullptr) {}
+          m_image_metadata(nullptr), m_host_refcount(1) {
+        m_program->register_kernel(this);
+    }
 
     CHECK_RETURN cl_int init();
     std::unique_ptr<cvk_kernel> clone(cl_int* errcode_ret) const;
 
-    virtual ~cvk_kernel() { m_argument_values.reset(); }
+    void retain_host() {
+        retain();
+        m_host_refcount++;
+    }
+    void release_host() {
+        if (--m_host_refcount == 0) {
+            m_program->unregister_kernel(this);
+        }
+        release();
+    }
+
+    virtual ~cvk_kernel() {
+        m_program->unregister_kernel(this);
+        m_argument_values.reset();
+    }
 
     std::shared_ptr<cvk_kernel_argument_values> argument_values() const {
         return m_argument_values;
@@ -166,6 +183,7 @@ private:
     std::shared_ptr<cvk_kernel_argument_values> m_argument_values;
     const kernel_sampler_metadata_map* m_sampler_metadata;
     const kernel_image_metadata_map* m_image_metadata;
+    std::atomic<int> m_host_refcount;
 };
 
 static inline cvk_kernel* icd_downcast(cl_kernel kernel) {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -659,6 +659,20 @@ bool spir_binary::strip_reflection(std::vector<uint32_t>* stripped) {
 }
 
 bool spir_binary::load_descriptor_map() {
+    m_literal_samplers.clear();
+    m_push_constants.clear();
+    m_spec_constants.clear();
+    m_sampler_metadata.clear();
+    m_image_metadata.clear();
+    m_printf_descriptors.clear();
+    m_printf_buffer_info = {};
+    m_constant_data_buffer.reset();
+    m_dmaps.clear();
+    m_reqd_work_group_sizes.clear();
+    m_kernels_attributes.clear();
+    m_flags.clear();
+    m_workgroup_variables_size = 0;
+
     reflection_parse_data parse_data;
     parse_data.binary = this;
 
@@ -891,7 +905,7 @@ bool cvk_program::read(const unsigned char* src, size_t size) {
             return true;
         }
         cvk_info_fn("llvm bitcode not found, looking for Vulkan SPIR-V binary");
-        if (m_binary.read(src, size)) {
+        if (m_binary->read(src, size)) {
             m_binary_type = CL_PROGRAM_BINARY_TYPE_EXECUTABLE;
             cvk_info_fn("Vulkan SPIR-V binary executable found");
             return true;
@@ -922,7 +936,7 @@ bool cvk_program::read(const unsigned char* src, size_t size) {
         success = read_llvm_bitcode(src, size);
         break;
     case CL_PROGRAM_BINARY_TYPE_EXECUTABLE:
-        success = m_binary.read(src, size);
+        success = m_binary->read(src, size);
         break;
     }
     if (success) {
@@ -945,7 +959,7 @@ bool cvk_program::write(unsigned char* dst) const {
         memcpy(dst, m_ir.data(), m_ir.size());
         return true;
     case CL_PROGRAM_BINARY_TYPE_EXECUTABLE:
-        return m_binary.write(dst);
+        return m_binary->write(dst);
     }
     return false;
 }
@@ -958,7 +972,7 @@ size_t cvk_program::binary_size() const {
     case CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT:
         return header_and_options_size + m_ir.size();
     case CL_PROGRAM_BINARY_TYPE_EXECUTABLE:
-        return header_and_options_size + m_binary.size();
+        return header_and_options_size + m_binary->size();
     }
     return 0;
 }
@@ -1340,7 +1354,7 @@ cl_build_status cvk_program::do_build_inner_offline(bool build_to_ir,
         }
     } else {
         const char* filename = clspv_output_file.c_str();
-        if (!m_binary.load(filename)) {
+        if (!m_binary->load(filename)) {
             cvk_error("Could not load SPIR-V binary from \"%s\"", filename);
             return CL_BUILD_ERROR;
         }
@@ -1348,7 +1362,7 @@ cl_build_status cvk_program::do_build_inner_offline(bool build_to_ir,
 
     cvk_info("Loaded %s binary from \"%s\", size = %zu %s",
              build_to_ir ? "IR" : "SPIR-V", clspv_output_file.c_str(),
-             build_to_ir ? m_ir.size() : m_binary.code().size(),
+             build_to_ir ? m_ir.size() : m_binary->code().size(),
              build_to_ir ? "bytes" : "words");
 
     return CL_BUILD_SUCCESS;
@@ -1463,7 +1477,7 @@ cl_build_status cvk_program::do_build_inner_online(
             memcpy(m_ir.data(), ir.data(), size);
         } else {
             status = clspv::CompileFromSourcesStringWithHeaders(
-                programs, headers, build_options, m_binary.raw_binary(),
+                programs, headers, build_options, m_binary->raw_binary(),
                 &m_build_log);
         }
     }
@@ -1564,7 +1578,7 @@ cl_build_status cvk_program::do_build_inner(const cvk_device* device) {
 }
 
 void cvk_program::prepare_push_constant_range() {
-    auto& pcs = m_binary.push_constants();
+    auto& pcs = m_binary->push_constants();
 
     uint32_t min_offset = UINT32_MAX;
     uint32_t max_end = 0;
@@ -1578,7 +1592,7 @@ void cvk_program::prepare_push_constant_range() {
         add_pc_range(pc_pcd.second.offset, pc_pcd.second.size);
     }
 
-    for (const auto& kname_args : m_binary.kernels_arguments()) {
+    for (const auto& kname_args : m_binary->kernels_arguments()) {
         for (const auto& arg : kname_args.second) {
             if (arg.is_pushconstant()) {
                 add_pc_range(arg.offset, arg.size);
@@ -1586,7 +1600,7 @@ void cvk_program::prepare_push_constant_range() {
         }
     }
 
-    for (const auto& kname_mds : m_binary.image_metadata()) {
+    for (const auto& kname_mds : m_binary->image_metadata()) {
         for (const auto& md : kname_mds.second) {
             if (md.second.has_valid_order()) {
                 add_pc_range(md.second.order_offset, sizeof(uint32_t));
@@ -1597,7 +1611,7 @@ void cvk_program::prepare_push_constant_range() {
         }
     }
 
-    for (const auto& kname_mds : m_binary.sampler_metadata()) {
+    for (const auto& kname_mds : m_binary->sampler_metadata()) {
         for (const auto& md : kname_mds.second) {
             add_pc_range(md.second, sizeof(uint32_t));
         }
@@ -1620,7 +1634,7 @@ void cvk_program::prepare_push_constant_range() {
 bool cvk_program::check_capabilities(const cvk_device* device) {
     // Get list of required SPIR-V capabilities.
     std::vector<spv::Capability> capabilities;
-    if (!m_binary.get_capabilities(capabilities)) {
+    if (!m_binary->get_capabilities(capabilities)) {
         cvk_error("Failed to get required SPIR-V capabilities.");
         return false;
     }
@@ -1646,10 +1660,27 @@ bool cvk_program::check_capabilities(const cvk_device* device) {
 }
 
 void cvk_program::do_build() {
-    // Destroy entry points from previous build
-    m_entry_points.clear();
-
     auto device = m_context->device();
+
+    // Clear old state immediately
+    if (m_operation != build_operation::build_binary) {
+        m_binary = std::make_unique<spir_binary>(device->vulkan_spirv_env());
+        m_binary_type = CL_PROGRAM_BINARY_TYPE_NONE;
+    }
+    if (!m_source.empty() || !m_il.empty()) {
+        m_ir.clear();
+    }
+    m_stripped_binary.clear();
+    vkDestroyShaderModule(device->vulkan_device(), m_shader_module, nullptr);
+    m_shader_module = VK_NULL_HANDLE;
+    for (auto& s : m_literal_samplers) {
+        s->release();
+    }
+    m_literal_samplers.clear();
+    m_module_constant_data_buffer.reset();
+    m_pipeline_cache = VK_NULL_HANDLE;
+    m_entry_points.clear();
+    m_build_log.clear();
 
     if (m_operation != build_operation::build_binary) {
         cl_build_status status = do_build_inner(device);
@@ -1662,7 +1693,7 @@ void cvk_program::do_build() {
     }
 
     // Load descriptor map
-    if (!m_binary.load_descriptor_map()) {
+    if (!m_binary->load_descriptor_map()) {
         cvk_error("Could not load descriptor map for SPIR-V binary.");
         complete_operation(device, CL_BUILD_ERROR);
         return;
@@ -1676,7 +1707,7 @@ void cvk_program::do_build() {
     prepare_push_constant_range();
 
     bool cache_hit =
-        device->get_pipeline_cache(m_binary.code(), m_pipeline_cache);
+        device->get_pipeline_cache(m_binary->code(), m_pipeline_cache);
     if (m_pipeline_cache == VK_NULL_HANDLE) {
         complete_operation(device, CL_BUILD_ERROR);
         return;
@@ -1689,7 +1720,7 @@ void cvk_program::do_build() {
             spirv_validation_options validation_options{};
             validation_options.uniform_buffer_std_layout =
                 m_context->device()->supports_ubo_stdlayout();
-            if (!validate_binary(m_binary, validation_options)) {
+            if (!validate_binary(*m_binary, validation_options)) {
                 complete_operation(device, CL_BUILD_ERROR);
                 return;
             }
@@ -1720,8 +1751,8 @@ void cvk_program::do_build() {
     // by the Vulkan implementation. This stripped binary is stored separately
     // from |m_binary| because clvk needs to be able to provide the binary with
     // reflection information for clGetProgramInfo.
-    const uint32_t* spir_data = m_binary.spir_data();
-    size_t spir_size = m_binary.spir_size();
+    const uint32_t* spir_data = m_binary->spir_data();
+    size_t spir_size = m_binary->spir_size();
     const bool should_strip_reflection =
         !device->is_vulkan_extension_enabled(
             VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME)
@@ -1730,7 +1761,7 @@ void cvk_program::do_build() {
 #endif
         ;
     if (should_strip_reflection) {
-        if (!m_binary.strip_reflection(&m_stripped_binary)) {
+        if (!m_binary->strip_reflection(&m_stripped_binary)) {
             cvk_error_fn("couldn't strip reflection from SPIR-V module");
             complete_operation(device, CL_BUILD_ERROR);
             return;
@@ -1770,6 +1801,11 @@ cl_int cvk_program::build(build_operation operation, cl_uint num_devices,
                           cvk_program_callback cb, void* data) {
     std::lock_guard<std::mutex> lock(m_lock);
 
+    // Check if there are kernel objects attached to program
+    if (!m_kernels.empty()) {
+        return CL_INVALID_OPERATION;
+    }
+
     // Check if there is already a build in progress
     // TODO: Allow concurrent builds targeting different devices
     if (std::count_if(m_dev_status.begin(), m_dev_status.end(),
@@ -1781,6 +1817,8 @@ cl_int cvk_program::build(build_operation operation, cl_uint num_devices,
 
     retain();
 
+    m_input_programs.clear();
+    m_header_include_names.clear();
     if (num_input_programs > 0) {
         std::vector<cvk_preserved_options> input_preserved;
         for (cl_uint i = 0; i < num_input_programs; i++) {
@@ -1796,8 +1834,8 @@ cl_int cvk_program::build(build_operation operation, cl_uint num_devices,
         auto merged_preserved = cvk_preserved_options::merge(input_preserved);
         m_build_options = cvk_build_options(options != nullptr ? options : "",
                                             merged_preserved);
-    } else if (options != nullptr) {
-        m_build_options = cvk_build_options(options);
+    } else {
+        m_build_options = cvk_build_options(options != nullptr ? options : "");
     }
 
     // Mark build in-progress and save devices
@@ -1810,7 +1848,6 @@ cl_int cvk_program::build(build_operation operation, cl_uint num_devices,
             m_dev_status[icd_downcast(device_list[i])] = CL_BUILD_IN_PROGRESS;
         }
     }
-
     m_num_input_programs = num_input_programs;
     m_operation = operation;
     m_operation_callback = cb;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -775,6 +775,7 @@ private:
     std::vector<cvk_descriptor_set_array> m_descriptor_sets_array;
 };
 
+struct cvk_kernel;
 struct cvk_program;
 using cvk_program_holder = refcounted_holder<cvk_program>;
 
@@ -782,9 +783,9 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
 
     cvk_program(cvk_context* ctx)
         : api_object(ctx), m_num_devices(1U),
-          m_binary_type(CL_PROGRAM_BINARY_TYPE_NONE),
-          m_shader_module(VK_NULL_HANDLE), m_build_options(""),
-          m_binary(m_context->device()->vulkan_spirv_env()) {
+          m_binary_type(CL_PROGRAM_BINARY_TYPE_NONE), m_build_options(""),
+          m_binary(std::make_unique<spir_binary>(
+              m_context->device()->vulkan_spirv_env())) {
         m_dev_status[m_context->device()] = CL_BUILD_NONE;
     }
 
@@ -802,6 +803,16 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
         for (auto& s : m_literal_samplers) {
             s->release();
         }
+    }
+
+    void register_kernel(cvk_kernel* kernel) {
+        std::lock_guard<std::mutex> lock(m_lock);
+        m_kernels.insert(kernel);
+    }
+
+    void unregister_kernel(cvk_kernel* kernel) {
+        std::lock_guard<std::mutex> lock(m_lock);
+        m_kernels.erase(kernel);
     }
 
     void append_source(const char* src, size_t len) {
@@ -890,17 +901,17 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
         release();
     }
 
-    unsigned num_kernels() const { return m_binary.num_kernels(); }
-    bool loaded_from_binary() const { return m_binary.loaded_from_binary(); }
-    bool uses_printf() { return !m_binary.printf_descriptors().empty(); }
+    unsigned num_kernels() const { return m_binary->num_kernels(); }
+    bool loaded_from_binary() const { return m_binary->loaded_from_binary(); }
+    bool uses_printf() { return !m_binary->printf_descriptors().empty(); }
     const std::unordered_map<uint32_t, printf_descriptor>&
     printf_descriptors() {
-        return m_binary.get_printf_descriptors();
+        return m_binary->get_printf_descriptors();
     }
 
     const std::vector<kernel_argument>* args_for_kernel(std::string& name) {
-        auto const& args = m_binary.kernels_arguments().find(name);
-        if (args != m_binary.kernels_arguments().end()) {
+        auto const& args = m_binary->kernels_arguments().find(name);
+        if (args != m_binary->kernels_arguments().end()) {
             return &args->second;
         } else {
             return nullptr;
@@ -908,8 +919,8 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
     }
 
     const kernel_sampler_metadata_map* sampler_metadata(std::string& name) {
-        auto const& md = m_binary.sampler_metadata().find(name);
-        if (md != m_binary.sampler_metadata().end()) {
+        auto const& md = m_binary->sampler_metadata().find(name);
+        if (md != m_binary->sampler_metadata().end()) {
             return &md->second;
         } else {
             return nullptr;
@@ -917,8 +928,8 @@ struct cvk_program : public _cl_program, api_object<object_magic::program> {
     }
 
     const kernel_image_metadata_map* image_metadata(std::string& name) {
-        auto const& md = m_binary.image_metadata().find(name);
-        if (md != m_binary.image_metadata().end()) {
+        auto const& md = m_binary->image_metadata().find(name);
+        if (md != m_binary->image_metadata().end()) {
             return &md->second;
         } else {
             return nullptr;
@@ -941,14 +952,14 @@ public:
 
     std::vector<const char*> kernel_names() const {
         std::vector<const char*> ret;
-        for (auto& kname_args : m_binary.kernels_arguments()) {
+        for (auto& kname_args : m_binary->kernels_arguments()) {
             ret.push_back(kname_args.first.c_str());
         }
         return ret;
     }
 
     const std::vector<sampler_desc>& literal_sampler_descs() {
-        return m_binary.literal_samplers();
+        return m_binary->literal_samplers();
     }
 
     const std::vector<cvk_sampler_holder>& literal_samplers() {
@@ -960,17 +971,17 @@ public:
     }
 
     CHECK_RETURN const pushconstant_desc* push_constant(pushconstant pc) const {
-        return m_binary.push_constant(pc);
+        return m_binary->push_constant(pc);
     }
 
     CHECK_RETURN const std::unordered_map<spec_constant, uint32_t>&
     spec_constants() const {
-        return m_binary.spec_constants();
+        return m_binary->spec_constants();
     }
 
     const std::array<uint32_t, 3>&
     required_work_group_size(const std::string& kernel) const {
-        return m_binary.required_work_group_size(kernel);
+        return m_binary->required_work_group_size(kernel);
     }
 
     uint32_t required_sub_group_size(std::string& kernel) const {
@@ -1017,8 +1028,8 @@ public:
 
     bool create_module_constant_data_buffer() {
         cl_int err;
-        if (m_binary.constant_data_buffer() != nullptr) {
-            auto& init_data = m_binary.constant_data_buffer()->data;
+        if (m_binary->constant_data_buffer() != nullptr) {
+            auto& init_data = m_binary->constant_data_buffer()->data;
             void* init_data_ptr =
                 reinterpret_cast<void*>(const_cast<char*>(init_data.data()));
             m_module_constant_data_buffer =
@@ -1036,11 +1047,11 @@ public:
     }
 
     const constant_data_buffer_info* module_constant_data_buffer_info() const {
-        return m_binary.constant_data_buffer();
+        return m_binary->constant_data_buffer();
     }
 
     const printf_buffer_desc_info& printf_buffer_info() const {
-        return m_binary.printf_buffer_info();
+        return m_binary->printf_buffer_info();
     }
 
     bool options_allow_split_region(const std::string& options) const {
@@ -1060,15 +1071,15 @@ public:
     CHECK_RETURN cl_int parse_user_spec_constants();
 
     const std::string& kernel_attributes(const std::string& kernel_name) const {
-        return m_binary.kernels_attributes().at(kernel_name);
+        return m_binary->kernels_attributes().at(kernel_name);
     }
 
     uint32_t kernel_flags(const std::string& kernel) const {
-        return m_binary.kernels_flags().at(kernel);
+        return m_binary->kernels_flags().at(kernel);
     }
 
     uint32_t workgroup_variables_size() const {
-        return m_binary.get_workgroup_variables_size();
+        return m_binary->get_workgroup_variables_size();
     }
 
 private:
@@ -1111,20 +1122,21 @@ private:
     std::string m_source;
     std::vector<uint8_t> m_ir;
     std::vector<uint8_t> m_il;
-    VkShaderModule m_shader_module;
+    VkShaderModule m_shader_module{VK_NULL_HANDLE};
     std::unordered_map<const cvk_device*, std::atomic<cl_build_status>>
         m_dev_status;
     cvk_build_options m_build_options;
-    spir_binary m_binary;
+    std::unique_ptr<spir_binary> m_binary;
     std::string m_build_log;
     std::vector<cvk_sampler_holder> m_literal_samplers;
     VkPushConstantRange m_push_constant_range;
     std::unordered_map<std::string, std::shared_ptr<cvk_entry_point>>
         m_entry_points;
     std::vector<uint32_t> m_stripped_binary;
-    VkPipelineCache m_pipeline_cache;
+    VkPipelineCache m_pipeline_cache{VK_NULL_HANDLE};
     std::unique_ptr<cvk_buffer> m_module_constant_data_buffer;
     std::unordered_map<uint32_t, user_spec_constant_data> m_user_spec_constants;
+    std::unordered_set<cvk_kernel*> m_kernels;
 };
 
 static inline cvk_program* icd_downcast(cl_program program) {

--- a/tests/api/compiler.cpp
+++ b/tests/api/compiler.cpp
@@ -586,3 +586,173 @@ TEST_F(WithContext, UnsupportedCapabilities) {
                 std::string::npos);
 }
 #endif
+
+TEST_F(WithCommandQueue, RebuildProgramWithDifferentDefines) {
+    static const char* source = R"(
+        kernel void test(global uint *output) {
+            output[0] = MACRO;
+        }
+    )";
+
+    auto program = CreateProgram(source);
+
+    // Build first time with MACRO=1
+    BuildProgram(program, "-DMACRO=1");
+    auto kernel = CreateKernel(program, "test");
+    auto buffer = CreateBuffer(CL_MEM_WRITE_ONLY, sizeof(cl_uint));
+    SetKernelArg(kernel, 0, buffer);
+
+    size_t gws = 1;
+    EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, nullptr);
+    cl_uint result = 0;
+    EnqueueReadBuffer(buffer, CL_BLOCKING, 0, sizeof(cl_uint), &result);
+    EXPECT_EQ(result, 1);
+
+    // Rebuild second time with MACRO=2
+    // We must release the kernel before rebuild, otherwise it fails with
+    // CL_INVALID_OPERATION
+    clReleaseKernel(kernel.release());
+    BuildProgram(program, "-DMACRO=2");
+
+    // Re-create kernel and set args again
+    auto kernel2 = CreateKernel(program, "test");
+    SetKernelArg(kernel2, 0, buffer);
+
+    EnqueueNDRangeKernel(kernel2, 1, nullptr, &gws, nullptr);
+    EnqueueReadBuffer(buffer, CL_BLOCKING, 0, sizeof(cl_uint), &result);
+    EXPECT_EQ(result, 2);
+}
+
+TEST_F(WithCommandQueue, RebuildProgramWithAttachedKernelsFails) {
+    static const char* source = R"(
+        kernel void test(global uint *output) {
+            output[0] = 1;
+        }
+    )";
+
+    auto program = CreateProgram(source);
+    BuildProgram(program);
+    auto kernel = CreateKernel(program, "test");
+
+    // Rebuild while kernel is still alive
+    cl_int err =
+        clBuildProgram(program, 1, &gDevice, nullptr, nullptr, nullptr);
+    EXPECT_EQ(err, CL_INVALID_OPERATION);
+}
+
+TEST_F(WithCommandQueue, RebuildProgramAfterFailedKernelCreation) {
+    static const char* source = R"(
+        kernel void test(global uint *output) {
+            output[0] = 42;
+        }
+    )";
+
+    auto program = CreateProgram(source);
+    BuildProgram(program);
+
+    cl_int err;
+    auto invalid_kernel = clCreateKernel(program, "non_existent", &err);
+    EXPECT_EQ(err, CL_INVALID_KERNEL_NAME);
+    EXPECT_EQ(invalid_kernel, nullptr);
+
+    // Rebuild should succeed because no valid kernel objects are attached
+    BuildProgram(program);
+
+    auto kernel = CreateKernel(program, "test");
+    auto buffer = CreateBuffer(CL_MEM_WRITE_ONLY, sizeof(cl_uint));
+    SetKernelArg(kernel, 0, buffer);
+
+    size_t gws = 1;
+    EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, nullptr);
+    cl_uint result = 0;
+    EnqueueReadBuffer(buffer, CL_BLOCKING, 0, sizeof(cl_uint), &result);
+    EXPECT_EQ(result, 42);
+}
+
+TEST_F(WithCommandQueue, RebuildProgramResetOptions) {
+    static const char* source = R"(
+        kernel void test(global uint *output) {
+#ifdef MACRO
+            output[0] = MACRO;
+#else
+            output[0] = 0;
+#endif
+        }
+    )";
+
+    auto program = CreateProgram(source);
+
+    // Build first time with MACRO=5
+    BuildProgram(program, "-DMACRO=5");
+    auto kernel = CreateKernel(program, "test");
+    auto buffer = CreateBuffer(CL_MEM_WRITE_ONLY, sizeof(cl_uint));
+    SetKernelArg(kernel, 0, buffer);
+
+    size_t gws = 1;
+    EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, nullptr);
+    cl_uint result = 0;
+    EnqueueReadBuffer(buffer, CL_BLOCKING, 0, sizeof(cl_uint), &result);
+    EXPECT_EQ(result, 5);
+
+    // Release kernel and rebuild with options = nullptr
+    clReleaseKernel(kernel.release());
+    BuildProgram(program, nullptr);
+
+    auto kernel2 = CreateKernel(program, "test");
+    SetKernelArg(kernel2, 0, buffer);
+
+    EnqueueNDRangeKernel(kernel2, 1, nullptr, &gws, nullptr);
+    EnqueueReadBuffer(buffer, CL_BLOCKING, 0, sizeof(cl_uint), &result);
+    EXPECT_EQ(result, 0);
+}
+
+TEST_F(WithCommandQueue, RebuildBinaryProgram) {
+    static const char* source = R"(
+        kernel void test(global uint *output) {
+            output[0] = 7;
+        }
+    )";
+
+    auto program = CreateAndBuildProgram(source);
+    auto binary = GetProgramBinary(program);
+
+    auto binary_program = CreateProgramWithBinary(binary);
+
+    // Build first time
+    BuildProgram(binary_program);
+    auto kernel = CreateKernel(binary_program, "test");
+    auto buffer = CreateBuffer(CL_MEM_WRITE_ONLY, sizeof(cl_uint));
+    SetKernelArg(kernel, 0, buffer);
+
+    size_t gws = 1;
+    EnqueueNDRangeKernel(kernel, 1, nullptr, &gws, nullptr);
+    cl_uint result = 0;
+    EnqueueReadBuffer(buffer, CL_BLOCKING, 0, sizeof(cl_uint), &result);
+    EXPECT_EQ(result, 7);
+
+    // Release kernel and rebuild second time
+    clReleaseKernel(kernel.release());
+    BuildProgram(binary_program);
+
+    auto kernel2 = CreateKernel(binary_program, "test");
+    SetKernelArg(kernel2, 0, buffer);
+
+    EnqueueNDRangeKernel(kernel2, 1, nullptr, &gws, nullptr);
+    EnqueueReadBuffer(buffer, CL_BLOCKING, 0, sizeof(cl_uint), &result);
+    EXPECT_EQ(result, 7);
+}
+
+TEST_F(WithContext, CompileProgramWithAttachedKernelsFails) {
+    static const char* source = R"(
+        kernel void test() {}
+    )";
+
+    auto program = CreateProgram(source);
+    BuildProgram(program);
+    auto kernel = CreateKernel(program, "test");
+
+    // Compile while kernel is still alive
+    cl_int err = clCompileProgram(program, 1, &gDevice, nullptr, 0, nullptr,
+                                  nullptr, nullptr, nullptr);
+    EXPECT_EQ(err, CL_INVALID_OPERATION);
+}


### PR DESCRIPTION
Enables calling clBuildProgram twice on the same program.

Implements a clear-first build flow in cvk_program::do_build, discarding previous build resources at the start to ensure clean failure states.

Changes m_binary to a std::unique_ptr<spir_binary> in cvk_program, allowing re-initialization by resetting the pointer during rebuilds while avoiding the need for manual move logic in spir_binary.

Tracks host-visible references to kernels and unregisters them from the program immediately inside cvk_kernel::release_host when the host releases them.

Enforces CL_INVALID_OPERATION in clBuildProgram if the host still holds references to kernels created from the program.