### PR TITLE
Add config options to force or mask denorm support

### DIFF
--- a/src/config.def
+++ b/src/config.def
@@ -111,6 +111,15 @@ OPTION(std::set<std::string>, device_extensions, std::set<std::string>())
 // a comma separated list of extensions.
 OPTION(std::set<std::string>, device_extensions_masked, std::set<std::string>())
 
+// Specify floating point types for which CL_FP_DENORM support should be
+// forcibly reported. Expects a comma separated list among "16", "32", "64".
+OPTION(std::set<std::string>, denorm_support, std::set<std::string>())
+
+// Specify floating point types for which CL_FP_DENORM support should be
+// masked (prevented from being reported). Expects a comma separated list among
+// "16", "32", "64".
+OPTION(std::set<std::string>, denorm_support_masked, std::set<std::string>())
+
 // Specify whether using samplers with `CL_FILTER_LINEAR` is supported.
 OPTION(bool, supports_filter_linear, true)
 

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -716,14 +716,23 @@ struct cvk_device : public _cl_device_id,
         return config.physical_addressing();
     }
 
+    bool has_denorm_support(const std::string& width,
+                            bool device_supports) const {
+        return config.denorm_support_masked().count(width) == 0 &&
+               (config.denorm_support().count(width) > 0 || device_supports);
+    }
+
     bool supports_denorm_preserve_16() const {
-        return m_float_controls_properties.shaderDenormPreserveFloat16;
+        return has_denorm_support(
+            "16", m_float_controls_properties.shaderDenormPreserveFloat16);
     }
     bool supports_denorm_preserve_32() const {
-        return m_float_controls_properties.shaderDenormPreserveFloat32;
+        return has_denorm_support(
+            "32", m_float_controls_properties.shaderDenormPreserveFloat32);
     }
     bool supports_denorm_preserve_64() const {
-        return m_float_controls_properties.shaderDenormPreserveFloat64;
+        return has_denorm_support(
+            "64", m_float_controls_properties.shaderDenormPreserveFloat64);
     }
     bool supports_denorm_ftz_16() const {
         return m_float_controls_properties.shaderDenormFlushToZeroFloat16;


### PR DESCRIPTION
This can be used to workaround driver bugs.

It can also be useful for testing and experimenting with applications and CTS without having to modify application code or rebuild clvk.