### PR TITLE
Add support for spv::CapabilitySignedZeroInfNanPreserve

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -1213,6 +1213,13 @@ bool cvk_device::supports_capability(spv::Capability capability) const {
         return m_float_controls_properties.shaderDenormFlushToZeroFloat32 ||
                m_float_controls_properties.shaderDenormFlushToZeroFloat16 ||
                m_float_controls_properties.shaderDenormFlushToZeroFloat64;
+    case spv::CapabilitySignedZeroInfNanPreserve:
+        return m_float_controls_properties
+                   .shaderSignedZeroInfNanPreserveFloat32 ||
+               m_float_controls_properties
+                   .shaderSignedZeroInfNanPreserveFloat16 ||
+               m_float_controls_properties
+                   .shaderSignedZeroInfNanPreserveFloat64;
     case spv::CapabilityDotProduct:
     case spv::CapabilityDotProductInput4x8BitPacked:
         return supports_dot_product();

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -750,6 +750,19 @@ struct cvk_device : public _cl_device_id,
         return m_float_controls_properties.shaderDenormFlushToZeroFloat64;
     }
 
+    bool supports_signed_zero_inf_nan_preserve_16() const {
+        return m_float_controls_properties
+            .shaderSignedZeroInfNanPreserveFloat16;
+    }
+    bool supports_signed_zero_inf_nan_preserve_32() const {
+        return m_float_controls_properties
+            .shaderSignedZeroInfNanPreserveFloat32;
+    }
+    bool supports_signed_zero_inf_nan_preserve_64() const {
+        return m_float_controls_properties
+            .shaderSignedZeroInfNanPreserveFloat64;
+    }
+
     const std::string& get_device_specific_compile_options() const {
         return m_device_compiler_options;
     }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1041,6 +1041,26 @@ std::string cvk_program::prepare_build_options(const cvk_device* device) const {
         }
     }
 
+    // Signed zero preserve options
+    std::vector<std::string> signedZeroPreserve;
+    if (device->supports_fp16() &&
+        device->supports_signed_zero_inf_nan_preserve_16()) {
+        signedZeroPreserve.push_back("16");
+    }
+    if (device->supports_signed_zero_inf_nan_preserve_32()) {
+        signedZeroPreserve.push_back("32");
+    }
+    if (device->supports_fp64() &&
+        device->supports_signed_zero_inf_nan_preserve_64()) {
+        signedZeroPreserve.push_back("64");
+    }
+    if ((options.find("-signed-zero-inf-nan-preserve=") == std::string::npos) &&
+        !signedZeroPreserve.empty()) {
+        options +=
+            " -signed-zero-inf-nan-preserve=" + join(',', signedZeroPreserve) +
+            " ";
+    }
+
     // Features
     if (options.find("-cl-std=CL3.0") != std::string::npos) {
         auto features = device->opencl_c_features();


### PR DESCRIPTION
- Add `supports_signed_zero_inf_nan_preserve_*` helper methods to `cvk_device`.
- Update `cvk_device::supports_capability` to handle `spv::CapabilitySignedZeroInfNanPreserve`.
- In `cvk_program::prepare_build_options`, pass `-signed-zero-inf-nan-preserve=` to clspv when supported by the device and not already specified in the options.